### PR TITLE
Make index lookups more robust

### DIFF
--- a/include/cantera/clib/ct.h
+++ b/include/cantera/clib/ct.h
@@ -11,6 +11,9 @@
 #ifndef CTC_CT_H
 #define CTC_CT_H
 
+#pragma message("warning: The legacy CLib library ct.h is deprecated and " \
+                "will be removed after Cantera 3.2. Use generated CLib instead.")
+
 #include "clib_defs.h"
 
 #ifdef __cplusplus

--- a/include/cantera/clib/ctfunc.h
+++ b/include/cantera/clib/ctfunc.h
@@ -11,6 +11,9 @@
 #ifndef CTC_FUNC1_H
 #define CTC_FUNC1_H
 
+#pragma message("warning: The legacy CLib library ctfunc.h is deprecated and " \
+                "will be removed after Cantera 3.2. Use generated CLib instead.")
+
 #include "clib_defs.h"
 
 #ifdef __cplusplus

--- a/include/cantera/clib/ctmatlab.h
+++ b/include/cantera/clib/ctmatlab.h
@@ -8,6 +8,9 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 
+#pragma message("warning: The legacy CLib library ctmatlab.h is deprecated and " \
+                "will be removed after Cantera 3.2.")
+
 #include "ct.h"
 #include "ctfunc.h"
 #include "ctmultiphase.h"

--- a/include/cantera/clib/ctmultiphase.h
+++ b/include/cantera/clib/ctmultiphase.h
@@ -11,6 +11,9 @@
 #ifndef CTC_MULTIPHASE_H
 #define CTC_MULTIPHASE_H
 
+#pragma message("warning: The legacy CLib library ctmultiphase.h is deprecated and " \
+                "will be removed after Cantera 3.2. Use generated CLib instead.")
+
 #include "clib_defs.h"
 
 #ifdef __cplusplus

--- a/include/cantera/clib/ctonedim.h
+++ b/include/cantera/clib/ctonedim.h
@@ -11,6 +11,9 @@
 #ifndef CTC_ONEDIM_H
 #define CTC_ONEDIM_H
 
+#pragma message("warning: The legacy CLib library ctonedim.h is deprecated and " \
+                "will be removed after Cantera 3.2. Use generated CLib instead.")
+
 #include "clib_defs.h"
 
 #ifdef __cplusplus

--- a/include/cantera/clib/ctreactor.h
+++ b/include/cantera/clib/ctreactor.h
@@ -11,6 +11,9 @@
 #ifndef CTC_REACTOR_H
 #define CTC_REACTOR_H
 
+#pragma message("warning: The legacy CLib library ctreactor.h is deprecated and " \
+                "will be removed after Cantera 3.2. Use generated CLib instead.")
+
 #include "clib_defs.h"
 
 #ifdef __cplusplus

--- a/include/cantera/clib/ctrpath.h
+++ b/include/cantera/clib/ctrpath.h
@@ -11,6 +11,9 @@
 #ifndef CTC_RXNPATH_H
 #define CTC_RXNPATH_H
 
+#pragma message("warning: The legacy CLib library ctrpath.h is deprecated and " \
+                "will be removed after Cantera 3.2. Use generated CLib instead.")
+
 #include "clib_defs.h"
 
 #ifdef __cplusplus

--- a/include/cantera/clib/ctsurf.h
+++ b/include/cantera/clib/ctsurf.h
@@ -11,6 +11,9 @@
 #ifndef CTC_SURF_H
 #define CTC_SURF_H
 
+#pragma message("warning: The legacy CLib library ctsurf.h is deprecated and " \
+                "will be removed after Cantera 3.2. Use generated CLib instead.")
+
 #include "clib_defs.h"
 
 #ifdef __cplusplus

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -158,8 +158,11 @@ public:
     }
 
     //! Check that the specified species index is in range.
-    //! Throws an exception if k is greater than nSpecies()-1
-    void checkSpeciesIndex(size_t k) const;
+    /*!
+     * @since After %Cantera 3.2, returns verified species index.
+     * @exception Throws an exception if k is greater than nSpecies()-1
+     */
+    size_t checkSpeciesIndex(size_t k) const;
 
     //! Check that an array size is at least nSpecies().
     //! Throws an exception if kk is less than nSpecies(). Used before calls

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -167,6 +167,7 @@ public:
     //! Check that an array size is at least nSpecies().
     //! Throws an exception if kk is less than nSpecies(). Used before calls
     //! which take an array pointer.
+    //! @deprecated To be removed after %Cantera 3.2. Only used by legacy CLib.
     void checkSpeciesArraySize(size_t kk) const;
 
     //! Name of species with global index @e kGlob
@@ -252,12 +253,16 @@ public:
     ThermoPhase& phase(size_t n);
 
     //! Check that the specified phase index is in range
-    //! Throws an exception if m is greater than nPhases()
-    void checkPhaseIndex(size_t m) const;
+    /*!
+     * @since After %Cantera 3.2, returns verified species index.
+     * @exception Throws an IndexError if m is greater than nPhases()-1
+     */
+    size_t checkPhaseIndex(size_t m) const;
 
     //! Check that an array size is at least nPhases()
     //! Throws an exception if mm is less than nPhases(). Used before calls
     //! which take an array pointer.
+    //! @deprecated To be removed after %Cantera 3.2. Unused
     void checkPhaseArraySize(size_t mm) const;
 
     //! Returns the moles of global species @c k. units = kmol

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -222,12 +222,12 @@ public:
      * @param pName Name of the phase
      * @param raise  If `true`, raise exception if the specified phase is not found.
      * @returns the index. A value of -1 means the phase isn't in the object.
-     * @since Added the `raise` argument in %Cantera 3.2. If not specified, the default
-     *      behavior if a phase is not found in %Cantera 3.2 is to return -1.
-     *      After %Cantera 3.2, the default behavior will be to throw an exception.
+     * @since Added the `raise` argument in %Cantera 3.2 and changed return type. If
+     *      not specified, the default behavior if a phase is not found in %Cantera 3.2
+     *      is to return @ref npos.
      * @exception Throws a CanteraError if the phase is not found.
      */
-    int phaseIndex(const string& pName, bool raise) const;
+    size_t phaseIndex(const string& pName, bool raise) const;
 
     //! Return the number of moles in phase n.
     /*!

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -117,7 +117,7 @@ public:
     //! Check that the specified element index is in range.
     /*!
      * @since After %Cantera 3.2, returns verified element index.
-     * @exception Throws an exception if m is greater than nElements()-1
+     * @exception Throws an IndexError if m is greater than nElements()-1
      */
     size_t checkElementIndex(size_t m) const;
 
@@ -148,7 +148,7 @@ public:
      * @since Added the `raise` argument in %Cantera 3.2. If not specified, the default
      *      behavior if an element is not found in %Cantera 3.2 is to return `npos`.
      *      After %Cantera 3.2, the default behavior will be to throw an exception.
-     * @exception Throws an IndexError.
+     * @exception Throws a CanteraError if the specified element is not found.
      */
     size_t elementIndex(const string& name, bool raise) const;
 
@@ -160,7 +160,7 @@ public:
     //! Check that the specified species index is in range.
     /*!
      * @since After %Cantera 3.2, returns verified species index.
-     * @exception Throws an exception if k is greater than nSpecies()-1
+     * @exception Throws an IndexError if k is greater than nSpecies()-1
      */
     size_t checkSpeciesIndex(size_t k) const;
 
@@ -212,8 +212,21 @@ public:
     /*!
      * @param pName Name of the phase
      * @returns the index. A value of -1 means the phase isn't in the object.
+     * @deprecated  To be removed after %Cantera 3.2. Use 2-parameter version instead.
      */
     int phaseIndex(const string& pName) const;
+
+    //! Returns the index, given the phase name
+    /*!
+     * @param pName Name of the phase
+     * @param raise  If `true`, raise exception if the specified phase is not found.
+     * @returns the index. A value of -1 means the phase isn't in the object.
+     * @since Added the `raise` argument in %Cantera 3.2. If not specified, the default
+     *      behavior if a phase is not found in %Cantera 3.2 is to return -1.
+     *      After %Cantera 3.2, the default behavior will be to throw an exception.
+     * @exception Throws a CanteraError if the phase is not found.
+     */
+    int phaseIndex(const string& pName, bool raise) const;
 
     //! Return the number of moles in phase n.
     /*!

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -121,6 +121,7 @@ public:
     //! Check that an array size is at least nElements().
     //! Throws an exception if mm is less than nElements(). Used before calls
     //! which take an array pointer.
+    //! @deprecated To be removed after %Cantera 3.2. Only used by legacy CLib.
     void checkElementArraySize(size_t mm) const;
 
     //! Returns the name of the global element *m*.
@@ -134,6 +135,16 @@ public:
      * @param name   String name of the global element
      */
     size_t elementIndex(const string& name) const;
+
+    //! Returns the index of the element with name @e name.
+    /*!
+     * @param name   String name of the global element
+     * @since Added the `force` argument in %Cantera 3.2. If not specified, the default
+     *      behavior in %Cantera 3.2 is to return `npos` if an element is not found.
+     *      After %Cantera 3.2, the default behavior will be to throw an exception.
+     * @exception Throws an IndexError.
+     */
+    size_t elementIndex(const string& name, bool force) const;
 
     //! Number of species, summed over all phases.
     size_t nSpecies() const {

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -115,8 +115,11 @@ public:
     }
 
     //! Check that the specified element index is in range.
-    //! Throws an exception if m is greater than nElements()-1
-    void checkElementIndex(size_t m) const;
+    /*!
+     * @since After %Cantera 3.2, returns verified element index.
+     * @exception Throws an exception if m is greater than nElements()-1
+     */
+    size_t checkElementIndex(size_t m) const;
 
     //! Check that an array size is at least nElements().
     //! Throws an exception if mm is less than nElements(). Used before calls
@@ -133,18 +136,21 @@ public:
     //! Returns the index of the element with name @e name.
     /*!
      * @param name   String name of the global element
+     * @deprecated  To be removed after %Cantera 3.2. Use 2-parameter version instead.
      */
     size_t elementIndex(const string& name) const;
 
     //! Returns the index of the element with name @e name.
     /*!
-     * @param name   String name of the global element
-     * @since Added the `force` argument in %Cantera 3.2. If not specified, the default
-     *      behavior in %Cantera 3.2 is to return `npos` if an element is not found.
+     * @param name  String name of the global element.
+     * @param raise  If `true`, raise exception if the specified element is not found;
+     *      otherwise, return @ref npos.
+     * @since Added the `raise` argument in %Cantera 3.2. If not specified, the default
+     *      behavior if an element is not found in %Cantera 3.2 is to return `npos`.
      *      After %Cantera 3.2, the default behavior will be to throw an exception.
      * @exception Throws an IndexError.
      */
-    size_t elementIndex(const string& name, bool force) const;
+    size_t elementIndex(const string& name, bool raise) const;
 
     //! Number of species, summed over all phases.
     size_t nSpecies() const {

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -116,7 +116,7 @@ public:
 
     //! Check that the specified element index is in range.
     /*!
-     * @since After %Cantera 3.2, returns verified element index.
+     * @since Starting in %Cantera 3.2, returns the input element index, if valid.
      * @exception Throws an IndexError if m is greater than nElements()-1
      */
     size_t checkElementIndex(size_t m) const;
@@ -148,7 +148,8 @@ public:
      * @since Added the `raise` argument in %Cantera 3.2. If not specified, the default
      *      behavior if an element is not found in %Cantera 3.2 is to return `npos`.
      *      After %Cantera 3.2, the default behavior will be to throw an exception.
-     * @exception Throws a CanteraError if the specified element is not found.
+     * @exception Throws a CanteraError if the specified element is not found and
+     *      `raise` is `true`.
      */
     size_t elementIndex(const string& name, bool raise) const;
 
@@ -159,7 +160,7 @@ public:
 
     //! Check that the specified species index is in range.
     /*!
-     * @since After %Cantera 3.2, returns verified species index.
+     * @since Starting in %Cantera 3.2, returns the input species index, if valid.
      * @exception Throws an IndexError if k is greater than nSpecies()-1
      */
     size_t checkSpeciesIndex(size_t k) const;
@@ -225,7 +226,8 @@ public:
      * @since Added the `raise` argument in %Cantera 3.2 and changed return type. If
      *      not specified, the default behavior if a phase is not found in %Cantera 3.2
      *      is to return @ref npos.
-     * @exception Throws a CanteraError if the phase is not found.
+     * @exception Throws a CanteraError if the specified phase is not found and
+     *      `raise` is `true`.
      */
     size_t phaseIndex(const string& pName, bool raise) const;
 
@@ -254,7 +256,7 @@ public:
 
     //! Check that the specified phase index is in range
     /*!
-     * @since After %Cantera 3.2, returns verified species index.
+     * @since Starting in %Cantera 3.2, returns the input species index, if valid.
      * @exception Throws an IndexError if m is greater than nPhases()-1
      */
     size_t checkPhaseIndex(size_t m) const;

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -164,7 +164,7 @@ public:
 
     //! Check that the specified reaction index is in range
     /*!
-     * @since After %Cantera 3.2, returns verified reaction index.
+     * @since Starting in %Cantera 3.2, returns the input reaction index, if valid.
      * @exception Throws an IndexError if m is greater than nReactions()-1
      */
     size_t checkReactionIndex(size_t m) const;
@@ -177,7 +177,7 @@ public:
 
     //! Check that the specified species index is in range
     /*!
-     * @since After %Cantera 3.2, returns verified species index.
+     * @since Starting in %Cantera 3.2, returns the input species index, if valid.
      * @exception Throws an IndexError if k is greater than nSpecies()-1
      */
     size_t checkSpeciesIndex(size_t k) const;
@@ -204,7 +204,7 @@ public:
 
     //! Check that the specified phase index is in range
     /*!
-     * @since After %Cantera 3.2, returns verified species index.
+     * @since Starting in %Cantera 3.2, returns the input phase index, if valid.
      * @exception Throws an IndexError if m is greater than nPhases()-1
      */
     size_t checkPhaseIndex(size_t m) const;
@@ -233,8 +233,8 @@ public:
     }
 
     /**
-     * Return the phase index of a phase in the list of phases defined within
-     * the object.
+     * Return the index of a phase among the phases participating in this kinetic
+     * mechanism.
      *
      * @param ph string name of the phase
      * @param raise  If `true`, raise exception if the specified phase is not defined
@@ -242,18 +242,10 @@ public:
      * @since Added the `raise` argument in %Cantera 3.2. If not specified, the default
      *      behavior if a phase is not found in %Cantera 3.2 is to return `npos`.
      *      After %Cantera 3.2, the default behavior will be to throw an exception.
-     * @exception Throws a CanteraError if the specified phase is not defined.
+     * @exception Throws a CanteraError if the specified phase is not found and
+     *      `raise` is `true`.
      */
-    size_t phaseIndex(const string& ph, bool raise) const {
-        if (m_phaseindex.find(ph) == m_phaseindex.end()) {
-            if (raise) {
-                throw CanteraError("Kinetics::phaseIndex", "Phase '{}' not found", ph);
-            }
-            return npos;
-        } else {
-            return m_phaseindex.at(ph) - 1;
-        }
-    }
+    size_t phaseIndex(const string& ph, bool raise) const;
 
     /**
      * Return pointer to phase where the reactions occur.

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -163,12 +163,16 @@ public:
     }
 
     //! Check that the specified reaction index is in range
-    //! Throws an exception if i is greater than nReactions()
-    void checkReactionIndex(size_t m) const;
+    /*!
+     * @since After %Cantera 3.2, returns verified reaction index.
+     * @exception Throws an IndexError if m is greater than nReactions()-1
+     */
+    size_t checkReactionIndex(size_t m) const;
 
     //! Check that an array size is at least nReactions()
     //! Throws an exception if ii is less than nReactions(). Used before calls
     //! which take an array pointer.
+    //! @deprecated To be removed after %Cantera 3.2. Only used by legacy CLib.
     void checkReactionArraySize(size_t ii) const;
 
     //! Check that the specified species index is in range
@@ -181,6 +185,7 @@ public:
     //! Check that an array size is at least nSpecies()
     //! Throws an exception if kk is less than nSpecies(). Used before calls
     //! which take an array pointer.
+    //! @deprecated To be removed after %Cantera 3.2. Only used by legacy CLib.
     void checkSpeciesArraySize(size_t mm) const;
 
     //! @}
@@ -198,12 +203,16 @@ public:
     }
 
     //! Check that the specified phase index is in range
-    //! Throws an exception if m is greater than nPhases()
-    void checkPhaseIndex(size_t m) const;
+    /*!
+     * @since After %Cantera 3.2, returns verified species index.
+     * @exception Throws an IndexError if m is greater than nPhases()-1
+     */
+    size_t checkPhaseIndex(size_t m) const;
 
     //! Check that an array size is at least nPhases()
     //! Throws an exception if mm is less than nPhases(). Used before calls
     //! which take an array pointer.
+    //! @deprecated To be removed after %Cantera 3.2. Unused
     void checkPhaseArraySize(size_t mm) const;
 
     /**

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -172,8 +172,11 @@ public:
     void checkReactionArraySize(size_t ii) const;
 
     //! Check that the specified species index is in range
-    //! Throws an exception if k is greater than nSpecies()-1
-    void checkSpeciesIndex(size_t k) const;
+    /*!
+     * @since After %Cantera 3.2, returns verified species index.
+     * @exception Throws an exception if k is greater than nSpecies()-1
+     */
+    size_t checkSpeciesIndex(size_t k) const;
 
     //! Check that an array size is at least nSpecies()
     //! Throws an exception if kk is less than nSpecies(). Used before calls

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -326,8 +326,25 @@ public:
      *   - If no match is found, the value -1 is returned.
      *
      * @param nm   Input string name of the species
+     * @deprecated  To be removed after %Cantera 3.2. Use 2-parameter version instead.
      */
     size_t kineticsSpeciesIndex(const string& nm) const;
+
+    /**
+     * Return the index of a species within the phases participating in this kinetic
+     * mechanism.
+     * This routine will look up a species number based on the input string `nm`. The
+     * lookup of species will occur for all phases listed in the Kinetics object.
+     * @param nm  Name of the species.
+     * @param raise  If `true`, raise exception if the specified species is not defined
+     *      in the Kinetics object.
+     * @since Added the `raise` argument in %Cantera 3.2. If not specified, the default
+     *      behavior if a phase is not found in %Cantera 3.2 is to return `npos`.
+     *      After %Cantera 3.2, the default behavior will be to throw an exception.
+     * @exception Throws a CanteraError if the specified species is not found and
+     *      `raise` is `true`.
+     */
+    size_t kineticsSpeciesIndex(const string& nm, bool raise) const;
 
     /**
      * This function looks up the name of a species and returns a

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -225,12 +225,7 @@ public:
      * object.
      * @deprecated  To be removed after %Cantera 3.2. Use 2-parameter version instead.
      */
-    size_t phaseIndex(const string& ph) const {
-        warn_deprecated("Kinetics::phaseIndex", "'raise' argument not specified; "
-            "Default behavior will change from returning -1 to throwing an exception "
-            "after Cantera 3.2.");
-        return phaseIndex(ph, false);
-    }
+    size_t phaseIndex(const string& ph) const;
 
     /**
      * Return the index of a phase among the phases participating in this kinetic

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -247,7 +247,7 @@ public:
     size_t phaseIndex(const string& ph, bool raise) const {
         if (m_phaseindex.find(ph) == m_phaseindex.end()) {
             if (raise) {
-                throw CanteraError("Kinetics::phaseIndex", "Phase {} not found.", ph);
+                throw CanteraError("Kinetics::phaseIndex", "Phase '{}' not found", ph);
             }
             return npos;
         } else {

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -174,7 +174,7 @@ public:
     //! Check that the specified species index is in range
     /*!
      * @since After %Cantera 3.2, returns verified species index.
-     * @exception Throws an exception if k is greater than nSpecies()-1
+     * @exception Throws an IndexError if k is greater than nSpecies()-1
      */
     size_t checkSpeciesIndex(size_t k) const;
 
@@ -214,9 +214,32 @@ public:
      *
      * If a -1 is returned, then the phase is not defined in the Kinetics
      * object.
+     * @deprecated  To be removed after %Cantera 3.2. Use 2-parameter version instead.
      */
     size_t phaseIndex(const string& ph) const {
+        warn_deprecated("Kinetics::phaseIndex", "'raise' argument not specified; "
+            "Default behavior will change from returning -1 to throwing an exception "
+            "after Cantera 3.2.");
+        return phaseIndex(ph, false);
+    }
+
+    /**
+     * Return the phase index of a phase in the list of phases defined within
+     * the object.
+     *
+     * @param ph string name of the phase
+     * @param raise  If `true`, raise exception if the specified phase is not defined
+     *      in the Kinetics object.
+     * @since Added the `raise` argument in %Cantera 3.2. If not specified, the default
+     *      behavior if a phase is not found in %Cantera 3.2 is to return `npos`.
+     *      After %Cantera 3.2, the default behavior will be to throw an exception.
+     * @exception Throws a CanteraError if the specified phase is not defined.
+     */
+    size_t phaseIndex(const string& ph, bool raise) const {
         if (m_phaseindex.find(ph) == m_phaseindex.end()) {
+            if (raise) {
+                throw CanteraError("Kinetics::phaseIndex", "Phase {} not found.", ph);
+            }
             return npos;
         } else {
             return m_phaseindex.at(ph) - 1;

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -151,6 +151,18 @@ public:
     //!     @param name Name of the element
     size_t elementIndex(const string& name) const;
 
+    //! Return the index of element named 'name'.
+    /*!
+     * The index is an integer assigned to each element in the order it was added.
+     * Returns @ref npos if the specified element is not found.
+     * @param name Name of the element.
+     * @since Added the `force` argument in %Cantera 3.2. If not specified, the default
+     *      behavior in %Cantera 3.2 is to return `npos` if an element is not found.
+     *      After %Cantera 3.2, the default behavior will be to throw an exception.
+     * @exception Throws an IndexError.
+     */
+    size_t elementIndex(const string& name, bool force) const;
+
     //! Return a read-only reference to the vector of element names.
     const vector<string>& elementNames() const;
 
@@ -205,6 +217,7 @@ public:
     //! Check that an array size is at least nElements().
     //! Throws an exception if mm is less than nElements(). Used before calls
     //! which take an array pointer.
+    //! @deprecated To be removed after %Cantera 3.2. Only used by legacy CLib.
     void checkElementArraySize(size_t mm) const;
 
     //! Number of atoms of element @c m in species @c k.

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -164,7 +164,7 @@ public:
      *      After %Cantera 3.2, the default behavior will be to throw an exception.
      * @exception Throws an IndexError.
      */
-    size_t elementIndex(const string& name, bool force) const;
+    size_t elementIndex(const string& name, bool raise) const;
 
     //! Return a read-only reference to the vector of element names.
     const vector<string>& elementNames() const;
@@ -238,7 +238,24 @@ public:
     //!            phaseName:speciesName
     //!     @return The index of the species. If the name is not found,
     //!             the value @ref npos is returned.
+    //! @deprecated  To be removed after %Cantera 3.2. Use 2-parameter version instead.
     size_t speciesIndex(const string& name) const;
+
+    //! Returns the index of a species named 'name' within the Phase object.
+    /*!
+     * The first species in the phase will have an index 0, and the last one
+     * will have an index of nSpecies() - 1.
+     * @param name String name of the species. It may also be in the form
+     *      phaseName:speciesName
+     * @param raise  If `true`, raise exception if the specified element is not found;
+     *      otherwise, return @ref npos.
+     * @return The index of the species.
+     * @since Added the `raise` argument in %Cantera 3.2. If not specified, the default
+     *      behavior if an element is not found in %Cantera 3.2 is to return `npos`.
+     *      After %Cantera 3.2, the default behavior will be to throw an exception.
+     * @exception Throws an IndexError.
+     */
+    size_t speciesIndex(const string& name, bool raise) const;
 
     //! Name of the species with index k
     //!     @param k index of the species

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -279,6 +279,7 @@ public:
     //! Check that an array size is at least nSpecies().
     //! Throws an exception if kk is less than nSpecies(). Used before calls
     //! which take an array pointer.
+    //! @deprecated To be removed after %Cantera 3.2. Only used by legacy CLib.
     void checkSpeciesArraySize(size_t kk) const;
 
     //! @} end group Element and Species Information

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -162,7 +162,7 @@ public:
      * @since Added the `raise` argument in %Cantera 3.2. If not specified, the default
      *      behavior if an element is not found in %Cantera 3.2 is to return `npos`.
      *      After %Cantera 3.2, the default behavior will be to throw an exception.
-     * @exception Throws an IndexError.
+     * @exception Throws a CanteraError if the specified element is not found.
      */
     size_t elementIndex(const string& name, bool raise) const;
 
@@ -216,7 +216,7 @@ public:
     //! Check that the specified element index is in range.
     /*!
      * @since After %Cantera 3.2, returns verified element index.
-     * @exception Throws an exception if m is greater than nElements()-1
+     * @exception Throws an IndexError if m is greater than nElements()-1
      */
     size_t checkElementIndex(size_t m) const;
 
@@ -247,13 +247,13 @@ public:
      * will have an index of nSpecies() - 1.
      * @param name String name of the species. It may also be in the form
      *      phaseName:speciesName
-     * @param raise  If `true`, raise exception if the specified element is not found;
+     * @param raise  If `true`, raise exception if the specified species is not found;
      *      otherwise, return @ref npos.
      * @return The index of the species.
      * @since Added the `raise` argument in %Cantera 3.2. If not specified, the default
-     *      behavior if an element is not found in %Cantera 3.2 is to return `npos`.
+     *      behavior if a species is not found in %Cantera 3.2 is to return `npos`.
      *      After %Cantera 3.2, the default behavior will be to throw an exception.
-     * @exception Throws an IndexError.
+     * @exception Throws a CanteraError if the specifieds species is not found.
      */
     size_t speciesIndex(const string& name, bool raise) const;
 
@@ -272,7 +272,7 @@ public:
     //! Check that the specified species index is in range.
     /*!
      * @since After %Cantera 3.2, returns verified species index.
-     * @exception Throws an exception if k is greater than nSpecies()-1
+     * @exception Throws an IndexError if k is greater than nSpecies()-1
      */
     size_t checkSpeciesIndex(size_t k) const;
 

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -149,6 +149,7 @@ public:
     //! assigned to each element in the order it was added. Returns @ref npos
     //! if the specified element is not found.
     //!     @param name Name of the element
+    //! @deprecated  To be removed after %Cantera 3.2. Use 2-parameter version instead.
     size_t elementIndex(const string& name) const;
 
     //! Return the index of element named 'name'.
@@ -156,8 +157,10 @@ public:
      * The index is an integer assigned to each element in the order it was added.
      * Returns @ref npos if the specified element is not found.
      * @param name Name of the element.
-     * @since Added the `force` argument in %Cantera 3.2. If not specified, the default
-     *      behavior in %Cantera 3.2 is to return `npos` if an element is not found.
+     * @param raise  If `true`, raise exception if the specified element is not found;
+     *      otherwise, return @ref npos.
+     * @since Added the `raise` argument in %Cantera 3.2. If not specified, the default
+     *      behavior if an element is not found in %Cantera 3.2 is to return `npos`.
      *      After %Cantera 3.2, the default behavior will be to throw an exception.
      * @exception Throws an IndexError.
      */
@@ -211,8 +214,11 @@ public:
     size_t nElements() const;
 
     //! Check that the specified element index is in range.
-    //! Throws an exception if m is greater than nElements()-1
-    void checkElementIndex(size_t m) const;
+    /*!
+     * @since After %Cantera 3.2, returns verified element index.
+     * @exception Throws an exception if m is greater than nElements()-1
+     */
+    size_t checkElementIndex(size_t m) const;
 
     //! Check that an array size is at least nElements().
     //! Throws an exception if mm is less than nElements(). Used before calls

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -270,8 +270,11 @@ public:
     }
 
     //! Check that the specified species index is in range.
-    //! Throws an exception if k is greater than nSpecies()-1
-    void checkSpeciesIndex(size_t k) const;
+    /*!
+     * @since After %Cantera 3.2, returns verified species index.
+     * @exception Throws an exception if k is greater than nSpecies()-1
+     */
+    size_t checkSpeciesIndex(size_t k) const;
 
     //! Check that an array size is at least nSpecies().
     //! Throws an exception if kk is less than nSpecies(). Used before calls

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -162,7 +162,8 @@ public:
      * @since Added the `raise` argument in %Cantera 3.2. If not specified, the default
      *      behavior if an element is not found in %Cantera 3.2 is to return `npos`.
      *      After %Cantera 3.2, the default behavior will be to throw an exception.
-     * @exception Throws a CanteraError if the specified element is not found.
+     * @exception Throws a CanteraError if the specified element is not found and
+     *      `raise` is `true`.
      */
     size_t elementIndex(const string& name, bool raise) const;
 
@@ -215,7 +216,7 @@ public:
 
     //! Check that the specified element index is in range.
     /*!
-     * @since After %Cantera 3.2, returns verified element index.
+     * @since Starting in %Cantera 3.2, returns the input element index, if valid.
      * @exception Throws an IndexError if m is greater than nElements()-1
      */
     size_t checkElementIndex(size_t m) const;
@@ -253,7 +254,8 @@ public:
      * @since Added the `raise` argument in %Cantera 3.2. If not specified, the default
      *      behavior if a species is not found in %Cantera 3.2 is to return `npos`.
      *      After %Cantera 3.2, the default behavior will be to throw an exception.
-     * @exception Throws a CanteraError if the specifieds species is not found.
+     * @exception Throws a CanteraError if the specified species is not found and
+     *      `raise` is `true`.
      */
     size_t speciesIndex(const string& name, bool raise) const;
 
@@ -271,7 +273,7 @@ public:
 
     //! Check that the specified species index is in range.
     /*!
-     * @since After %Cantera 3.2, returns verified species index.
+     * @since Starting in %Cantera 3.2, returns the input phase index, if valid.
      * @exception Throws an IndexError if k is greater than nSpecies()-1
      */
     size_t checkSpeciesIndex(size_t k) const;

--- a/include/cantera/transport/Transport.h
+++ b/include/cantera/transport/Transport.h
@@ -114,7 +114,7 @@ public:
 
     //! Check that the specified species index is in range.
     /*!
-     * @since After %Cantera 3.2, returns verified species index.
+     * @since Starting in %Cantera 3.2, returns the input species index, if valid.
      * @exception Throws an IndexError if k is greater than #m_nsp.
      */
     size_t checkSpeciesIndex(size_t k) const;

--- a/include/cantera/transport/Transport.h
+++ b/include/cantera/transport/Transport.h
@@ -115,7 +115,7 @@ public:
     //! Check that the specified species index is in range.
     /*!
      * @since After %Cantera 3.2, returns verified species index.
-     * @exception Throws an exception if k is greater than #m_nsp.
+     * @exception Throws an IndexError if k is greater than #m_nsp.
      */
     size_t checkSpeciesIndex(size_t k) const;
 

--- a/include/cantera/transport/Transport.h
+++ b/include/cantera/transport/Transport.h
@@ -122,6 +122,7 @@ public:
     //! Check that an array size is at least #m_nsp. Throws an exception if
     //! kk is less than #m_nsp. Used before calls which take an array
     //! pointer.
+    //! @deprecated To be removed after %Cantera 3.2. Only used by legacy CLib.
     void checkSpeciesArraySize(size_t kk) const;
 
     //! @name Transport Properties

--- a/include/cantera/transport/Transport.h
+++ b/include/cantera/transport/Transport.h
@@ -112,9 +112,12 @@ public:
         return *m_thermo;
     }
 
-    //! Check that the specified species index is in range. Throws an exception
-    //! if k is greater than #m_nsp.
-    void checkSpeciesIndex(size_t k) const;
+    //! Check that the specified species index is in range.
+    /*!
+     * @since After %Cantera 3.2, returns verified species index.
+     * @exception Throws an exception if k is greater than #m_nsp.
+     */
+    size_t checkSpeciesIndex(size_t k) const;
 
     //! Check that an array size is at least #m_nsp. Throws an exception if
     //! kk is less than #m_nsp. Used before calls which take an array

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -1074,24 +1074,14 @@ cdef class Sim1D:
 
     def domain_index(self, dom):
         """
-        Get the index of a domain, specified either by name or as a Domain1D
-        object.
+        Get the index of a domain, specified either by name or as a Domain1D object.
         """
         if isinstance(dom, Domain1D):
-            idom = self.domains.index(dom)
-        elif isinstance(dom, int):
-            idom = dom
-        else:
-            idom = None
-            for i,d in enumerate(self.domains):
-                if d.name == dom:
-                    idom = i
-                    dom = d
-            if idom is None:
-                raise KeyError('Domain named "{0}" not found.'.format(dom))
-
-        assert 0 <= idom < len(self.domains)
-        return idom
+            return self.domains.index(dom)
+        if isinstance(dom, (str, bytes)):
+            return self.sim.domainIndex(stringify(dom))
+        assert 0 <= dom < len(self.domains)
+        return dom
 
     def _get_indices(self, dom, comp):
         idom = self.domain_index(dom)

--- a/interfaces/cython/cantera/kinetics.pxd
+++ b/interfaces/cython/cantera/kinetics.pxd
@@ -24,7 +24,7 @@ cdef extern from "cantera/kinetics/Kinetics.h" namespace "Cantera":
         int nTotalSpecies()
         int nReactions()
         int nPhases()
-        int phaseIndex(string&, cbool)
+        int phaseIndex(string&, cbool) except +translate_exception
         int kineticsSpeciesIndex(int, int)
         int kineticsSpeciesIndex(string)
         string kineticsSpeciesName(int)

--- a/interfaces/cython/cantera/kinetics.pxd
+++ b/interfaces/cython/cantera/kinetics.pxd
@@ -24,7 +24,7 @@ cdef extern from "cantera/kinetics/Kinetics.h" namespace "Cantera":
         int nTotalSpecies()
         int nReactions()
         int nPhases()
-        int phaseIndex(string)
+        int phaseIndex(string&, cbool)
         int kineticsSpeciesIndex(int, int)
         int kineticsSpeciesIndex(string)
         string kineticsSpeciesName(int)

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -928,7 +928,7 @@ cdef class InterfaceKinetics(Kinetics):
     def _setup_phase_indices(self):
         self._phase_indices = {}
         for name, phase in list(self.adjacent.items()) + [(self.name, self)]:
-            i = self.kinetics.phaseIndex(stringify(name))
+            i = self.kinetics.phaseIndex(stringify(name), True)
             self._phase_indices[phase] = i
             self._phase_indices[name] = i
             self._phase_indices[i] = i

--- a/interfaces/cython/cantera/mixture.pxd
+++ b/interfaces/cython/cantera/mixture.pxd
@@ -20,6 +20,7 @@ cdef extern from "cantera/equil/MultiPhase.h" namespace "Cantera":
         size_t nElements()
         size_t nPhases()
         size_t elementIndex(string, cbool) except +translate_exception
+        size_t checkElementIndex(size_t) except +translate_exception
         size_t speciesIndex(size_t, size_t) except +translate_exception
         string speciesName(size_t) except +translate_exception
         double nAtoms(size_t, size_t) except +translate_exception

--- a/interfaces/cython/cantera/mixture.pxd
+++ b/interfaces/cython/cantera/mixture.pxd
@@ -19,7 +19,7 @@ cdef extern from "cantera/equil/MultiPhase.h" namespace "Cantera":
         size_t nSpecies()
         size_t nElements()
         size_t nPhases()
-        size_t elementIndex(string) except +translate_exception
+        size_t elementIndex(string, cbool) except +translate_exception
         size_t speciesIndex(size_t, size_t) except +translate_exception
         string speciesName(size_t) except +translate_exception
         double nAtoms(size_t, size_t) except +translate_exception

--- a/interfaces/cython/cantera/mixture.pyx
+++ b/interfaces/cython/cantera/mixture.pyx
@@ -98,19 +98,19 @@ cdef class Mixture:
         """Index of element with name 'element'.
 
             >>> mix.element_index('H')
-            2
         """
         if isinstance(element, (str, bytes)):
-            index = self.mix.elementIndex(stringify(element))
-        elif isinstance(element, (int, float)):
+            return self.mix.elementIndex(stringify(element), True)
+
+        if isinstance(element, (int, float)):
             index = <int>element
+            if 0 <= index < self.n_elements:
+                return index
         else:
-            raise TypeError("'element' must be a string or a number")
+            raise TypeError("'element' must be a string or a number. "
+                            f"Got {element!r}.")
 
-        if not 0 <= index < self.n_elements:
-            raise ValueError('No such element.')
-
-        return index
+        raise ValueError(f"No such element {element!r}.")
 
     property n_species:
         """Number of species."""

--- a/interfaces/cython/cantera/mixture.pyx
+++ b/interfaces/cython/cantera/mixture.pyx
@@ -103,9 +103,7 @@ cdef class Mixture:
             return self.mix.elementIndex(stringify(element), True)
 
         if isinstance(element, (int, float)):
-            index = <int>element
-            if 0 <= index < self.n_elements:
-                return index
+            return self.mix.checkElementIndex(<int>element)
         else:
             raise TypeError("'element' must be a string or a number. "
                             f"Got {element!r}.")

--- a/interfaces/cython/cantera/mixture.pyx
+++ b/interfaces/cython/cantera/mixture.pyx
@@ -98,17 +98,16 @@ cdef class Mixture:
         """Index of element with name 'element'.
 
             >>> mix.element_index('H')
+            2
         """
         if isinstance(element, (str, bytes)):
             return self.mix.elementIndex(stringify(element), True)
 
         if isinstance(element, (int, float)):
             return self.mix.checkElementIndex(<int>element)
-        else:
-            raise TypeError("'element' must be a string or a number. "
-                            f"Got {element!r}.")
 
-        raise ValueError(f"No such element {element!r}.")
+        raise TypeError("'element' must be a string or a number. "
+                        f"Got {element!r}.")
 
     property n_species:
         """Number of species."""

--- a/interfaces/cython/cantera/mixture.pyx
+++ b/interfaces/cython/cantera/mixture.pyx
@@ -136,12 +136,8 @@ cdef class Mixture:
         """
         p = self.phase_index(phase)
 
-        if isinstance(species, (str, bytes)):
+        if isinstance(species, (str, bytes, int, float)):
             k = self.phase(p).species_index(species)
-        elif isinstance(species, (int, float)):
-            k = <int?>species
-            if not 0 <= k < self.n_species:
-                raise ValueError('Species index out of range')
         else:
             raise TypeError("'species' must be a string or number")
 

--- a/interfaces/cython/cantera/thermo.pxd
+++ b/interfaces/cython/cantera/thermo.pxd
@@ -82,7 +82,7 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
 
         # element properties
         size_t nElements()
-        size_t elementIndex(string) except +translate_exception
+        size_t elementIndex(string, cbool) except +translate_exception
         string elementName(size_t) except +translate_exception
         double atomicWeight(size_t) except +translate_exception
 

--- a/interfaces/cython/cantera/thermo.pxd
+++ b/interfaces/cython/cantera/thermo.pxd
@@ -92,6 +92,7 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
         shared_ptr[CxxSpecies] species(string) except +translate_exception
         shared_ptr[CxxSpecies] species(size_t) except +translate_exception
         size_t speciesIndex(string, cbool) except +translate_exception
+        size_t checkSpeciesIndex(size_t) except +translate_exception
         string speciesName(size_t) except +translate_exception
         double nAtoms(size_t, size_t) except +translate_exception
         void getAtoms(size_t, double*) except +translate_exception

--- a/interfaces/cython/cantera/thermo.pxd
+++ b/interfaces/cython/cantera/thermo.pxd
@@ -91,7 +91,7 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
         size_t nSpecies()
         shared_ptr[CxxSpecies] species(string) except +translate_exception
         shared_ptr[CxxSpecies] species(size_t) except +translate_exception
-        size_t speciesIndex(string) except +translate_exception
+        size_t speciesIndex(string, cbool) except +translate_exception
         string speciesName(size_t) except +translate_exception
         double nAtoms(size_t, size_t) except +translate_exception
         void getAtoms(size_t, double*) except +translate_exception

--- a/interfaces/cython/cantera/thermo.pxd
+++ b/interfaces/cython/cantera/thermo.pxd
@@ -83,6 +83,7 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
         # element properties
         size_t nElements()
         size_t elementIndex(string, cbool) except +translate_exception
+        size_t checkElementIndex(size_t) except +translate_exception
         string elementName(size_t) except +translate_exception
         double atomicWeight(size_t) except +translate_exception
 

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -463,17 +463,16 @@ cdef class ThermoPhase(_SolutionBase):
         returned. If no such element is present, an exception is thrown.
         """
         if isinstance(element, (str, bytes)):
-            index = self.thermo.elementIndex(stringify(element))
-        elif isinstance(element, (int, float)):
+            return self.thermo.elementIndex(stringify(element), True)
+        if isinstance(element, (int, float)):
             index = <int>element
+            if 0 <= index < self.n_elements:
+                return index
         else:
-            raise TypeError("'element' must be a string or a number."
-                            " Got {!r}.".format(element))
+            raise TypeError("'element' must be a string or a number. "
+                            f"Got {element!r}.")
 
-        if not 0 <= index < self.n_elements:
-            raise ValueError('No such element {!r}.'.format(element))
-
-        return index
+        raise ValueError(f"No such element {element!r}.")
 
     def element_name(self, m):
         """Name of the element with index ``m``."""
@@ -533,7 +532,7 @@ cdef class ThermoPhase(_SolutionBase):
                             " Got {!r}.".format(species))
 
         if not 0 <= index < self.n_species:
-            raise ValueError('No such species {!r}.'.format(species))
+            raise ValueError(f"No such species {species!r}.")
 
         return index
 

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -522,7 +522,7 @@ cdef class ThermoPhase(_SolutionBase):
         returned. If no such species is present, an exception is thrown.
         """
         if isinstance(species, (str, bytes)):
-            index = self.thermo.speciesIndex(stringify(species))
+            index = self.thermo.speciesIndex(stringify(species), False)
         elif isinstance(species, (int, float)):
             index = <int>species
         else:

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -466,11 +466,9 @@ cdef class ThermoPhase(_SolutionBase):
             return self.thermo.elementIndex(stringify(element), True)
         if isinstance(element, (int, float)):
             return self.thermo.checkElementIndex(<int>element)
-        else:
-            raise TypeError("'element' must be a string or a number. "
-                            f"Got {element!r}.")
 
-        raise ValueError(f"No such element {element!r}.")
+        raise TypeError("'element' must be a string or a number. "
+                        f"Got {element!r}.")
 
     def element_name(self, m):
         """Name of the element with index ``m``."""

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -465,9 +465,7 @@ cdef class ThermoPhase(_SolutionBase):
         if isinstance(element, (str, bytes)):
             return self.thermo.elementIndex(stringify(element), True)
         if isinstance(element, (int, float)):
-            index = <int>element
-            if 0 <= index < self.n_elements:
-                return index
+            return self.thermo.checkElementIndex(<int>element)
         else:
             raise TypeError("'element' must be a string or a number. "
                             f"Got {element!r}.")

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -522,17 +522,11 @@ cdef class ThermoPhase(_SolutionBase):
         returned. If no such species is present, an exception is thrown.
         """
         if isinstance(species, (str, bytes)):
-            index = self.thermo.speciesIndex(stringify(species), False)
-        elif isinstance(species, (int, float)):
-            index = <int>species
-        else:
-            raise TypeError("'species' must be a string or a number."
-                            " Got {!r}.".format(species))
-
-        if not 0 <= index < self.n_species:
-            raise ValueError(f"No such species {species!r}.")
-
-        return index
+            return self.thermo.speciesIndex(stringify(species), True)
+        if isinstance(species, (int, float)):
+            return self.thermo.checkSpeciesIndex(<int>species)
+        raise TypeError("'species' must be a string or a number."
+                        f" Got {species!r}.")
 
     property case_sensitive_species_names:
         """Enforce case-sensitivity for look up of species names"""

--- a/interfaces/sourcegen/src/sourcegen/headers/ctkin.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctkin.yaml
@@ -21,8 +21,18 @@ recipes:
 - name: reactionPhase  # New in Cantera 3.2
   what: accessor
 - name: phaseIndex
-  # alternate version to be removed after Cantera 3.2
-  wraps: phaseIndex(const string&, bool)
+  # temporary custom code due to changing C++ API: replaceable by
+  # wraps: phaseIndex(const string&)
+  # with implicit `raise=true` default after Cantera 3.2
+  brief: Return the phase index of a phase in the list of phases defined within the object.
+  what: method
+  declaration: int32_t kin_phaseIndex(int32_t handle, const char* ph);
+  parameters:
+    handle: Handle to queried Kinetics object.
+    ph: string name of the phase
+  uses: phaseIndex(const string&, bool)
+  code: |-
+    return KineticsCabinet::at(handle)->phaseIndex(ph, true);
 - name: nTotalSpecies  # Renamed in Cantera 3.2 (previously nSpecies)
 - name: reactantStoichCoeff
 - name: productStoichCoeff
@@ -38,8 +48,19 @@ recipes:
 - name: multiplier
 - name: setMultiplier
 - name: isReversible
-- name: speciesIndex
-  wraps: kineticsSpeciesIndex(const string&)  # inconsistent API (preexisting)
+- name: kineticsSpeciesIndex  # Renamed in Cantera 3.2 (previously speciesIndex)
+  # temporary custom code due to changing C++ API: replaceable by
+  # wraps: kineticsSpeciesIndex(const string&)
+  # with implicit `raise=true` default after Cantera 3.2
+  brief: Return the index of a species within the phases participating in this kinetic mechanism.
+  what: method
+  declaration: int32_t kin_kineticsSpeciesIndex(int32_t handle, const char* nm);
+  parameters:
+    handle: Handle to queried Kinetics object.
+    nm: name of the species
+  uses: kineticsSpeciesIndex(const string&, bool)
+  code: |-
+    return KineticsCabinet::at(handle)->kineticsSpeciesIndex(nm, true);
 - name: advanceCoverages
   wraps: advanceCoverages(double)
 - name: getDeltaEnthalpy  # Changed in Cantera 3.2 (previously part of getDelta)

--- a/interfaces/sourcegen/src/sourcegen/headers/ctkin.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctkin.yaml
@@ -21,6 +21,8 @@ recipes:
 - name: reactionPhase  # New in Cantera 3.2
   what: accessor
 - name: phaseIndex
+  # alternate version to be removed after Cantera 3.2
+  wraps: phaseIndex(const string&, bool)
 - name: nTotalSpecies  # Renamed in Cantera 3.2 (previously nSpecies)
 - name: reactantStoichCoeff
 - name: productStoichCoeff

--- a/interfaces/sourcegen/src/sourcegen/headers/ctmix.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctmix.yaml
@@ -15,7 +15,18 @@ recipes:
 - name: updatePhases
 - name: nElements
 - name: elementIndex
-  wraps: elementIndex(const string&, bool)
+  # temporary custom code due to changing C++ API: replaceable by
+  # wraps: elementIndex(const string&)
+  # with implicit `raise=true` default after Cantera 3.2
+  brief: Returns the index of the element with name
+  what: method
+  declaration: int32_t mix_elementIndex(int32_t handle, const char* name)
+  parameters:
+    handle: Handle to queried MultiPhase object.
+    name: String name of the global element
+  uses: elementIndex(const string&, bool)
+  code: |-
+    return MultiPhaseCabinet::at(handle)->elementIndex(name, true);
 - name: nSpecies
 - name: speciesIndex
   wraps: speciesIndex(size_t, size_t)

--- a/interfaces/sourcegen/src/sourcegen/headers/ctmix.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctmix.yaml
@@ -15,6 +15,7 @@ recipes:
 - name: updatePhases
 - name: nElements
 - name: elementIndex
+  wraps: elementIndex(const string&, bool)
 - name: nSpecies
 - name: speciesIndex
   wraps: speciesIndex(size_t, size_t)

--- a/interfaces/sourcegen/src/sourcegen/headers/ctthermo.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctthermo.yaml
@@ -46,8 +46,10 @@ recipes:
 - name: elementName  # Renamed in Cantera 3.2 (previously getElementName)
 - name: speciesName  # Renamed in Cantera 3.2 (previously getSpeciesName)
 - name: elementIndex
+  # alternate version to be removed after Cantera 3.2
   wraps: elementIndex(const string&, bool)
 - name: speciesIndex
+  # alternate version to be removed after Cantera 3.2
   wraps: speciesIndex(const string&, bool)
 - name: nAtoms
 - name: addElement

--- a/interfaces/sourcegen/src/sourcegen/headers/ctthermo.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctthermo.yaml
@@ -46,6 +46,7 @@ recipes:
 - name: elementName  # Renamed in Cantera 3.2 (previously getElementName)
 - name: speciesName  # Renamed in Cantera 3.2 (previously getSpeciesName)
 - name: elementIndex
+  wraps: elementIndex(const string&, bool)
 - name: speciesIndex
 - name: nAtoms
 - name: addElement

--- a/interfaces/sourcegen/src/sourcegen/headers/ctthermo.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctthermo.yaml
@@ -46,11 +46,31 @@ recipes:
 - name: elementName  # Renamed in Cantera 3.2 (previously getElementName)
 - name: speciesName  # Renamed in Cantera 3.2 (previously getSpeciesName)
 - name: elementIndex
-  # alternate version to be removed after Cantera 3.2
-  wraps: elementIndex(const string&, bool)
+  # temporary custom code due to changing C++ API: replaceable by
+  # wraps: elementIndex(const string&)
+  # with implicit `raise=true` default after Cantera 3.2
+  brief: Return the index of element named 'name'.
+  what: method
+  declaration: int32_t thermo_elementIndex(int32_t handle, const char* name)
+  parameters:
+    handle: Handle to queried Phase object.
+    name: Name of the element
+  uses: elementIndex(const string&, bool)
+  code: |-
+    return ThermoPhaseCabinet::as<Phase>(handle)->elementIndex(name, true);
 - name: speciesIndex
-  # alternate version to be removed after Cantera 3.2
-  wraps: speciesIndex(const string&, bool)
+  # temporary custom code due to changing C++ API: replaceable by
+  # wraps: speciesIndex(const string&)
+  # with implicit `raise=true` default after Cantera 3.2
+  brief: Returns the index of a species named 'name' within the Phase object.
+  what: method
+  declaration: int32_t thermo_speciesIndex(int32_t handle, const char* name)
+  parameters:
+    handle: Handle to queried Phase object.
+    name: String name of the species. It may also be in the form phaseName:speciesName
+  uses: speciesIndex(const string&, bool)
+  code: |-
+    return ThermoPhaseCabinet::as<Phase>(handle)->speciesIndex(name, true);
 - name: nAtoms
 - name: addElement
 - name: refPressure

--- a/interfaces/sourcegen/src/sourcegen/headers/ctthermo.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctthermo.yaml
@@ -48,6 +48,7 @@ recipes:
 - name: elementIndex
   wraps: elementIndex(const string&, bool)
 - name: speciesIndex
+  wraps: speciesIndex(const string&, bool)
 - name: nAtoms
 - name: addElement
 - name: refPressure

--- a/samples/clib_legacy/demo.c
+++ b/samples/clib_legacy/demo.c
@@ -43,7 +43,7 @@ void exit_with_error()
 
 int main(int argc, char** argv)
 {
-    ct_suppress_deprecation_warnings(0); // throw errors for deprecated functions
+    ct_suppress_deprecation_warnings(1); // suppress all deprecation warnings
 
     int soln = soln_newSolution("gri30.yaml", "gri30", "default");
     // In principle, one ought to check for errors after every Cantera call. But this
@@ -92,9 +92,7 @@ int main(int argc, char** argv)
     printf("\ntime       Temperature\n");
     int reactor = reactor_new("IdealGasReactor", soln, "test");
     int net = reactornet_new();
-    ct_suppress_deprecation_warnings(1);
     reactornet_addreactor(net, reactor);
-    ct_suppress_deprecation_warnings(0);
 
     double t = 0.0;
     int ret = 0;

--- a/src/base/Solution.cpp
+++ b/src/base/Solution.cpp
@@ -32,7 +32,7 @@ shared_ptr<Solution> Solution::clone(const vector<shared_ptr<Solution>>& adjacen
         map<string, shared_ptr<Solution>> adjacentByName;
         for (const auto& soln : adjacent) {
             adjacentByName[soln->name()] = soln;
-            if (m_kinetics->phaseIndex(soln->name()) == -1) {
+            if (m_kinetics->phaseIndex(soln->name(),false) == npos) {
                 throw CanteraError("Solution::clone", "Provided adjacent phase '{}'"
                     " not found in Kinetics object.", soln->name());
             }

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -680,7 +680,7 @@ bool SolutionArray::hasComponent(const string& name, bool checkAlias) const
         // auxiliary data
         return true;
     }
-    if (m_sol->thermo()->speciesIndex(name) != npos) {
+    if (m_sol->thermo()->speciesIndex(name, false) != npos) {
         // species
         return true;
     }
@@ -741,7 +741,7 @@ AnyValue SolutionArray::getComponent(const string& name) const
 
     // component is part of state information
     vector<double> data(m_size);
-    size_t ix = m_sol->thermo()->speciesIndex(_name);
+    size_t ix = m_sol->thermo()->speciesIndex(_name, false);
     if (ix == npos) {
         // state other than species
         ix = m_sol->thermo()->nativeState()[_name];
@@ -787,7 +787,7 @@ void SolutionArray::setComponent(const string& name, const AnyValue& data)
     }
 
     auto& vec = data.asVector<double>();
-    size_t ix = m_sol->thermo()->speciesIndex(name);
+    size_t ix = m_sol->thermo()->speciesIndex(name, false);
     if (ix == npos) {
         ix = m_sol->thermo()->nativeState()[name];
     } else {

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -321,7 +321,7 @@ extern "C" {
     size_t thermo_elementIndex(int n, const char* nm)
     {
         try {
-             size_t k = ThermoCabinet::at(n)->elementIndex(nm);
+             size_t k = ThermoCabinet::at(n)->elementIndex(nm, false);
              if (k == npos) {
                 throw CanteraError("thermo_elementIndex",
                                    "No such element {}.", nm);
@@ -335,7 +335,7 @@ extern "C" {
     size_t thermo_speciesIndex(int n, const char* nm)
     {
         try {
-             size_t k = ThermoCabinet::at(n)->speciesIndex(nm);
+             size_t k = ThermoCabinet::at(n)->speciesIndex(nm, false);
              if (k == npos) {
                 throw CanteraError("thermo_speciesIndex",
                                    "No such species {}.", nm);
@@ -1179,7 +1179,7 @@ extern "C" {
     size_t kin_phaseIndex(int n, const char* ph)
     {
         try {
-            size_t k = KineticsCabinet::at(n)->phaseIndex(ph);
+            size_t k = KineticsCabinet::at(n)->phaseIndex(ph, false);
             if (k == npos) {
                 throw CanteraError("kin_phaseIndex",
                                    "No such phase {}.", ph);

--- a/src/clib/ctmultiphase.cpp
+++ b/src/clib/ctmultiphase.cpp
@@ -93,7 +93,7 @@ extern "C" {
     size_t mix_elementIndex(int i, const char* name)
     {
         try {
-            return mixCabinet::at(i)->elementIndex(name);
+            return mixCabinet::at(i)->elementIndex(name, false);
         } catch (...) {
             return handleAllExceptions(npos, npos);
         }

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -227,10 +227,7 @@ size_t MultiPhase::speciesIndex(const string& speciesName, const string& phaseNa
     if (p == npos) {
         throw CanteraError("MultiPhase::speciesIndex", "phase not found: " + phaseName);
     }
-    size_t k = m_phase[p]->speciesIndex(speciesName);
-    if (k == npos) {
-        throw CanteraError("MultiPhase::speciesIndex", "species not found: " + speciesName);
-    }
+    size_t k = m_phase[p]->speciesIndex(speciesName, true);
     return m_spstart[p] + k;
 }
 

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -754,7 +754,7 @@ size_t MultiPhase::elementIndex(const string& name, bool raise) const
     if (!raise) {
         return npos;
     }
-    throw CanteraError("MultiPhase::elementIndex", "Element {} not found.", name);
+    throw CanteraError("MultiPhase::elementIndex", "Element '{}' not found", name);
 }
 
 size_t MultiPhase::checkSpeciesIndex(size_t k) const
@@ -812,7 +812,7 @@ int MultiPhase::phaseIndex(const string& pName, bool raise) const
     if (!raise) {
         return -1;
     }
-    throw CanteraError("MultiPhase::phaseIndex", "Phase {} not found.", pName);
+    throw CanteraError("MultiPhase::phaseIndex", "Phase '{}' not found", pName);
 }
 
 double MultiPhase::phaseMoles(const size_t n) const

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -798,11 +798,11 @@ int MultiPhase::phaseIndex(const string& pName) const
 {
     warn_deprecated("MultiPhase::phaseIndex", "'raise' argument not specified; "
         "Default behavior will change from returning -1 to throwing an exception "
-        "after Cantera 3.2.");
+        "after Cantera 3.2. 'npos' will be return instead of -1 if 'raise=true'.");
     return phaseIndex(pName, false);
 }
 
-int MultiPhase::phaseIndex(const string& pName, bool raise) const
+size_t MultiPhase::phaseIndex(const string& pName, bool raise) const
 {
     for (int iph = 0; iph < (int) nPhases(); iph++) {
         if (m_phase[iph]->name() == pName) {
@@ -810,7 +810,7 @@ int MultiPhase::phaseIndex(const string& pName, bool raise) const
         }
     }
     if (!raise) {
-        return -1;
+        return npos;
     }
     throw CanteraError("MultiPhase::phaseIndex", "Phase '{}' not found", pName);
 }

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -717,11 +717,12 @@ void MultiPhase::setTemperature(const double T)
     updatePhases();
 }
 
-void MultiPhase::checkElementIndex(size_t m) const
+size_t MultiPhase::checkElementIndex(size_t m) const
 {
-    if (m >= m_nel) {
-        throw IndexError("MultiPhase::checkElementIndex", "elements", m, m_nel);
+    if (m < m_nel) {
+        return m;
     }
+    throw IndexError("MultiPhase::checkElementIndex", "elements", m, m_nel);
 }
 
 void MultiPhase::checkElementArraySize(size_t mm) const
@@ -740,20 +741,20 @@ string MultiPhase::elementName(size_t m) const
 
 size_t MultiPhase::elementIndex(const string& name) const
 {
-    warn_deprecated("MultiPhase::elementIndex", "'force' argument not specified; "
+    warn_deprecated("MultiPhase::elementIndex", "'raise' argument not specified; "
         "Default behavior will change from returning npos to throwing an exception "
         "after Cantera 3.2.");
     return elementIndex(name, false);
 }
 
-size_t MultiPhase::elementIndex(const string& name, bool force) const
+size_t MultiPhase::elementIndex(const string& name, bool raise) const
 {
     for (size_t e = 0; e < m_nel; e++) {
         if (m_enames[e] == name) {
             return e;
         }
     }
-    if (!force) {
+    if (!raise) {
         return npos;
     }
     throw CanteraError("MultiPhase::elementIndex", "Element {} not found.", name);

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -223,10 +223,7 @@ size_t MultiPhase::speciesIndex(const string& speciesName, const string& phaseNa
     if (!m_init) {
         init();
     }
-    size_t p = phaseIndex(phaseName);
-    if (p == npos) {
-        throw CanteraError("MultiPhase::speciesIndex", "phase not found: " + phaseName);
-    }
+    size_t p = phaseIndex(phaseName, true);
     size_t k = m_phase[p]->speciesIndex(speciesName, true);
     return m_spstart[p] + k;
 }
@@ -794,12 +791,23 @@ string MultiPhase::phaseName(const size_t iph) const
 
 int MultiPhase::phaseIndex(const string& pName) const
 {
+    warn_deprecated("MultiPhase::phaseIndex", "'raise' argument not specified; "
+        "Default behavior will change from returning -1 to throwing an exception "
+        "after Cantera 3.2.");
+    return phaseIndex(pName, false);
+}
+
+int MultiPhase::phaseIndex(const string& pName, bool raise) const
+{
     for (int iph = 0; iph < (int) nPhases(); iph++) {
         if (m_phase[iph]->name() == pName) {
             return iph;
         }
     }
-    return -1;
+    if (!raise) {
+        return -1;
+    }
+    throw CanteraError("MultiPhase::phaseIndex", "Phase {} not found.", pName);
 }
 
 double MultiPhase::phaseMoles(const size_t n) const

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -139,7 +139,7 @@ void MultiPhase::init()
         for (size_t ip = 0; ip < nPhases(); ip++) {
             ThermoPhase* p = m_phase[ip];
             size_t nsp = p->nSpecies();
-            size_t mlocal = p->elementIndex(m_enames[m]);
+            size_t mlocal = p->elementIndex(m_enames[m], false);
             for (size_t kp = 0; kp < nsp; kp++) {
                 if (mlocal != npos) {
                     m_atoms(m, k) = p->nAtoms(kp, mlocal);
@@ -726,6 +726,8 @@ void MultiPhase::checkElementIndex(size_t m) const
 
 void MultiPhase::checkElementArraySize(size_t mm) const
 {
+    warn_deprecated("Phase::checkElementArraySize",
+        "To be removed after Cantera 3.2. Only used by legacy CLib.");
     if (m_nel > mm) {
         throw ArraySizeError("MultiPhase::checkElementArraySize", mm, m_nel);
     }
@@ -738,12 +740,23 @@ string MultiPhase::elementName(size_t m) const
 
 size_t MultiPhase::elementIndex(const string& name) const
 {
+    warn_deprecated("MultiPhase::elementIndex", "'force' argument not specified; "
+        "Default behavior will change from returning npos to throwing an exception "
+        "after Cantera 3.2.");
+    return elementIndex(name, false);
+}
+
+size_t MultiPhase::elementIndex(const string& name, bool force) const
+{
     for (size_t e = 0; e < m_nel; e++) {
         if (m_enames[e] == name) {
             return e;
         }
     }
-    return npos;
+    if (!force) {
+        return npos;
+    }
+    throw CanteraError("MultiPhase::elementIndex", "Element {} not found.", name);
 }
 
 void MultiPhase::checkSpeciesIndex(size_t k) const

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -757,11 +757,12 @@ size_t MultiPhase::elementIndex(const string& name, bool raise) const
     throw CanteraError("MultiPhase::elementIndex", "Element {} not found.", name);
 }
 
-void MultiPhase::checkSpeciesIndex(size_t k) const
+size_t MultiPhase::checkSpeciesIndex(size_t k) const
 {
-    if (k >= m_nsp) {
-        throw IndexError("MultiPhase::checkSpeciesIndex", "species", k, m_nsp);
+    if (k < m_nsp) {
+        return k;
     }
+    throw IndexError("MultiPhase::checkSpeciesIndex", "species", k, m_nsp);
 }
 
 void MultiPhase::checkSpeciesArraySize(size_t kk) const

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -174,15 +174,18 @@ ThermoPhase& MultiPhase::phase(size_t n)
     return *m_phase[n];
 }
 
-void MultiPhase::checkPhaseIndex(size_t m) const
+size_t MultiPhase::checkPhaseIndex(size_t m) const
 {
-    if (m >= nPhases()) {
-        throw IndexError("MultiPhase::checkPhaseIndex", "phase", m, nPhases());
+    if (m < nPhases()) {
+        return m;
     }
+    throw IndexError("MultiPhase::checkPhaseIndex", "phase", m, nPhases());
 }
 
 void MultiPhase::checkPhaseArraySize(size_t mm) const
 {
+    warn_deprecated("MultiPhase::checkPhaseArraySize",
+        "To be removed after Cantera 3.2. Unused.");
     if (nPhases() > mm) {
         throw ArraySizeError("MultiPhase::checkPhaseIndex", mm, nPhases());
     }
@@ -721,7 +724,7 @@ size_t MultiPhase::checkElementIndex(size_t m) const
 
 void MultiPhase::checkElementArraySize(size_t mm) const
 {
-    warn_deprecated("Phase::checkElementArraySize",
+    warn_deprecated("MultiPhase::checkElementArraySize",
         "To be removed after Cantera 3.2. Only used by legacy CLib.");
     if (m_nel > mm) {
         throw ArraySizeError("MultiPhase::checkElementArraySize", mm, m_nel);
@@ -764,6 +767,8 @@ size_t MultiPhase::checkSpeciesIndex(size_t k) const
 
 void MultiPhase::checkSpeciesArraySize(size_t kk) const
 {
+    warn_deprecated("MultiPhase::checkSpeciesArraySize",
+        "To be removed after Cantera 3.2. Only used by legacy CLib.");
     if (m_nsp > kk) {
         throw ArraySizeError("MultiPhase::checkSpeciesArraySize", kk, m_nsp);
     }

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -738,10 +738,13 @@ string MultiPhase::elementName(size_t m) const
 
 size_t MultiPhase::elementIndex(const string& name) const
 {
-    warn_deprecated("MultiPhase::elementIndex", "'raise' argument not specified; "
-        "Default behavior will change from returning npos to throwing an exception "
-        "after Cantera 3.2.");
-    return elementIndex(name, false);
+    size_t ix = elementIndex(name, false);
+    if (ix == npos) {
+        warn_deprecated("MultiPhase::elementIndex", "'raise' argument not specified; "
+            "Default behavior will change from returning npos to throwing an exception "
+            "after Cantera 3.2.");
+    }
+    return ix;
 }
 
 size_t MultiPhase::elementIndex(const string& name, bool raise) const
@@ -796,10 +799,13 @@ string MultiPhase::phaseName(const size_t iph) const
 
 int MultiPhase::phaseIndex(const string& pName) const
 {
-    warn_deprecated("MultiPhase::phaseIndex", "'raise' argument not specified; "
-        "Default behavior will change from returning -1 to throwing an exception "
-        "after Cantera 3.2. 'npos' will be return instead of -1 if 'raise=true'.");
-    return phaseIndex(pName, false);
+    size_t ix = phaseIndex(pName, false);
+    if (ix == npos) {
+        warn_deprecated("MultiPhase::phaseIndex", "'raise' argument not specified; "
+            "Default behavior will change from returning -1 to throwing an exception "
+            "after Cantera 3.2. 'npos' will be return instead of -1 if 'raise=true'.");
+    }
+    return ix;
 }
 
 size_t MultiPhase::phaseIndex(const string& pName, bool raise) const

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -66,7 +66,7 @@ void BulkKinetics::addThirdBody(shared_ptr<Reaction> r)
 {
     map<size_t, double> efficiencies;
     for (const auto& [name, efficiency] : r->thirdBody()->efficiencies) {
-        size_t k = kineticsSpeciesIndex(name);
+        size_t k = kineticsSpeciesIndex(name, false);
         if (k != npos) {
             efficiencies[k] = efficiency;
         } else if (!m_skipUndeclaredThirdBodies) {

--- a/src/kinetics/ElectronCollisionPlasmaRate.cpp
+++ b/src/kinetics/ElectronCollisionPlasmaRate.cpp
@@ -204,7 +204,7 @@ void ElectronCollisionPlasmaRate::setContext(const Reaction& rxn, const Kinetics
                 if (p == electronName) {
                     continue;
                 }
-                double q = thermo.charge(thermo.speciesIndex(p));
+                double q = thermo.charge(thermo.speciesIndex(p, true));
                 if (q > 0) {
                     m_kind = "ionization";
                 } else if (q < 0) {

--- a/src/kinetics/InterfaceRate.cpp
+++ b/src/kinetics/InterfaceRate.cpp
@@ -382,7 +382,7 @@ void StickingCoverage::setContext(const Reaction& rxn, const Kinetics& kin)
     for (const auto& [name, stoich] : rxn.reactants) {
         size_t iPhase = kin.speciesPhaseIndex(kin.kineticsSpeciesIndex(name));
         const ThermoPhase& p = kin.thermo(iPhase);
-        size_t k = p.speciesIndex(name);
+        size_t k = p.speciesIndex(name, true);
         if (name == sticking_species) {
             multiplier *= sqrt(GasConstant / (2 * Pi * p.molecularWeight(k)));
         } else {

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -39,11 +39,12 @@ shared_ptr<Kinetics> Kinetics::clone(
     return newKinetics(phases, phaseNode, rootNode, phases[0]->root());
 }
 
-void Kinetics::checkReactionIndex(size_t i) const
+size_t Kinetics::checkReactionIndex(size_t i) const
 {
-    if (i >= nReactions()) {
-        throw IndexError("Kinetics::checkReactionIndex", "reactions", i, nReactions());
+    if (i < nReactions()) {
+        return i;
     }
+    throw IndexError("Kinetics::checkReactionIndex", "reactions", i, nReactions());
 }
 
 void Kinetics::resizeReactions()
@@ -65,21 +66,26 @@ void Kinetics::resizeReactions()
 
 void Kinetics::checkReactionArraySize(size_t ii) const
 {
+    warn_deprecated("Kinetics::checkReactionArraySize",
+        "To be removed after Cantera 3.2. Only used by legacy CLib.");
     if (nReactions() > ii) {
         throw ArraySizeError("Kinetics::checkReactionArraySize", ii,
                              nReactions());
     }
 }
 
-void Kinetics::checkPhaseIndex(size_t m) const
+size_t Kinetics::checkPhaseIndex(size_t m) const
 {
-    if (m >= nPhases()) {
-        throw IndexError("Kinetics::checkPhaseIndex", "phase", m, nPhases());
+    if (m < nPhases()) {
+        return m;
     }
+    throw IndexError("Kinetics::checkPhaseIndex", "phase", m, nPhases());
 }
 
 void Kinetics::checkPhaseArraySize(size_t mm) const
 {
+    warn_deprecated("Kinetics::checkPhaseArraySize",
+        "To be removed after Cantera 3.2. Unused.");
     if (nPhases() > mm) {
         throw ArraySizeError("Kinetics::checkPhaseArraySize", mm, nPhases());
     }
@@ -100,6 +106,8 @@ size_t Kinetics::checkSpeciesIndex(size_t k) const
 
 void Kinetics::checkSpeciesArraySize(size_t kk) const
 {
+    warn_deprecated("Kinetics::checkSpeciesArraySize",
+        "To be removed after Cantera 3.2. Only used by legacy CLib.");
     if (m_kk > kk) {
         throw ArraySizeError("Kinetics::checkSpeciesArraySize", kk, m_kk);
     }

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -91,6 +91,17 @@ void Kinetics::checkPhaseArraySize(size_t mm) const
     }
 }
 
+size_t Kinetics::phaseIndex(const string& ph) const
+{
+    size_t ix = phaseIndex(ph, false);
+    if (ix == npos) {
+        warn_deprecated("Kinetics::phaseIndex", "'raise' argument not specified; "
+            "Default behavior will change from returning -1 to throwing an "
+            "exception after Cantera 3.2.");
+    }
+    return ix;
+}
+
 size_t Kinetics::phaseIndex(const string& ph, bool raise) const
 {
     if (m_phaseindex.find(ph) == m_phaseindex.end()) {

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -90,11 +90,12 @@ shared_ptr<ThermoPhase> Kinetics::reactionPhase() const
     return m_thermo[0];
 }
 
-void Kinetics::checkSpeciesIndex(size_t k) const
+size_t Kinetics::checkSpeciesIndex(size_t k) const
 {
-    if (k >= m_kk) {
-        throw IndexError("Kinetics::checkSpeciesIndex", "species", k, m_kk);
+    if (k < m_kk) {
+        return k;
     }
+    throw IndexError("Kinetics::checkSpeciesIndex", "species", k, m_kk);
 }
 
 void Kinetics::checkSpeciesArraySize(size_t kk) const

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -91,6 +91,18 @@ void Kinetics::checkPhaseArraySize(size_t mm) const
     }
 }
 
+size_t Kinetics::phaseIndex(const string& ph, bool raise) const
+{
+    if (m_phaseindex.find(ph) == m_phaseindex.end()) {
+        if (raise) {
+            throw CanteraError("Kinetics::phaseIndex", "Phase '{}' not found", ph);
+        }
+        return npos;
+    } else {
+        return m_phaseindex.at(ph) - 1;
+    }
+}
+
 shared_ptr<ThermoPhase> Kinetics::reactionPhase() const
 {
     return m_thermo[0];

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -95,8 +95,8 @@ size_t Kinetics::phaseIndex(const string& ph) const
 {
     size_t ix = phaseIndex(ph, false);
     if (ix == npos) {
-        warn_deprecated("Kinetics::phaseIndex", "'raise' argument not specified; "
-            "Default behavior will change from returning -1 to throwing an "
+        warn_deprecated("Kinetics::phaseIndex", "'raise' argument not specified. "
+            "Default behavior will change from returning npos to throwing an "
             "exception after Cantera 3.2.");
     }
     return ix;
@@ -344,12 +344,27 @@ string Kinetics::kineticsSpeciesName(size_t k) const
 
 size_t Kinetics::kineticsSpeciesIndex(const string& nm) const
 {
+    size_t ix = kineticsSpeciesIndex(nm, false);
+    if (ix == npos) {
+        warn_deprecated("Kinetics::kineticsSpeciesIndex", "'raise' argument not "
+            "specified. Default behavior will change from returning npos to throwing "
+            "an exception after Cantera 3.2.");
+    }
+    return ix;
+}
+
+size_t Kinetics::kineticsSpeciesIndex(const string& nm, bool raise) const
+{
     for (size_t n = 0; n < m_thermo.size(); n++) {
         // Check the ThermoPhase object for a match
         size_t k = thermo(n).speciesIndex(nm, false);
         if (k != npos) {
             return k + m_start[n];
         }
+    }
+    if (raise) {
+        throw CanteraError("Kinetics::kineticsSpeciesIndex",
+            "Species '{}' not found", nm);
     }
     return npos;
 }

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -314,7 +314,7 @@ size_t Kinetics::kineticsSpeciesIndex(const string& nm) const
 {
     for (size_t n = 0; n < m_thermo.size(); n++) {
         // Check the ThermoPhase object for a match
-        size_t k = thermo(n).speciesIndex(nm);
+        size_t k = thermo(n).speciesIndex(nm, false);
         if (k != npos) {
             return k + m_start[n];
         }
@@ -325,7 +325,7 @@ size_t Kinetics::kineticsSpeciesIndex(const string& nm) const
 ThermoPhase& Kinetics::speciesPhase(const string& nm)
 {
     for (size_t n = 0; n < m_thermo.size(); n++) {
-        size_t k = thermo(n).speciesIndex(nm);
+        size_t k = thermo(n).speciesIndex(nm, false);
         if (k != npos) {
             return thermo(n);
         }
@@ -336,7 +336,7 @@ ThermoPhase& Kinetics::speciesPhase(const string& nm)
 const ThermoPhase& Kinetics::speciesPhase(const string& nm) const
 {
     for (const auto& thermo : m_thermo) {
-        if (thermo->speciesIndex(nm) != npos) {
+        if (thermo->speciesIndex(nm, false) != npos) {
             return *thermo;
         }
     }

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -633,7 +633,7 @@ void Reaction::checkBalance(const Kinetics& kin) const
     // iterate over products and reactants
     for (const auto& [name, stoich] : products) {
         const ThermoPhase& ph = kin.speciesPhase(name);
-        size_t k = ph.speciesIndex(name);
+        size_t k = ph.speciesIndex(name, true);
         for (size_t m = 0; m < ph.nElements(); m++) {
             balr[ph.elementName(m)] = 0.0; // so that balr contains all species
             balp[ph.elementName(m)] += stoich * ph.nAtoms(k, m);
@@ -641,7 +641,7 @@ void Reaction::checkBalance(const Kinetics& kin) const
     }
     for (const auto& [name, stoich] : reactants) {
         const ThermoPhase& ph = kin.speciesPhase(name);
-        size_t k = ph.speciesIndex(name);
+        size_t k = ph.speciesIndex(name, true);
         for (size_t m = 0; m < ph.nElements(); m++) {
             balr[ph.elementName(m)] += stoich * ph.nAtoms(k, m);
         }
@@ -674,13 +674,13 @@ void Reaction::checkBalance(const Kinetics& kin) const
     double prod_sites = 0.0;
     auto& surf = dynamic_cast<const SurfPhase&>(kin.thermo(0));
     for (const auto& [name, stoich] : reactants) {
-        size_t k = surf.speciesIndex(name);
+        size_t k = surf.speciesIndex(name, false);
         if (k != npos) {
             reac_sites += stoich * surf.size(k);
         }
     }
     for (const auto& [name, stoich] : products) {
-        size_t k = surf.speciesIndex(name);
+        size_t k = surf.speciesIndex(name, false);
         if (k != npos) {
             prod_sites += stoich * surf.size(k);
         }
@@ -746,7 +746,7 @@ bool Reaction::usesElectrochemistry(const Kinetics& kin) const
     for (const auto& [name, stoich] : products) {
         size_t kkin = kin.kineticsSpeciesIndex(name);
         size_t i = kin.speciesPhaseIndex(kkin);
-        size_t kphase = kin.thermo(i).speciesIndex(name);
+        size_t kphase = kin.thermo(i).speciesIndex(name, true);
         e_counter[i] += stoich * kin.thermo(i).charge(kphase);
     }
 
@@ -754,7 +754,7 @@ bool Reaction::usesElectrochemistry(const Kinetics& kin) const
     for (const auto& [name, stoich] : reactants) {
         size_t kkin = kin.kineticsSpeciesIndex(name);
         size_t i = kin.speciesPhaseIndex(kkin);
-        size_t kphase = kin.thermo(i).speciesIndex(name);
+        size_t kphase = kin.thermo(i).speciesIndex(name, true);
         e_counter[i] -= stoich * kin.thermo(i).charge(kphase);
     }
 

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -295,7 +295,7 @@ void Reaction::setParameters(const AnyMap& node, const Kinetics& kin)
     if (node.hasKey("orders")) {
         for (const auto& [name, order] : node["orders"].asMap<double>()) {
             orders[name] = order;
-            if (kin.kineticsSpeciesIndex(name) == npos) {
+            if (kin.kineticsSpeciesIndex(name, false) == npos) {
                 setValid(false);
             }
         }
@@ -620,7 +620,7 @@ void updateUndeclared(vector<string>& undeclared,
                       const Composition& comp, const Kinetics& kin)
 {
     for (const auto& [name, stoich]: comp) {
-        if (kin.kineticsSpeciesIndex(name) == npos) {
+        if (kin.kineticsSpeciesIndex(name, false) == npos) {
             undeclared.emplace_back(name);
         }
     }
@@ -936,7 +936,7 @@ void parseReactionEquation(Reaction& R, const string& equation,
                     equation, tokens[i],
                     (last_used == npos) ? "n/a" : tokens[last_used]);
             }
-            if (!kin || (kin->kineticsSpeciesIndex(species) == npos
+            if (!kin || (kin->kineticsSpeciesIndex(species, false) == npos
                          && mass_action && species != "M"))
             {
                 R.setValid(false);

--- a/src/kinetics/ReactionPath.cpp
+++ b/src/kinetics/ReactionPath.cpp
@@ -587,12 +587,12 @@ void ReactionPathBuilder::findElements(Kinetics& kin)
         // iterate over the phases
         for (size_t ip = 0; ip < kin.nPhases(); ip++) {
             ThermoPhase* p = &kin.thermo(ip);
-            size_t mlocal = p->elementIndex(m_elementSymbols[m]);
-            for (size_t kp = 0; kp < p->nSpecies(); kp++) {
-                if (mlocal != npos) {
+            size_t mlocal = p->elementIndex(m_elementSymbols[m], false);
+            if (mlocal != npos) {
+                for (size_t kp = 0; kp < p->nSpecies(); kp++) {
                     m_atoms(k, m) = p->nAtoms(kp, mlocal);
+                    k++;
                 }
-                k++;
             }
         }
     }

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -656,7 +656,7 @@ string ReactingSurf1D::componentName(size_t n) const
 
 size_t ReactingSurf1D::componentIndex(const string& name, bool checkAlias) const
 {
-    return m_sphase->speciesIndex(name);
+    return m_sphase->speciesIndex(name, true);
 }
 
 void ReactingSurf1D::init()

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -89,7 +89,7 @@ size_t Domain1D::componentIndex(const string& name, bool checkAlias) const
         }
     }
     throw CanteraError("Domain1D::componentIndex",
-                       "no component named '{}'", name);
+                       "Component '{}' not found", name);
 }
 
 bool Domain1D::hasComponent(const string& name, bool checkAlias) const
@@ -100,7 +100,7 @@ bool Domain1D::hasComponent(const string& name, bool checkAlias) const
         }
     }
     throw CanteraError("Domain1D::hasComponent",
-                       "no component named '{}'", name);
+                       "Component '{}' not found", name);
 }
 
 void Domain1D::setTransientTolerances(double rtol, double atol, size_t n)

--- a/src/oneD/Flow1D.cpp
+++ b/src/oneD/Flow1D.cpp
@@ -103,8 +103,8 @@ void Flow1D::_init(ThermoPhase* ph, size_t nsp, size_t points)
 
     // Find indices for radiating species
     m_kRadiating.resize(2, npos);
-    m_kRadiating[0] = m_thermo->speciesIndex("CO2");
-    m_kRadiating[1] = m_thermo->speciesIndex("H2O");
+    m_kRadiating[0] = m_thermo->speciesIndex("CO2", false);
+    m_kRadiating[1] = m_thermo->speciesIndex("H2O", false);
 }
 
 Flow1D::Flow1D(shared_ptr<ThermoPhase> th, size_t nsp, size_t points)

--- a/src/oneD/Flow1D.cpp
+++ b/src/oneD/Flow1D.cpp
@@ -890,7 +890,7 @@ size_t Flow1D::componentIndex(const string& name, bool checkAlias) const
         }
     }
     throw CanteraError("Flow1D::componentIndex",
-                       "No component named '{}'", name);
+                       "Component '{}' not found", name);
 }
 
 bool Flow1D::hasComponent(const string& name, bool checkAlias) const

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -40,8 +40,8 @@ void IonFlow::_init(ThermoPhase* ph, size_t nsp, size_t points)
     }
 
     // Find the index of electron
-    if (m_thermo->speciesIndex("E") != npos ) {
-        m_kElectron = m_thermo->speciesIndex("E");
+    if (m_thermo->speciesIndex("E", false) != npos ) {
+        m_kElectron = m_thermo->speciesIndex("E", true);
     }
 
     // no bound for electric potential

--- a/src/oneD/OneDim.cpp
+++ b/src/oneD/OneDim.cpp
@@ -33,7 +33,7 @@ size_t OneDim::domainIndex(const string& name) const
             return n;
         }
     }
-    throw CanteraError("OneDim::domainIndex","no domain named >>"+name+"<<");
+    throw CanteraError("OneDim::domainIndex", "Domain '{}' not found", name);
 }
 
 std::tuple<string, size_t, string> OneDim::component(size_t i) const {

--- a/src/thermo/BinarySolutionTabulatedThermo.cpp
+++ b/src/thermo/BinarySolutionTabulatedThermo.cpp
@@ -80,7 +80,7 @@ bool BinarySolutionTabulatedThermo::addSpecies(shared_ptr<Species> spec)
 void BinarySolutionTabulatedThermo::initThermo()
 {
     if (m_input.hasKey("tabulated-thermo")) {
-        m_kk_tab = speciesIndex(m_input["tabulated-species"].asString());
+        m_kk_tab = speciesIndex(m_input["tabulated-species"].asString(), true);
         if (nSpecies() != 2) {
             throw InputFileError("BinarySolutionTabulatedThermo::initThermo",
                 m_input["species"],

--- a/src/thermo/CoverageDependentSurfPhase.cpp
+++ b/src/thermo/CoverageDependentSurfPhase.cpp
@@ -172,8 +172,8 @@ void CoverageDependentSurfPhase::initThermo()
         if (item.second->input.hasKey("coverage-dependencies")) {
             auto& cov_map = item.second->input["coverage-dependencies"];
             for (const auto& item2 : cov_map) {
-                size_t k = speciesIndex(item.first);
-                size_t j = speciesIndex(item2.first);
+                size_t k = speciesIndex(item.first, false);
+                size_t j = speciesIndex(item2.first, false);
                 if (k == npos) {
                    throw InputFileError("CoverageDependentSurfPhase::initThermo",
                         item.second->input, "Unknown species '{}'.", item.first);
@@ -239,7 +239,7 @@ void CoverageDependentSurfPhase::getSpeciesParameters(const string& name,
                                                       AnyMap& speciesNode) const
 {
     SurfPhase::getSpeciesParameters(name, speciesNode);
-    size_t k = speciesIndex(name);
+    size_t k = speciesIndex(name, true);
     // Get linear and polynomial model parameters from PolynomialDependency vector
     for (auto& item : m_PolynomialDependency) {
         if (item.k == k) {

--- a/src/thermo/DebyeHuckel.cpp
+++ b/src/thermo/DebyeHuckel.cpp
@@ -313,14 +313,8 @@ void DebyeHuckel::setDefaultIonicRadius(double value)
 
 void DebyeHuckel::setBeta(const string& sp1, const string& sp2, double value)
 {
-    size_t k1 = speciesIndex(sp1);
-    if (k1 == npos) {
-        throw CanteraError("DebyeHuckel::setBeta", "Species '{}' not found", sp1);
-    }
-    size_t k2 = speciesIndex(sp2);
-    if (k2 == npos) {
-        throw CanteraError("DebyeHuckel::setBeta", "Species '{}' not found", sp2);
-    }
+    size_t k1 = speciesIndex(sp1, true);
+    size_t k2 = speciesIndex(sp2, true);
     m_Beta_ij(k1, k2) = value;
     m_Beta_ij(k2, k1) = value;
 }
@@ -451,7 +445,7 @@ void DebyeHuckel::getParameters(AnyMap& phaseNode) const
 void DebyeHuckel::getSpeciesParameters(const string& name, AnyMap& speciesNode) const
 {
     MolalityVPSSTP::getSpeciesParameters(name, speciesNode);
-    size_t k = speciesIndex(name);
+    size_t k = speciesIndex(name, true);
     checkSpeciesIndex(k);
     AnyMap dhNode;
     if (m_Aionic[k] != m_Aionic_default) {

--- a/src/thermo/DebyeHuckel.cpp
+++ b/src/thermo/DebyeHuckel.cpp
@@ -446,7 +446,6 @@ void DebyeHuckel::getSpeciesParameters(const string& name, AnyMap& speciesNode) 
 {
     MolalityVPSSTP::getSpeciesParameters(name, speciesNode);
     size_t k = speciesIndex(name, true);
-    checkSpeciesIndex(k);
     AnyMap dhNode;
     if (m_Aionic[k] != m_Aionic_default) {
         dhNode["ionic-radius"].setQuantity(m_Aionic[k], "m");

--- a/src/thermo/HMWSoln.cpp
+++ b/src/thermo/HMWSoln.cpp
@@ -317,13 +317,8 @@ void HMWSoln::setBinarySalt(const string& sp1, const string& sp2,
     size_t nParams, double* beta0, double* beta1, double* beta2,
     double* Cphi, double alpha1, double alpha2)
 {
-    size_t k1 = speciesIndex(sp1);
-    size_t k2 = speciesIndex(sp2);
-    if (k1 == npos) {
-        throw CanteraError("HMWSoln::setBinarySalt", "Species '{}' not found", sp1);
-    } else if (k2 == npos) {
-        throw CanteraError("HMWSoln::setBinarySalt", "Species '{}' not found", sp2);
-    }
+    size_t k1 = speciesIndex(sp1, true);
+    size_t k2 = speciesIndex(sp2, true);
     if (charge(k1) < 0 && charge(k2) > 0) {
         std::swap(k1, k2);
     } else if (charge(k1) * charge(k2) >= 0) {
@@ -351,13 +346,8 @@ void HMWSoln::setBinarySalt(const string& sp1, const string& sp2,
 void HMWSoln::setTheta(const string& sp1, const string& sp2,
         size_t nParams, double* theta)
 {
-    size_t k1 = speciesIndex(sp1);
-    size_t k2 = speciesIndex(sp2);
-    if (k1 == npos) {
-        throw CanteraError("HMWSoln::setTheta", "Species '{}' not found", sp1);
-    } else if (k2 == npos) {
-        throw CanteraError("HMWSoln::setTheta", "Species '{}' not found", sp2);
-    }
+    size_t k1 = speciesIndex(sp1, true);
+    size_t k2 = speciesIndex(sp2, true);
     if (charge(k1) * charge(k2) <= 0) {
         throw CanteraError("HMWSoln::setTheta", "Species '{}' and '{}' "
             "should both have the same (non-zero) charge ({}, {})", sp1, sp2,
@@ -374,16 +364,9 @@ void HMWSoln::setTheta(const string& sp1, const string& sp2,
 void HMWSoln::setPsi(const string& sp1, const string& sp2,
         const string& sp3, size_t nParams, double* psi)
 {
-    size_t k1 = speciesIndex(sp1);
-    size_t k2 = speciesIndex(sp2);
-    size_t k3 = speciesIndex(sp3);
-    if (k1 == npos) {
-        throw CanteraError("HMWSoln::setPsi", "Species '{}' not found", sp1);
-    } else if (k2 == npos) {
-        throw CanteraError("HMWSoln::setPsi", "Species '{}' not found", sp2);
-    } else if (k3 == npos) {
-        throw CanteraError("HMWSoln::setPsi", "Species '{}' not found", sp3);
-    }
+    size_t k1 = speciesIndex(sp1, true);
+    size_t k2 = speciesIndex(sp2, true);
+    size_t k3 = speciesIndex(sp3, true);
 
     if (!charge(k1) || !charge(k2) || !charge(k3) ||
         std::abs(sign(charge(k1) + sign(charge(k2)) + sign(charge(k3)))) != 1) {
@@ -410,13 +393,8 @@ void HMWSoln::setPsi(const string& sp1, const string& sp2,
 void HMWSoln::setLambda(const string& sp1, const string& sp2,
         size_t nParams, double* lambda)
 {
-    size_t k1 = speciesIndex(sp1);
-    size_t k2 = speciesIndex(sp2);
-    if (k1 == npos) {
-        throw CanteraError("HMWSoln::setLambda", "Species '{}' not found", sp1);
-    } else if (k2 == npos) {
-        throw CanteraError("HMWSoln::setLambda", "Species '{}' not found", sp2);
-    }
+    size_t k1 = speciesIndex(sp1, true);
+    size_t k2 = speciesIndex(sp2, true);
 
     if (charge(k1) != 0 && charge(k2) != 0) {
         throw CanteraError("HMWSoln::setLambda", "Expected at least one neutral"
@@ -436,10 +414,7 @@ void HMWSoln::setLambda(const string& sp1, const string& sp2,
 
 void HMWSoln::setMunnn(const string& sp, size_t nParams, double* munnn)
 {
-    size_t k = speciesIndex(sp);
-    if (k == npos) {
-        throw CanteraError("HMWSoln::setMunnn", "Species '{}' not found", sp);
-    }
+    size_t k = speciesIndex(sp, true);
 
     if (charge(k) != 0) {
         throw CanteraError("HMWSoln::setMunnn", "Expected a neutral species,"
@@ -455,16 +430,9 @@ void HMWSoln::setMunnn(const string& sp, size_t nParams, double* munnn)
 void HMWSoln::setZeta(const string& sp1, const string& sp2,
         const string& sp3, size_t nParams, double* psi)
 {
-    size_t k1 = speciesIndex(sp1);
-    size_t k2 = speciesIndex(sp2);
-    size_t k3 = speciesIndex(sp3);
-    if (k1 == npos) {
-        throw CanteraError("HMWSoln::setZeta", "Species '{}' not found", sp1);
-    } else if (k2 == npos) {
-        throw CanteraError("HMWSoln::setZeta", "Species '{}' not found", sp2);
-    } else if (k3 == npos) {
-        throw CanteraError("HMWSoln::setZeta", "Species '{}' not found", sp3);
-    }
+    size_t k1 = speciesIndex(sp1, true);
+    size_t k2 = speciesIndex(sp2, true);
+    size_t k3 = speciesIndex(sp3, true);
 
     if (charge(k1)*charge(k2)*charge(k3) != 0 ||
         sign(charge(k1)) + sign(charge(k2)) + sign(charge(k3)) != 0) {
@@ -573,9 +541,9 @@ void HMWSoln::initThermo()
             for (auto& item : actData["interactions"].asVector<AnyMap>()) {
                 auto& species = item["species"].asVector<string>(1, 3);
                 size_t nsp = species.size();
-                double q0 = charge(speciesIndex(species[0]));
-                double q1 = (nsp > 1) ? charge(speciesIndex(species[1])) : 0;
-                double q2 = (nsp == 3) ? charge(speciesIndex(species[2])) : 0;
+                double q0 = charge(speciesIndex(species[0], true));
+                double q1 = (nsp > 1) ? charge(speciesIndex(species[1], true)) : 0;
+                double q2 = (nsp == 3) ? charge(speciesIndex(species[2], true)) : 0;
                 if (nsp == 2 && q0 * q1 < 0) {
                     // Two species with opposite charges - binary salt
                     vector<double> beta0 = getSizedVector(item, "beta0", nCoeffs);
@@ -658,8 +626,8 @@ void HMWSoln::initThermo()
                 kMaxC = k;
             }
         }
-        size_t kHp = speciesIndex("H+");
-        size_t kOHm = speciesIndex("OH-");
+        size_t kHp = speciesIndex("H+", false);
+        size_t kOHm = speciesIndex("OH-", false);
 
         if (fabs(sum) > 1.0E-30) {
             if (kHp != npos) {

--- a/src/thermo/IdealSolidSolnPhase.cpp
+++ b/src/thermo/IdealSolidSolnPhase.cpp
@@ -347,7 +347,7 @@ void IdealSolidSolnPhase::getSpeciesParameters(const string &name,
                                                AnyMap& speciesNode) const
 {
     ThermoPhase::getSpeciesParameters(name, speciesNode);
-    size_t k = speciesIndex(name);
+    size_t k = speciesIndex(name, true);
     const auto S = species(k);
     auto& eosNode = speciesNode["equation-of-state"].getMapWhere(
         "model", "constant-volume", true);

--- a/src/thermo/LatticePhase.cpp
+++ b/src/thermo/LatticePhase.cpp
@@ -298,7 +298,7 @@ void LatticePhase::getParameters(AnyMap& phaseNode) const
 void LatticePhase::getSpeciesParameters(const string& name, AnyMap& speciesNode) const
 {
     ThermoPhase::getSpeciesParameters(name, speciesNode);
-    size_t k = speciesIndex(name);
+    size_t k = speciesIndex(name, true);
     // Output volume information in a form consistent with the input
     const auto S = species(k);
     if (S->input.hasKey("equation-of-state")) {

--- a/src/thermo/LatticeSolidPhase.cpp
+++ b/src/thermo/LatticeSolidPhase.cpp
@@ -340,7 +340,7 @@ void LatticeSolidPhase::getSpeciesParameters(const string& name,
     // Use child lattice phases to determine species parameters so that these
     // are set consistently
     for (const auto& phase : m_lattice) {
-        if (phase->speciesIndex(name) != npos) {
+        if (phase->speciesIndex(name, false) != npos) {
             phase->getSpeciesParameters(name, speciesNode);
             break;
         }

--- a/src/thermo/MargulesVPSSTP.cpp
+++ b/src/thermo/MargulesVPSSTP.cpp
@@ -204,8 +204,8 @@ void MargulesVPSSTP::addBinaryInteraction(const string& speciesA,
     const string& speciesB, double h0, double h1, double s0, double s1,
     double vh0, double vh1, double vs0, double vs1)
 {
-    size_t kA = speciesIndex(speciesA);
-    size_t kB = speciesIndex(speciesB);
+    size_t kA = speciesIndex(speciesA, false);
+    size_t kB = speciesIndex(speciesB, false);
     // The interaction is silently ignored if either species is not defined in
     // the current phase.
     if (kA == npos || kB == npos) {

--- a/src/thermo/MolalityVPSSTP.cpp
+++ b/src/thermo/MolalityVPSSTP.cpp
@@ -383,7 +383,7 @@ string MolalityVPSSTP::report(bool show_thermo, double threshold) const
         getMolalityActivityCoefficients(&acMolal[0]);
         getActivities(&actMolal[0]);
 
-        size_t iHp = speciesIndex("H+");
+        size_t iHp = speciesIndex("H+", false);
         if (iHp != npos) {
             double pH = -log(actMolal[iHp]) / log(10.0);
             fmt_append(b,

--- a/src/thermo/PDSS_HKFT.cpp
+++ b/src/thermo/PDSS_HKFT.cpp
@@ -560,10 +560,7 @@ double PDSS_HKFT::gstar(const double temp, const double pres, const int ifunc) c
 
 double PDSS_HKFT::LookupGe(const string& elemName)
 {
-    size_t iE = m_tp->elementIndex(elemName);
-    if (iE == npos) {
-        throw CanteraError("PDSS_HKFT::LookupGe", "element " + elemName + " not found");
-    }
+    size_t iE = m_tp->elementIndex(elemName, true);
     double geValue = m_tp->entropyElement298(iE);
     if (geValue == ENTROPY298_UNKNOWN) {
         throw CanteraError("PDSS_HKFT::LookupGe",

--- a/src/thermo/PengRobinson.cpp
+++ b/src/thermo/PengRobinson.cpp
@@ -28,11 +28,7 @@ PengRobinson::PengRobinson(const string& infile, const string& id_)
 
 void PengRobinson::setSpeciesCoeffs(const string& species, double a, double b, double w)
 {
-    size_t k = speciesIndex(species);
-    if (k == npos) {
-        throw CanteraError("PengRobinson::setSpeciesCoeffs",
-            "Unknown species '{}'.", species);
-    }
+    size_t k = speciesIndex(species, true);
 
     // Calculate value of kappa (independent of temperature)
     // w is an acentric factor of species
@@ -74,16 +70,8 @@ void PengRobinson::setSpeciesCoeffs(const string& species, double a, double b, d
 void PengRobinson::setBinaryCoeffs(const string& species_i,
         const string& species_j, double a0)
 {
-    size_t ki = speciesIndex(species_i);
-    if (ki == npos) {
-        throw CanteraError("PengRobinson::setBinaryCoeffs",
-            "Unknown species '{}'.", species_i);
-    }
-    size_t kj = speciesIndex(species_j);
-    if (kj == npos) {
-        throw CanteraError("PengRobinson::setBinaryCoeffs",
-            "Unknown species '{}'.", species_j);
-    }
+    size_t ki = speciesIndex(species_i, true);
+    size_t kj = speciesIndex(species_j, true);
 
     m_a_coeffs(ki, kj) = m_a_coeffs(kj, ki) = a0;
     m_binaryParameters[species_i][species_j] = a0;
@@ -343,7 +331,7 @@ void PengRobinson::initThermo()
 
     for (auto& [name, species] : m_species) {
         auto& data = species->input;
-        size_t k = speciesIndex(name);
+        size_t k = speciesIndex(name, true);
         if (m_a_coeffs(k, k) != 0.0) {
             continue;
         }
@@ -423,8 +411,7 @@ void PengRobinson::initThermo()
 void PengRobinson::getSpeciesParameters(const string& name, AnyMap& speciesNode) const
 {
     MixtureFugacityTP::getSpeciesParameters(name, speciesNode);
-    size_t k = speciesIndex(name);
-    checkSpeciesIndex(k);
+    size_t k = speciesIndex(name, true);
 
     // Pure species parameters
     if (m_coeffSource[k] == CoeffSource::EoS) {

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -72,7 +72,7 @@ size_t Phase::elementIndex(const string& elementName, bool raise) const
     if (!raise) {
         return npos;
     }
-    throw CanteraError("Phase::elementIndex", "Element {} not found.", elementName);
+    throw CanteraError("Phase::elementIndex", "Element '{}' not found", elementName);
 }
 
 const vector<string>& Phase::elementNames() const
@@ -156,7 +156,7 @@ size_t Phase::speciesIndex(const string& name, bool raise) const
         loc = findSpeciesLower(name);
     }
     if (loc==npos && raise) {
-        throw CanteraError("Phase::speciesIndex", "Species {} not found.", name);
+        throw CanteraError("Phase::speciesIndex", "Species '{}' not found", name);
     }
 
     return loc;

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -114,8 +114,9 @@ int Phase::changeElementType(int m, int elem_type)
 
 double Phase::nAtoms(size_t k, size_t m) const
 {
+    checkElementIndex(m);
     checkSpeciesIndex(k);
-    return m_speciesComp[m_mm * k + checkElementIndex(m)];
+    return m_speciesComp[m_mm * k + m];
 }
 
 size_t Phase::findSpeciesLower(const string& name) const
@@ -150,8 +151,7 @@ size_t Phase::speciesIndex(const string& name, bool raise) const
     size_t loc = npos;
     auto it = m_speciesIndices.find(name);
     if (it != m_speciesIndices.end()) {
-        checkSpeciesIndex(it->second);
-        return it->second;
+        return checkSpeciesIndex(it->second);
     } else if (!m_caseSensitiveSpecies) {
         loc = findSpeciesLower(name);
     }
@@ -173,11 +173,12 @@ const vector<string>& Phase::speciesNames() const
     return m_speciesNames;
 }
 
-void Phase::checkSpeciesIndex(size_t k) const
+size_t Phase::checkSpeciesIndex(size_t k) const
 {
-    if (k >= m_kk) {
-        throw IndexError("Phase::checkSpeciesIndex", "species", k, m_kk);
+    if (k < m_kk) {
+        return k;
     }
+    throw IndexError("Phase::checkSpeciesIndex", "species", k, m_kk);
 }
 
 void Phase::checkSpeciesArraySize(size_t kk) const

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -183,6 +183,8 @@ size_t Phase::checkSpeciesIndex(size_t k) const
 
 void Phase::checkSpeciesArraySize(size_t kk) const
 {
+    warn_deprecated("Phase::checkSpeciesArraySize",
+        "To be removed after Cantera 3.2. Only used by legacy CLib.");
     if (m_kk > kk) {
         throw ArraySizeError("Phase::checkSpeciesArraySize", kk, m_kk);
     }

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -56,10 +56,13 @@ string Phase::elementName(size_t m) const
 
 size_t Phase::elementIndex(const string& name) const
 {
-    warn_deprecated("Phase::elementIndex", "'raise' argument not specified; "
-        "Default behavior will change from returning npos to throwing an exception "
-        "after Cantera 3.2.");
-    return elementIndex(name, false);
+    size_t ix = elementIndex(name, false);
+    if (ix == npos) {
+        warn_deprecated("Phase::elementIndex", "'raise' argument not specified; "
+            "Default behavior will change from returning npos to throwing an exception "
+            "after Cantera 3.2.");
+    }
+    return ix;
 }
 
 size_t Phase::elementIndex(const string& elementName, bool raise) const
@@ -140,10 +143,13 @@ size_t Phase::findSpeciesLower(const string& name) const
 
 size_t Phase::speciesIndex(const string& name) const
 {
-    warn_deprecated("Phase::speciesIndex", "'raise' argument not specified; "
-        "Default behavior will change from returning npos to throwing an exception "
-        "after Cantera 3.2.");
-    return speciesIndex(name, false);
+    size_t ix = speciesIndex(name, false);
+    if (ix == npos) {
+        warn_deprecated("Phase::speciesIndex", "'raise' argument not specified; "
+            "Default behavior will change from returning npos to throwing an exception "
+            "after Cantera 3.2.");
+    }
+    return ix;
 }
 
 size_t Phase::speciesIndex(const string& name, bool raise) const

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -151,7 +151,7 @@ size_t Phase::speciesIndex(const string& name, bool raise) const
     size_t loc = npos;
     auto it = m_speciesIndices.find(name);
     if (it != m_speciesIndices.end()) {
-        return checkSpeciesIndex(it->second);
+        return it->second;
     } else if (!m_caseSensitiveSpecies) {
         loc = findSpeciesLower(name);
     }

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -32,11 +32,12 @@ size_t Phase::nElements() const
     return m_mm;
 }
 
-void Phase::checkElementIndex(size_t m) const
+size_t Phase::checkElementIndex(size_t m) const
 {
-    if (m >= m_mm) {
-        throw IndexError("Phase::checkElementIndex", "elements", m, m_mm);
+    if (m < m_mm) {
+        return m;
     }
+    throw IndexError("Phase::checkElementIndex", "elements", m, m_mm);
 }
 
 void Phase::checkElementArraySize(size_t mm) const
@@ -50,26 +51,25 @@ void Phase::checkElementArraySize(size_t mm) const
 
 string Phase::elementName(size_t m) const
 {
-    checkElementIndex(m);
-    return m_elementNames[m];
+    return m_elementNames[checkElementIndex(m)];
 }
 
 size_t Phase::elementIndex(const string& name) const
 {
-    warn_deprecated("Phase::elementIndex", "'force' argument not specified; "
+    warn_deprecated("Phase::elementIndex", "'raise' argument not specified; "
         "Default behavior will change from returning npos to throwing an exception "
         "after Cantera 3.2.");
     return elementIndex(name, false);
 }
 
-size_t Phase::elementIndex(const string& elementName, bool force) const
+size_t Phase::elementIndex(const string& elementName, bool raise) const
 {
     for (size_t i = 0; i < m_mm; i++) {
         if (m_elementNames[i] == elementName) {
             return i;
         }
     }
-    if (!force) {
+    if (!raise) {
         return npos;
     }
     throw CanteraError("Phase::elementIndex", "Element {} not found.", elementName);
@@ -87,8 +87,7 @@ double Phase::atomicWeight(size_t m) const
 
 double Phase::entropyElement298(size_t m) const
 {
-    checkElementIndex(m);
-    return m_entropy298[m];
+    return m_entropy298[checkElementIndex(m)];
 }
 
 const vector<double>& Phase::atomicWeights() const
@@ -115,9 +114,8 @@ int Phase::changeElementType(int m, int elem_type)
 
 double Phase::nAtoms(size_t k, size_t m) const
 {
-    checkElementIndex(m);
     checkSpeciesIndex(k);
-    return m_speciesComp[m_mm * k + m];
+    return m_speciesComp[m_mm * k + checkElementIndex(m)];
 }
 
 size_t Phase::findSpeciesLower(const string& name) const
@@ -587,7 +585,6 @@ void Phase::setMolesNoTruncate(const double* const N)
 
 double Phase::elementalMassFraction(const size_t m) const
 {
-    checkElementIndex(m);
     double Z_m = 0.0;
     for (size_t k = 0; k != m_kk; ++k) {
         Z_m += nAtoms(k, m) * atomicWeight(m) / molecularWeight(k)
@@ -598,7 +595,6 @@ double Phase::elementalMassFraction(const size_t m) const
 
 double Phase::elementalMoleFraction(const size_t m) const
 {
-    checkElementIndex(m);
     double denom = 0;
     for (size_t k = 0; k < m_kk; k++) {
         double atoms = 0;

--- a/src/thermo/PlasmaPhase.cpp
+++ b/src/thermo/PlasmaPhase.cpp
@@ -419,7 +419,7 @@ void PlasmaPhase::addCollision(shared_ptr<Reaction> collision)
     for (const auto& [name, _] : collision->reactants) {
         // Reactants are expected to be electrons and the target species
         if (name != electronSpeciesName()) {
-            m_targetSpeciesIndices.emplace_back(speciesIndex(name));
+            m_targetSpeciesIndices.emplace_back(speciesIndex(name, true));
             target = name;
             break;
         }

--- a/src/thermo/RedlichKisterVPSSTP.cpp
+++ b/src/thermo/RedlichKisterVPSSTP.cpp
@@ -424,15 +424,8 @@ void RedlichKisterVPSSTP::addBinaryInteraction(
     const double* excess_enthalpy, size_t n_enthalpy,
     const double* excess_entropy, size_t n_entropy)
 {
-    size_t kA = speciesIndex(speciesA);
-    size_t kB = speciesIndex(speciesB);
-    if (kA == npos) {
-        throw CanteraError("RedlichKisterVPSSTP::addBinaryInteraction",
-            "Species '{}' not present in phase", speciesA);
-    } else if (kB == npos) {
-        throw CanteraError("RedlichKisterVPSSTP::addBinaryInteraction",
-            "Species '{}' not present in phase", speciesB);
-    }
+    size_t kA = speciesIndex(speciesA, true);
+    size_t kB = speciesIndex(speciesB, true);
     if (charge(kA) != 0) {
         throw CanteraError("RedlichKisterVPSSTP::addBinaryInteraction",
             "Species '{}' should be neutral", speciesA);

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -29,11 +29,7 @@ RedlichKwongMFTP::RedlichKwongMFTP(const string& infile, const string& id_)
 void RedlichKwongMFTP::setSpeciesCoeffs(const string& species,
                                         double a0, double a1, double b)
 {
-    size_t k = speciesIndex(species);
-    if (k == npos) {
-        throw CanteraError("RedlichKwongMFTP::setSpeciesCoeffs",
-            "Unknown species '{}'.", species);
-    }
+    size_t k = speciesIndex(species, true);
 
     if (a1 != 0.0) {
         m_formTempParam = 1; // expression is temperature-dependent
@@ -71,16 +67,8 @@ void RedlichKwongMFTP::setSpeciesCoeffs(const string& species,
 void RedlichKwongMFTP::setBinaryCoeffs(const string& species_i, const string& species_j,
                                        double a0, double a1)
 {
-    size_t ki = speciesIndex(species_i);
-    if (ki == npos) {
-        throw CanteraError("RedlichKwongMFTP::setBinaryCoeffs",
-            "Unknown species '{}'.", species_i);
-    }
-    size_t kj = speciesIndex(species_j);
-    if (kj == npos) {
-        throw CanteraError("RedlichKwongMFTP::setBinaryCoeffs",
-            "Unknown species '{}'.", species_j);
-    }
+    size_t ki = speciesIndex(species_i, true);
+    size_t kj = speciesIndex(species_j, true);
 
     if (a1 != 0.0) {
         m_formTempParam = 1; // expression is temperature-dependent
@@ -377,7 +365,7 @@ void RedlichKwongMFTP::initThermo()
 
     for (auto& [name, species] : m_species) {
         auto& data = species->input;
-        size_t k = speciesIndex(name);
+        size_t k = speciesIndex(name, true);
         if (!isnan(a_coeff_vec(0, k + m_kk * k))) {
             continue;
         }
@@ -472,8 +460,7 @@ void RedlichKwongMFTP::getSpeciesParameters(const string& name,
                                             AnyMap& speciesNode) const
 {
     MixtureFugacityTP::getSpeciesParameters(name, speciesNode);
-    size_t k = speciesIndex(name);
-    checkSpeciesIndex(k);
+    size_t k = speciesIndex(name, true);
     if (m_coeffSource[k] == CoeffSource::EoS) {
         auto& eosNode = speciesNode["equation-of-state"].getMapWhere(
             "model", "Redlich-Kwong", true);

--- a/src/thermo/StoichSubstance.cpp
+++ b/src/thermo/StoichSubstance.cpp
@@ -154,7 +154,7 @@ void StoichSubstance::getSpeciesParameters(const string& name,
                                            AnyMap& speciesNode) const
 {
     SingleSpeciesTP::getSpeciesParameters(name, speciesNode);
-    size_t k = speciesIndex(name);
+    size_t k = speciesIndex(name, true);
     const auto S = species(k);
     auto& eosNode = speciesNode["equation-of-state"].getMapWhere(
         "model", "constant-volume", true);

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -680,9 +680,9 @@ void ThermoPhase::setState_SPorSV(double Starget, double p,
 double ThermoPhase::o2Required(const double* y) const
 {
     // indices of fuel elements
-    size_t iC = elementIndex("C");
-    size_t iS = elementIndex("S");
-    size_t iH = elementIndex("H");
+    size_t iC = elementIndex("C", false);
+    size_t iS = elementIndex("S", false);
+    size_t iH = elementIndex("H", false);
 
     double o2req = 0.0;
     double sum = 0.0;
@@ -708,7 +708,7 @@ double ThermoPhase::o2Required(const double* y) const
 
 double ThermoPhase::o2Present(const double* y) const
 {
-    size_t iO = elementIndex("O");
+    size_t iO = elementIndex("O", true);
     double o2pres = 0.0;
     double sum = 0.0;
     for (size_t k = 0; k != m_kk; ++k) {
@@ -1009,7 +1009,7 @@ double ThermoPhase::mixtureFraction(const double* fuelComp, const double* oxComp
             return Z_m;
         };
 
-        size_t m = elementIndex(element);
+        size_t m = elementIndex(element, true);
         double Z_m_fuel = elementalFraction(m, fuelComp)/sum_yf;
         double Z_m_ox   = elementalFraction(m, oxComp)/sum_yo;
         double Z_m_mix  = elementalFraction(m, massFractions());

--- a/src/thermo/VPStandardStateTP.cpp
+++ b/src/thermo/VPStandardStateTP.cpp
@@ -156,7 +156,7 @@ void VPStandardStateTP::getSpeciesParameters(const string& name,
                                              AnyMap& speciesNode) const
 {
     AnyMap eos;
-    providePDSS(speciesIndex(name))->getParameters(eos);
+    providePDSS(speciesIndex(name, true))->getParameters(eos);
     speciesNode["equation-of-state"].getMapWhere(
         "model", eos.getString("model", ""), true) = std::move(eos);
 }

--- a/src/thermo/WaterSSTP.cpp
+++ b/src/thermo/WaterSSTP.cpp
@@ -34,17 +34,9 @@ void WaterSSTP::initThermo()
     // codes exhibiting mass loss issues. We need to grab the elemental atomic
     // weights used in the Element class and calculate a consistent H2O
     // molecular weight based on that.
-    size_t nH = elementIndex("H");
-    if (nH == npos) {
-        throw CanteraError("WaterSSTP::initThermo",
-                           "H not an element");
-    }
+    size_t nH = elementIndex("H", true);
     double mw_H = atomicWeight(nH);
-    size_t nO = elementIndex("O");
-    if (nO == npos) {
-        throw CanteraError("WaterSSTP::initThermo",
-                           "O not an element");
-    }
+    size_t nO = elementIndex("O", true);
     double mw_O = atomicWeight(nO);
     m_mw = 2.0 * mw_H + mw_O;
     setMolecularWeight(0,m_mw);

--- a/src/transport/IonGasTransport.cpp
+++ b/src/transport/IonGasTransport.cpp
@@ -201,10 +201,10 @@ void IonGasTransport::fitDiffCoeffs(MMCollisionInt& integrals)
                 // Stockmayer-(n,6,4) model is not suitable for collision
                 // between O2/O2- due to resonant charge transfer.
                 // Therefore, the experimental collision data is used instead.
-                if ((k == m_thermo->speciesIndex("O2-") ||
-                     j == m_thermo->speciesIndex("O2-")) &&
-                    (k == m_thermo->speciesIndex("O2") ||
-                     j == m_thermo->speciesIndex("O2"))) {
+                if ((k == m_thermo->speciesIndex("O2-", false) ||
+                     j == m_thermo->speciesIndex("O2-", false)) &&
+                    (k == m_thermo->speciesIndex("O2", false) ||
+                     j == m_thermo->speciesIndex("O2", false))) {
                        om11 = poly5(t, m_om11_O2.data()) / 1e20;
                 }
                 double diffcoeff = 3.0/16.0 * sqrt(2.0 * Pi/m_reducedMass(k,j))

--- a/src/transport/Transport.cpp
+++ b/src/transport/Transport.cpp
@@ -28,6 +28,8 @@ size_t Transport::checkSpeciesIndex(size_t k) const
 
 void Transport::checkSpeciesArraySize(size_t kk) const
 {
+    warn_deprecated("Transport::checkSpeciesArraySize",
+        "To be removed after Cantera 3.2. Only used by legacy CLib.");
     if (m_nsp > kk) {
         throw ArraySizeError("Transport::checkSpeciesArraySize", kk, m_nsp);
     }

--- a/src/transport/Transport.cpp
+++ b/src/transport/Transport.cpp
@@ -18,11 +18,12 @@ shared_ptr<Transport> Transport::clone(shared_ptr<ThermoPhase> thermo) const
     return newTransport(thermo, transportModel());
 }
 
-void Transport::checkSpeciesIndex(size_t k) const
+size_t Transport::checkSpeciesIndex(size_t k) const
 {
-    if (k >= m_nsp) {
-        throw IndexError("Transport::checkSpeciesIndex", "species", k, m_nsp);
+    if (k < m_nsp) {
+        return k;
     }
+    throw IndexError("Transport::checkSpeciesIndex", "species", k, m_nsp);
 }
 
 void Transport::checkSpeciesArraySize(size_t kk) const

--- a/src/zeroD/ConstPressureMoleReactor.cpp
+++ b/src/zeroD/ConstPressureMoleReactor.cpp
@@ -109,13 +109,14 @@ void ConstPressureMoleReactor::eval(double time, double* LHS, double* RHS)
 
 size_t ConstPressureMoleReactor::componentIndex(const string& nm) const
 {
-    size_t k = speciesIndex(nm);
-    if (k != npos) {
-        return k + m_sidx;
-    } else if (nm == "enthalpy") {
+    if (nm == "enthalpy") {
         return 0;
-    } else {
-        return npos;
+    }
+    try {
+        return speciesIndex(nm) + m_sidx;
+    } catch (const CanteraError&) {
+        throw CanteraError("ConstPressureMoleReactor::componentIndex",
+            "Unknown component '{}'", nm);
     }
 }
 

--- a/src/zeroD/ConstPressureMoleReactor.cpp
+++ b/src/zeroD/ConstPressureMoleReactor.cpp
@@ -116,7 +116,7 @@ size_t ConstPressureMoleReactor::componentIndex(const string& nm) const
         return speciesIndex(nm) + m_sidx;
     } catch (const CanteraError&) {
         throw CanteraError("ConstPressureMoleReactor::componentIndex",
-            "Unknown component '{}'", nm);
+            "Component '{}' not found", nm);
     }
 }
 

--- a/src/zeroD/ConstPressureReactor.cpp
+++ b/src/zeroD/ConstPressureReactor.cpp
@@ -130,15 +130,17 @@ vector<size_t> ConstPressureReactor::steadyConstraints() const {
 
 size_t ConstPressureReactor::componentIndex(const string& nm) const
 {
-    size_t k = speciesIndex(nm);
-    if (k != npos) {
-        return k + 2;
-    } else if (nm == "mass") {
+    if (nm == "mass") {
         return 0;
-    } else if (nm == "enthalpy") {
+    }
+    if (nm == "enthalpy") {
         return 1;
-    } else {
-        return npos;
+    }
+    try {
+        return speciesIndex(nm) + 2;
+    } catch (const CanteraError&) {
+        throw CanteraError("ConstPressureReactor::componentIndex",
+            "Unknown component '{}'", nm);
     }
 }
 

--- a/src/zeroD/ConstPressureReactor.cpp
+++ b/src/zeroD/ConstPressureReactor.cpp
@@ -140,7 +140,7 @@ size_t ConstPressureReactor::componentIndex(const string& nm) const
         return speciesIndex(nm) + 2;
     } catch (const CanteraError&) {
         throw CanteraError("ConstPressureReactor::componentIndex",
-            "Unknown component '{}'", nm);
+            "Component '{}' not found", nm);
     }
 }
 

--- a/src/zeroD/FlowDevice.cpp
+++ b/src/zeroD/FlowDevice.cpp
@@ -35,12 +35,12 @@ FlowDevice::FlowDevice(shared_ptr<ReactorBase> r0, shared_ptr<ReactorBase> r1,
     size_t ki, ko;
     for (ki = 0; ki < m_nspin; ki++) {
         nm = mixin.speciesName(ki);
-        ko = mixout.speciesIndex(nm);
+        ko = mixout.speciesIndex(nm, false);
         m_in2out.push_back(ko);
     }
     for (ko = 0; ko < m_nspout; ko++) {
         nm = mixout.speciesName(ko);
-        ki = mixin.speciesIndex(nm);
+        ki = mixin.speciesIndex(nm, false);
         m_out2in.push_back(ki);
     }
 }
@@ -68,12 +68,12 @@ bool FlowDevice::install(ReactorBase& in, ReactorBase& out)
     size_t ki, ko;
     for (ki = 0; ki < m_nspin; ki++) {
         nm = mixin.speciesName(ki);
-        ko = mixout.speciesIndex(nm);
+        ko = mixout.speciesIndex(nm, false);
         m_in2out.push_back(ko);
     }
     for (ko = 0; ko < m_nspout; ko++) {
         nm = mixout.speciesName(ko);
-        ki = mixin.speciesIndex(nm);
+        ki = mixin.speciesIndex(nm, false);
         m_out2in.push_back(ki);
     }
     return true;

--- a/src/zeroD/FlowReactor.cpp
+++ b/src/zeroD/FlowReactor.cpp
@@ -341,14 +341,11 @@ size_t FlowReactor::componentIndex(const string& nm) const
 {
     if (nm == "density") {
         return 0;
-    }
-    if (nm == "speed") {
+    } else if (nm == "speed") {
         return 1;
-    }
-    if (nm == "pressure") {
+    } else if (nm == "pressure") {
         return 2;
-    }
-    if (nm == "temperature") {
+    } else if (nm == "temperature") {
         return 3;
     }
     try {

--- a/src/zeroD/FlowReactor.cpp
+++ b/src/zeroD/FlowReactor.cpp
@@ -355,7 +355,7 @@ size_t FlowReactor::componentIndex(const string& nm) const
         return speciesIndex(nm) + m_offset_Y;
     } catch (const CanteraError&) {
         throw CanteraError("FlowReactor::componentIndex",
-            "Unknown component '{}'", nm);
+            "Component '{}' not found", nm);
     }
 }
 

--- a/src/zeroD/FlowReactor.cpp
+++ b/src/zeroD/FlowReactor.cpp
@@ -339,19 +339,23 @@ void FlowReactor::getConstraints(double* constraints) {
 
 size_t FlowReactor::componentIndex(const string& nm) const
 {
-    size_t k = speciesIndex(nm);
-    if (k != npos) {
-        return k + m_offset_Y;
-    } else if (nm == "density") {
+    if (nm == "density") {
         return 0;
-    } else if (nm == "speed") {
+    }
+    if (nm == "speed") {
         return 1;
-    } else if (nm == "pressure") {
+    }
+    if (nm == "pressure") {
         return 2;
-    } else if (nm == "temperature") {
+    }
+    if (nm == "temperature") {
         return 3;
-    } else {
-        return npos;
+    }
+    try {
+        return speciesIndex(nm) + m_offset_Y;
+    } catch (const CanteraError&) {
+        throw CanteraError("FlowReactor::componentIndex",
+            "Unknown component '{}'", nm);
     }
 }
 

--- a/src/zeroD/IdealGasConstPressureMoleReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureMoleReactor.cpp
@@ -242,7 +242,7 @@ size_t IdealGasConstPressureMoleReactor::componentIndex(const string& nm) const
         return speciesIndex(nm) + m_sidx;
     } catch (const CanteraError&) {
         throw CanteraError("IdealGasConstPressureReactor::componentIndex",
-            "Unknown component '{}'", nm);
+            "Component '{}' not found", nm);
     }
 }
 

--- a/src/zeroD/IdealGasConstPressureReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureReactor.cpp
@@ -141,15 +141,17 @@ vector<size_t> IdealGasConstPressureReactor::steadyConstraints() const
 
 size_t IdealGasConstPressureReactor::componentIndex(const string& nm) const
 {
-    size_t k = speciesIndex(nm);
-    if (k != npos) {
-        return k + 2;
-    } else if (nm == "mass") {
+    if (nm == "mass") {
         return 0;
-    } else if (nm == "temperature") {
+    }
+    if (nm == "temperature") {
         return 1;
-    } else {
-        return npos;
+    }
+    try {
+        return speciesIndex(nm) + 2;
+    } catch (const CanteraError&) {
+        throw CanteraError("IdealGasConstPressureReactor::componentIndex",
+            "Unknown component '{}'", nm);
     }
 }
 

--- a/src/zeroD/IdealGasConstPressureReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureReactor.cpp
@@ -151,7 +151,7 @@ size_t IdealGasConstPressureReactor::componentIndex(const string& nm) const
         return speciesIndex(nm) + 2;
     } catch (const CanteraError&) {
         throw CanteraError("IdealGasConstPressureReactor::componentIndex",
-            "Unknown component '{}'", nm);
+            "Component '{}' not found", nm);
     }
 }
 

--- a/src/zeroD/IdealGasMoleReactor.cpp
+++ b/src/zeroD/IdealGasMoleReactor.cpp
@@ -53,7 +53,7 @@ size_t IdealGasMoleReactor::componentIndex(const string& nm) const
         return speciesIndex(nm) + m_sidx;
     } catch (const CanteraError&) {
         throw CanteraError("IdealGasMoleReactor::componentIndex",
-            "Unknown component '{}'", nm);
+            "Component '{}' not found", nm);
     }
 }
 

--- a/src/zeroD/IdealGasMoleReactor.cpp
+++ b/src/zeroD/IdealGasMoleReactor.cpp
@@ -43,15 +43,17 @@ void IdealGasMoleReactor::getState(double* y)
 
 size_t IdealGasMoleReactor::componentIndex(const string& nm) const
 {
-    size_t k = speciesIndex(nm);
-    if (k != npos) {
-        return k + m_sidx;
-    } else if (nm == "temperature") {
+    if (nm == "temperature") {
         return 0;
-    } else if (nm == "volume") {
+    }
+    if (nm == "volume") {
         return 1;
-    } else {
-        return npos;
+    }
+    try {
+        return speciesIndex(nm) + m_sidx;
+    } catch (const CanteraError&) {
+        throw CanteraError("IdealGasMoleReactor::componentIndex",
+            "Unknown component '{}'", nm);
     }
 }
 

--- a/src/zeroD/IdealGasReactor.cpp
+++ b/src/zeroD/IdealGasReactor.cpp
@@ -160,7 +160,7 @@ size_t IdealGasReactor::componentIndex(const string& nm) const
         return speciesIndex(nm) + 3;
     } catch (const CanteraError&) {
         throw CanteraError("IdealGasReactor::componentIndex",
-            "Unknown component '{}'", nm);
+            "Component '{}' not found", nm);
     }
 }
 

--- a/src/zeroD/IdealGasReactor.cpp
+++ b/src/zeroD/IdealGasReactor.cpp
@@ -147,17 +147,20 @@ vector<size_t> IdealGasReactor::steadyConstraints() const
 
 size_t IdealGasReactor::componentIndex(const string& nm) const
 {
-    size_t k = speciesIndex(nm);
-    if (k != npos) {
-        return k + 3;
-    } else if (nm == "mass") {
+    if (nm == "mass") {
         return 0;
-    } else if (nm == "volume") {
+    }
+    if (nm == "volume") {
         return 1;
-    } else if (nm == "temperature") {
+    }
+    if (nm == "temperature") {
         return 2;
-    } else {
-        return npos;
+    }
+    try {
+        return speciesIndex(nm) + 3;
+    } catch (const CanteraError&) {
+        throw CanteraError("IdealGasReactor::componentIndex",
+            "Unknown component '{}'", nm);
     }
 }
 

--- a/src/zeroD/MoleReactor.cpp
+++ b/src/zeroD/MoleReactor.cpp
@@ -293,7 +293,7 @@ size_t MoleReactor::componentIndex(const string& nm) const
         return speciesIndex(nm) + m_sidx;
     } catch (const CanteraError&) {
         throw CanteraError("MoleReactor::componentIndex",
-            "Unknown component '{}'", nm);
+            "Component '{}' not found", nm);
     }
 }
 

--- a/src/zeroD/MoleReactor.cpp
+++ b/src/zeroD/MoleReactor.cpp
@@ -283,15 +283,17 @@ void MoleReactor::eval(double time, double* LHS, double* RHS)
 
 size_t MoleReactor::componentIndex(const string& nm) const
 {
-    size_t k = speciesIndex(nm);
-    if (k != npos) {
-        return k + m_sidx;
-    } else if (nm == "int_energy") {
+    if (nm == "int_energy") {
         return 0;
-    } else if (nm == "volume") {
+    }
+    if (nm == "volume") {
         return 1;
-    } else {
-        return npos;
+    }
+    try {
+        return speciesIndex(nm) + m_sidx;
+    } catch (const CanteraError&) {
+        throw CanteraError("MoleReactor::componentIndex",
+            "Unknown component '{}'", nm);
     }
 }
 

--- a/src/zeroD/MoleReactor.cpp
+++ b/src/zeroD/MoleReactor.cpp
@@ -104,8 +104,8 @@ void MoleReactor::addSurfaceJacobian(vector<Eigen::Triplet<double>> &triplets)
                 size_t col = it.col();
                 auto& rowPhase = kin->speciesPhase(row);
                 auto& colPhase = kin->speciesPhase(col);
-                size_t rpi = kin->phaseIndex(rowPhase.name());
-                size_t cpi = kin->phaseIndex(colPhase.name());
+                size_t rpi = kin->phaseIndex(rowPhase.name(), true);
+                size_t cpi = kin->phaseIndex(colPhase.name(), true);
                 // check if the reactor kinetics object contains both phases to avoid
                 // any solid phases which may be included then use phases to map surf
                 // kinetics indicies to reactor kinetic indices

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -464,7 +464,7 @@ void Reactor::addSensitivitySpeciesEnthalpy(size_t k)
 size_t Reactor::speciesIndex(const string& nm) const
 {
     // check for a gas species name
-    size_t k = m_thermo->speciesIndex(nm);
+    size_t k = m_thermo->speciesIndex(nm, false);
     if (k != npos) {
         return k;
     }
@@ -473,7 +473,7 @@ size_t Reactor::speciesIndex(const string& nm) const
     size_t offset = m_nsp;
     for (auto& S : m_surfaces) {
         ThermoPhase* th = S->thermo();
-        k = th->speciesIndex(nm);
+        k = th->speciesIndex(nm, false);
         if (k != npos) {
             return k + offset;
         } else {

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -480,22 +480,26 @@ size_t Reactor::speciesIndex(const string& nm) const
             offset += th->nSpecies();
         }
     }
-    return npos;
+    throw CanteraError("Reactor::speciesIndex",
+        "Unknown species '{}'", nm);
 }
 
 size_t Reactor::componentIndex(const string& nm) const
 {
-    size_t k = speciesIndex(nm);
-    if (k != npos) {
-        return k + 3;
-    } else if (nm == "mass") {
+    if (nm == "mass") {
         return 0;
-    } else if (nm == "volume") {
+    }
+    if (nm == "volume") {
         return 1;
-    } else if (nm == "int_energy") {
+    }
+    if (nm == "int_energy") {
         return 2;
-    } else {
-        return npos;
+    }
+    try {
+        return speciesIndex(nm) + 3;
+    } catch (const CanteraError&) {
+        throw CanteraError("Reactor::componentIndex",
+            "Unknown component '{}'", nm);
     }
 }
 
@@ -631,9 +635,6 @@ bool Reactor::getAdvanceLimits(double *limits) const
 void Reactor::setAdvanceLimit(const string& nm, const double limit)
 {
     size_t k = componentIndex(nm);
-    if (k == npos) {
-        throw CanteraError("Reactor::setAdvanceLimit", "No component named '{}'", nm);
-    }
 
     if (m_thermo == 0) {
         throw CanteraError("Reactor::setAdvanceLimit",

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -481,7 +481,7 @@ size_t Reactor::speciesIndex(const string& nm) const
         }
     }
     throw CanteraError("Reactor::speciesIndex",
-        "Unknown species '{}'", nm);
+        "Species '{}' not found", nm);
 }
 
 size_t Reactor::componentIndex(const string& nm) const
@@ -499,7 +499,7 @@ size_t Reactor::componentIndex(const string& nm) const
         return speciesIndex(nm) + 3;
     } catch (const CanteraError&) {
         throw CanteraError("Reactor::componentIndex",
-            "Unknown component '{}'", nm);
+            "Component '{}' not found", nm);
     }
 }
 

--- a/test/clib_legacy/test_clib.cpp
+++ b/test/clib_legacy/test_clib.cpp
@@ -178,6 +178,7 @@ TEST(ct, new_interface_auto)
 
 TEST(ct, thermo)
 {
+    suppress_deprecation_warnings();
     int ret;
     int sol = soln_newSolution("gri30.yaml", "gri30", "none");
     int thermo = soln_thermo(sol);
@@ -223,6 +224,7 @@ TEST(ct, thermo)
     thermo_getPartialMolarVolumes(thermo, ns, work.data());
     prod = std::inner_product(X.begin(), X.end(), work.begin(), 0.0);
     ASSERT_NEAR(prod, 1./thermo_molarDensity(thermo), 1e-6);
+    make_deprecation_warnings_fatal();
 }
 
 TEST(ct, kinetics)
@@ -259,6 +261,7 @@ TEST(ct, kinetics)
 
 TEST(ct, transport)
 {
+    suppress_deprecation_warnings();
     int sol0 = soln_newSolution("gri30.yaml", "gri30", "default");
     int thermo = soln_thermo(sol0);
     int tran = soln_transport(sol0);
@@ -276,6 +279,7 @@ TEST(ct, transport)
     for (size_t n = 0; n < nsp; n++) {
         ASSERT_NEAR(cpp_dkm[n], c_dkm[n], 1e-10);
     }
+    make_deprecation_warnings_fatal();
 }
 
 

--- a/test/python/test_mixture.py
+++ b/test/python/test_mixture.py
@@ -28,7 +28,7 @@ class TestMixture:
         assert len(E) == mix.n_elements
 
     def test_element_index(self, mix):
-        with pytest.raises(ValueError, match='No such element'):
+        with pytest.raises(ct.CanteraError, match="Element W not found."):
             mix.element_index('W')
 
         with pytest.raises(ValueError, match='No such element'):

--- a/test/python/test_mixture.py
+++ b/test/python/test_mixture.py
@@ -54,13 +54,13 @@ class TestMixture:
         with pytest.raises(IndexError, match='out of range'):
             mix.species_index(3, 'OH')
 
-        with pytest.raises(ValueError, match='No such species'):
+        with pytest.raises(ct.CanteraError, match="Species OH not found."):
             mix.species_index(1, 'OH')
 
-        with pytest.raises(ValueError, match='out of range'):
+        with pytest.raises(ct.CanteraError, match="outside valid range"):
             mix.species_index(0, -2)
 
-        with pytest.raises(ValueError, match='No such species'):
+        with pytest.raises(ct.CanteraError, match="Species CO2 not found."):
             mix.species_index(1, 'CO2')
 
     def test_n_atoms(self, mix):

--- a/test/python/test_mixture.py
+++ b/test/python/test_mixture.py
@@ -28,7 +28,7 @@ class TestMixture:
         assert len(E) == mix.n_elements
 
     def test_element_index(self, mix):
-        with pytest.raises(ct.CanteraError, match="Element W not found."):
+        with pytest.raises(ct.CanteraError, match="Element 'W' not found"):
             mix.element_index('W')
 
         with pytest.raises(ct.CanteraError, match="outside valid range"):
@@ -54,13 +54,13 @@ class TestMixture:
         with pytest.raises(IndexError, match='out of range'):
             mix.species_index(3, 'OH')
 
-        with pytest.raises(ct.CanteraError, match="Species OH not found."):
+        with pytest.raises(ct.CanteraError, match="Species 'OH' not found"):
             mix.species_index(1, 'OH')
 
         with pytest.raises(ct.CanteraError, match="outside valid range"):
             mix.species_index(0, -2)
 
-        with pytest.raises(ct.CanteraError, match="Species CO2 not found."):
+        with pytest.raises(ct.CanteraError, match="Species 'CO2' not found"):
             mix.species_index(1, 'CO2')
 
     def test_n_atoms(self, mix):

--- a/test/python/test_mixture.py
+++ b/test/python/test_mixture.py
@@ -31,7 +31,7 @@ class TestMixture:
         with pytest.raises(ct.CanteraError, match="Element W not found."):
             mix.element_index('W')
 
-        with pytest.raises(ValueError, match='No such element'):
+        with pytest.raises(ct.CanteraError, match="outside valid range"):
             mix.element_index(41)
 
         with pytest.raises(TypeError, match='must be a string or a number'):

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -34,11 +34,16 @@ class TestOnedim:
     def test_boundaryProperties(self):
         gas1 = ct.Solution("h2o2.yaml")
         gas2 = ct.Solution("h2o2.yaml")
-        inlet = ct.Inlet1D(name='something', phase=gas1)
-        flame = ct.FreeFlow(gas1)
+        inlet = ct.Inlet1D(gas1, name="spam")
+        flame = ct.FreeFlow(gas1, name="eggs")
         sim = ct.Sim1D((inlet, flame))
 
-        assert inlet.name == 'something'
+        assert sim.domain_index("spam") == 0
+        assert sim.domain_index(inlet) == 0
+        assert sim.domain_index("eggs") == 1
+        assert inlet.name == "spam"
+        with pytest.raises(ct.CanteraError, match="Domain 'bacon' not found"):
+            sim.domain_index("bacon")
 
         gas2.TPX = 400, 101325, 'H2:0.3, O2:0.5, AR:0.2'
         Xref = gas2.X

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -113,7 +113,7 @@ class TestOnedim:
         # Some things don't work until the domains have been added to a Sim1D
         sim = ct.Sim1D((left, flame, right))
 
-        with pytest.raises(ct.CanteraError, match='No component'):
+        with pytest.raises(ct.CanteraError, match="Component 'foobar' not found"):
             flame.set_steady_tolerances(foobar=(3e-4, 3e-6))
 
         flame.set_steady_tolerances(default=(5e-3, 5e-5),

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -359,7 +359,7 @@ class TestReactor:
     def test_advance_limits_invalid(self):
         self.make_reactors(n_reactors=1)
 
-        with pytest.raises(ct.CanteraError, match="No component named 'spam'"):
+        with pytest.raises(ct.CanteraError, match="Unknown component 'spam'"):
             self.r1.set_advance_limit("spam", 0.1)
 
     def test_advance_reverse(self):
@@ -1786,7 +1786,7 @@ class TestFlowReactor:
             name = r.component_name(i)
             assert r.component_index(name) == i
 
-        with pytest.raises(IndexError, match="No such component: 'spam'"):
+        with pytest.raises(ct.CanteraError, match="Unknown component 'spam'"):
             r.component_index('spam')
 
         with pytest.raises(ct.CanteraError, match='out of bounds'):

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -359,7 +359,7 @@ class TestReactor:
     def test_advance_limits_invalid(self):
         self.make_reactors(n_reactors=1)
 
-        with pytest.raises(ct.CanteraError, match="Unknown component 'spam'"):
+        with pytest.raises(ct.CanteraError, match="Component 'spam' not found"):
             self.r1.set_advance_limit("spam", 0.1)
 
     def test_advance_reverse(self):
@@ -1786,7 +1786,7 @@ class TestFlowReactor:
             name = r.component_name(i)
             assert r.component_index(name) == i
 
-        with pytest.raises(ct.CanteraError, match="Unknown component 'spam'"):
+        with pytest.raises(ct.CanteraError, match="Component 'spam' not found"):
             r.component_index('spam')
 
         with pytest.raises(ct.CanteraError, match='out of bounds'):

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -102,7 +102,7 @@ class TestThermoPhase:
             kSpec = self.phase.species_index(species)
             assert self.phase.n_atoms(kSpec, mElem) == n
 
-        with pytest.raises(ValueError, match="No such species 'C'"):
+        with pytest.raises(ct.CanteraError, match="Species C not found."):
             self.phase.n_atoms('C', 'H2')
         with pytest.raises(ct.CanteraError, match='Element CH4 not found.'):
             self.phase.n_atoms('H', 'CH4')
@@ -1929,7 +1929,7 @@ class TestMisc:
 
         gas.case_sensitive_species_names = True
         assert gas.case_sensitive_species_names
-        with pytest.raises(ValueError):
+        with pytest.raises(ct.CanteraError, match="Species h2 not found."):
             gas.species_index('h2')
         with pytest.raises(ct.CanteraError, match="Species h2 not found."):
             gas.X = 'h2:1.0, o2:1.0'
@@ -1949,7 +1949,7 @@ class TestMisc:
         with pytest.raises(ct.CanteraError, match='is not unique'):
             gas.species_index('cs')
         gas.case_sensitive_species_names = True
-        with pytest.raises(ValueError):
+        with pytest.raises(ct.CanteraError, match="Species cs not found."):
             gas.species_index('cs')
 
     def test_unstable_element_in_phase(self):

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -102,9 +102,9 @@ class TestThermoPhase:
             kSpec = self.phase.species_index(species)
             assert self.phase.n_atoms(kSpec, mElem) == n
 
-        with pytest.raises(ValueError, match='No such species'):
+        with pytest.raises(ValueError, match="No such species 'C'"):
             self.phase.n_atoms('C', 'H2')
-        with pytest.raises(ValueError, match='No such element'):
+        with pytest.raises(ct.CanteraError, match='Element CH4 not found.'):
             self.phase.n_atoms('H', 'CH4')
 
     def test_elemental_mass_fraction(self):
@@ -119,7 +119,7 @@ class TestThermoPhase:
         assert Zh == approx(0.5 * (2.016 / 18.015))
         assert Zar == 0.0
 
-        with pytest.raises(ValueError, match='No such element'):
+        with pytest.raises(ct.CanteraError, match="Element C not found."):
             self.phase.elemental_mass_fraction('C')
         with pytest.raises(ValueError, match='No such element'):
             self.phase.elemental_mass_fraction(5)
@@ -136,7 +136,7 @@ class TestThermoPhase:
         assert Zh == approx((2 * 0.5) / (0.5 * 3 + 0.5 * 2))
         assert Zar == 0.0
 
-        with pytest.raises(ValueError, match='No such element'):
+        with pytest.raises(ct.CanteraError, match="Element C not found."):
             self.phase.elemental_mole_fraction('C')
         with pytest.raises(ValueError, match='No such element'):
             self.phase.elemental_mole_fraction(5)

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -102,9 +102,9 @@ class TestThermoPhase:
             kSpec = self.phase.species_index(species)
             assert self.phase.n_atoms(kSpec, mElem) == n
 
-        with pytest.raises(ct.CanteraError, match="Species C not found."):
+        with pytest.raises(ct.CanteraError, match="Species 'C' not found"):
             self.phase.n_atoms('C', 'H2')
-        with pytest.raises(ct.CanteraError, match='Element CH4 not found.'):
+        with pytest.raises(ct.CanteraError, match="Element 'CH4' not found"):
             self.phase.n_atoms('H', 'CH4')
 
     def test_elemental_mass_fraction(self):
@@ -119,7 +119,7 @@ class TestThermoPhase:
         assert Zh == approx(0.5 * (2.016 / 18.015))
         assert Zar == 0.0
 
-        with pytest.raises(ct.CanteraError, match="Element C not found."):
+        with pytest.raises(ct.CanteraError, match="Element 'C' not found"):
             self.phase.elemental_mass_fraction('C')
         with pytest.raises(ct.CanteraError, match="outside valid range"):
             self.phase.elemental_mass_fraction(5)
@@ -136,7 +136,7 @@ class TestThermoPhase:
         assert Zh == approx((2 * 0.5) / (0.5 * 3 + 0.5 * 2))
         assert Zar == 0.0
 
-        with pytest.raises(ct.CanteraError, match="Element C not found."):
+        with pytest.raises(ct.CanteraError, match="Element 'C' not found"):
             self.phase.elemental_mole_fraction('C')
         with pytest.raises(ct.CanteraError, match="outside valid range"):
             self.phase.elemental_mole_fraction(5)
@@ -198,7 +198,7 @@ class TestThermoPhase:
         assert X[0] == approx(0.5)
         assert X[3] == approx(0.5)
 
-        with pytest.raises(ct.CanteraError, match="Species CO2 not found."):
+        with pytest.raises(ct.CanteraError, match="Species 'CO2' not found"):
             self.phase.X = 'H2:1.0, CO2:1.5'
 
     def test_setCompositionStringBad(self):
@@ -264,7 +264,7 @@ class TestThermoPhase:
             self.phase.set_unnormalized_mass_fractions([1, 2, 3])
 
     def test_setCompositionDict_bad1(self):
-        with pytest.raises(ct.CanteraError, match="Species HCl not found."):
+        with pytest.raises(ct.CanteraError, match="Species 'HCl' not found"):
             self.phase.X = {'H2': 1.0, 'HCl': 3.0}
 
     def test_setCompositionDict_bad2(self):
@@ -1929,11 +1929,11 @@ class TestMisc:
 
         gas.case_sensitive_species_names = True
         assert gas.case_sensitive_species_names
-        with pytest.raises(ct.CanteraError, match="Species h2 not found."):
+        with pytest.raises(ct.CanteraError, match="Species 'h2' not found"):
             gas.species_index('h2')
-        with pytest.raises(ct.CanteraError, match="Species h2 not found."):
+        with pytest.raises(ct.CanteraError, match="Species 'h2' not found"):
             gas.X = 'h2:1.0, o2:1.0'
-        with pytest.raises(ct.CanteraError, match="Species h2 not found."):
+        with pytest.raises(ct.CanteraError, match="Species 'h2' not found"):
             gas.Y = 'h2:1.0, o2:1.0'
 
         gas_yaml = """
@@ -1949,7 +1949,7 @@ class TestMisc:
         with pytest.raises(ct.CanteraError, match='is not unique'):
             gas.species_index('cs')
         gas.case_sensitive_species_names = True
-        with pytest.raises(ct.CanteraError, match="Species cs not found."):
+        with pytest.raises(ct.CanteraError, match="Species 'cs' not found"):
             gas.species_index('cs')
 
     def test_unstable_element_in_phase(self):

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -198,7 +198,7 @@ class TestThermoPhase:
         assert X[0] == approx(0.5)
         assert X[3] == approx(0.5)
 
-        with pytest.raises(ct.CanteraError, match='Unknown species'):
+        with pytest.raises(ct.CanteraError, match="Species CO2 not found."):
             self.phase.X = 'H2:1.0, CO2:1.5'
 
     def test_setCompositionStringBad(self):
@@ -264,7 +264,7 @@ class TestThermoPhase:
             self.phase.set_unnormalized_mass_fractions([1, 2, 3])
 
     def test_setCompositionDict_bad1(self):
-        with pytest.raises(ct.CanteraError, match='Unknown species'):
+        with pytest.raises(ct.CanteraError, match="Species HCl not found."):
             self.phase.X = {'H2': 1.0, 'HCl': 3.0}
 
     def test_setCompositionDict_bad2(self):
@@ -1931,9 +1931,9 @@ class TestMisc:
         assert gas.case_sensitive_species_names
         with pytest.raises(ValueError):
             gas.species_index('h2')
-        with pytest.raises(ct.CanteraError, match='Unknown species'):
+        with pytest.raises(ct.CanteraError, match="Species h2 not found."):
             gas.X = 'h2:1.0, o2:1.0'
-        with pytest.raises(ct.CanteraError, match='Unknown species'):
+        with pytest.raises(ct.CanteraError, match="Species h2 not found."):
             gas.Y = 'h2:1.0, o2:1.0'
 
         gas_yaml = """

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -121,7 +121,7 @@ class TestThermoPhase:
 
         with pytest.raises(ct.CanteraError, match="Element C not found."):
             self.phase.elemental_mass_fraction('C')
-        with pytest.raises(ValueError, match='No such element'):
+        with pytest.raises(ct.CanteraError, match="outside valid range"):
             self.phase.elemental_mass_fraction(5)
 
     def test_elemental_mole_fraction(self):
@@ -138,7 +138,7 @@ class TestThermoPhase:
 
         with pytest.raises(ct.CanteraError, match="Element C not found."):
             self.phase.elemental_mole_fraction('C')
-        with pytest.raises(ValueError, match='No such element'):
+        with pytest.raises(ct.CanteraError, match="outside valid range"):
             self.phase.elemental_mole_fraction(5)
 
     def test_elemental_mass_mole_fraction(self):

--- a/test/thermo/ThermoPhase_Test.cpp
+++ b/test/thermo/ThermoPhase_Test.cpp
@@ -162,15 +162,15 @@ public:
         } else {
             gas.setState_TPX(300.0, 1e5, m_fuel);
         }
-        double Y_Cf = gas.elementalMassFraction(gas.elementIndex("C", true));
-        double Y_Of = gas.elementalMassFraction(gas.elementIndex("O", true));
+        double Y_Cf = gas.elementalMassFraction(gas.elementIndex("C"));
+        double Y_Of = gas.elementalMassFraction(gas.elementIndex("O"));
         if (basis == ThermoBasis::mass) {
             gas.setState_TPY(300.0, 1e5, m_ox);
         } else {
             gas.setState_TPX(300.0, 1e5, m_ox);
         }
-        double Y_Co = gas.elementalMassFraction(gas.elementIndex("C", true));
-        double Y_Oo = gas.elementalMassFraction(gas.elementIndex("O", true));
+        double Y_Co = gas.elementalMassFraction(gas.elementIndex("C"));
+        double Y_Oo = gas.elementalMassFraction(gas.elementIndex("O"));
 
         gas.setEquivalenceRatio(1.3, m_fuel, m_ox, basis);
         double T = gas.temperature();
@@ -179,8 +179,8 @@ public:
         // mixture fraction are independent of reaction progress
         gas.equilibrate("HP");
         test_mixture_results(T, basis, 1.3, 1.1726068608195617, 0.13415725911057605,
-                (gas.elementalMassFraction(gas.elementIndex("C", true))-Y_Co)/(Y_Cf-Y_Co),
-                (gas.elementalMassFraction(gas.elementIndex("O", true))-Y_Oo)/(Y_Of-Y_Oo),
+                (gas.elementalMassFraction(gas.elementIndex("C"))-Y_Co)/(Y_Cf-Y_Co),
+                (gas.elementalMassFraction(gas.elementIndex("O"))-Y_Oo)/(Y_Of-Y_Oo),
                 8.3901204498353561, m_fuel, m_ox);
 
         gas.setState_TP(300.0,1e5);
@@ -188,8 +188,8 @@ public:
         T = gas.temperature();
         gas.equilibrate("HP");
         test_mixture_results(T, basis, 1.3, 1.1726068608195617, 0.13415725911057605,
-                (gas.elementalMassFraction(gas.elementIndex("C", true))-Y_Co)/(Y_Cf-Y_Co),
-                (gas.elementalMassFraction(gas.elementIndex("O", true))-Y_Oo)/(Y_Of-Y_Oo),
+                (gas.elementalMassFraction(gas.elementIndex("C"))-Y_Co)/(Y_Cf-Y_Co),
+                (gas.elementalMassFraction(gas.elementIndex("O"))-Y_Oo)/(Y_Of-Y_Oo),
                 8.3901204498353561, m_fuel, m_ox);
     }
 

--- a/test/thermo/ThermoPhase_Test.cpp
+++ b/test/thermo/ThermoPhase_Test.cpp
@@ -162,15 +162,15 @@ public:
         } else {
             gas.setState_TPX(300.0, 1e5, m_fuel);
         }
-        double Y_Cf = gas.elementalMassFraction(gas.elementIndex("C"));
-        double Y_Of = gas.elementalMassFraction(gas.elementIndex("O"));
+        double Y_Cf = gas.elementalMassFraction(gas.elementIndex("C", true));
+        double Y_Of = gas.elementalMassFraction(gas.elementIndex("O", true));
         if (basis == ThermoBasis::mass) {
             gas.setState_TPY(300.0, 1e5, m_ox);
         } else {
             gas.setState_TPX(300.0, 1e5, m_ox);
         }
-        double Y_Co = gas.elementalMassFraction(gas.elementIndex("C"));
-        double Y_Oo = gas.elementalMassFraction(gas.elementIndex("O"));
+        double Y_Co = gas.elementalMassFraction(gas.elementIndex("C", true));
+        double Y_Oo = gas.elementalMassFraction(gas.elementIndex("O", true));
 
         gas.setEquivalenceRatio(1.3, m_fuel, m_ox, basis);
         double T = gas.temperature();
@@ -179,8 +179,8 @@ public:
         // mixture fraction are independent of reaction progress
         gas.equilibrate("HP");
         test_mixture_results(T, basis, 1.3, 1.1726068608195617, 0.13415725911057605,
-                (gas.elementalMassFraction(gas.elementIndex("C"))-Y_Co)/(Y_Cf-Y_Co),
-                (gas.elementalMassFraction(gas.elementIndex("O"))-Y_Oo)/(Y_Of-Y_Oo),
+                (gas.elementalMassFraction(gas.elementIndex("C", true))-Y_Co)/(Y_Cf-Y_Co),
+                (gas.elementalMassFraction(gas.elementIndex("O", true))-Y_Oo)/(Y_Of-Y_Oo),
                 8.3901204498353561, m_fuel, m_ox);
 
         gas.setState_TP(300.0,1e5);
@@ -188,8 +188,8 @@ public:
         T = gas.temperature();
         gas.equilibrate("HP");
         test_mixture_results(T, basis, 1.3, 1.1726068608195617, 0.13415725911057605,
-                (gas.elementalMassFraction(gas.elementIndex("C"))-Y_Co)/(Y_Cf-Y_Co),
-                (gas.elementalMassFraction(gas.elementIndex("O"))-Y_Oo)/(Y_Of-Y_Oo),
+                (gas.elementalMassFraction(gas.elementIndex("C", true))-Y_Co)/(Y_Cf-Y_Co),
+                (gas.elementalMassFraction(gas.elementIndex("O", true))-Y_Oo)/(Y_Of-Y_Oo),
                 8.3901204498353561, m_fuel, m_ox);
     }
 

--- a/test/thermo/phaseConstructors.cpp
+++ b/test/thermo/phaseConstructors.cpp
@@ -98,7 +98,7 @@ TEST_F(ConstructFromScratch, AddElements)
     p.addElement("O");
     ASSERT_EQ((size_t) 2, p.nElements());
     ASSERT_EQ("H", p.elementName(0));
-    ASSERT_EQ((size_t) 1, p.elementIndex("O", true));
+    ASSERT_EQ((size_t) 1, p.elementIndex("O"));
 }
 
 TEST_F(ConstructFromScratch, throwUndefindElements)
@@ -137,7 +137,8 @@ TEST_F(ConstructFromScratch, ignoreUndefinedElements)
     p.addSpecies(sCO2);
     ASSERT_EQ((size_t) 2, p.nSpecies());
     ASSERT_EQ((size_t) 2, p.nElements());
-    ASSERT_EQ(npos, p.speciesIndex("CO2"));
+    ASSERT_EQ(npos, p.speciesIndex("CO2", false));
+    ASSERT_THROW(p.speciesIndex("CO2", true), CanteraError);
 }
 
 TEST_F(ConstructFromScratch, addUndefinedElements)
@@ -156,8 +157,8 @@ TEST_F(ConstructFromScratch, addUndefinedElements)
     p.addSpecies(sCO2);
     ASSERT_EQ((size_t) 4, p.nSpecies());
     ASSERT_EQ((size_t) 3, p.nElements());
-    ASSERT_EQ((size_t) 1, p.nAtoms(p.speciesIndex("CO2"), p.elementIndex("C", true)));
-    ASSERT_EQ((size_t) 2, p.nAtoms(p.speciesIndex("co2"), p.elementIndex("O", true)));
+    ASSERT_EQ((size_t) 1, p.nAtoms(p.speciesIndex("CO2"), p.elementIndex("C")));
+    ASSERT_EQ((size_t) 2, p.nAtoms(p.speciesIndex("co2"), p.elementIndex("O")));
     p.setMassFractionsByName("H2:0.5, CO2:0.5");
     ASSERT_DOUBLE_EQ(0.5, p.massFraction("CO2"));
 }

--- a/test/thermo/phaseConstructors.cpp
+++ b/test/thermo/phaseConstructors.cpp
@@ -98,7 +98,7 @@ TEST_F(ConstructFromScratch, AddElements)
     p.addElement("O");
     ASSERT_EQ((size_t) 2, p.nElements());
     ASSERT_EQ("H", p.elementName(0));
-    ASSERT_EQ((size_t) 1, p.elementIndex("O"));
+    ASSERT_EQ((size_t) 1, p.elementIndex("O", true));
 }
 
 TEST_F(ConstructFromScratch, throwUndefindElements)
@@ -156,8 +156,8 @@ TEST_F(ConstructFromScratch, addUndefinedElements)
     p.addSpecies(sCO2);
     ASSERT_EQ((size_t) 4, p.nSpecies());
     ASSERT_EQ((size_t) 3, p.nElements());
-    ASSERT_EQ((size_t) 1, p.nAtoms(p.speciesIndex("CO2"), p.elementIndex("C")));
-    ASSERT_EQ((size_t) 2, p.nAtoms(p.speciesIndex("co2"), p.elementIndex("O")));
+    ASSERT_EQ((size_t) 1, p.nAtoms(p.speciesIndex("CO2"), p.elementIndex("C", true)));
+    ASSERT_EQ((size_t) 2, p.nAtoms(p.speciesIndex("co2"), p.elementIndex("O", true)));
     p.setMassFractionsByName("H2:0.5, CO2:0.5");
     ASSERT_DOUBLE_EQ(0.5, p.massFraction("CO2"));
 }

--- a/test_problems/stoichSolidKinetics/stoichSolidKinetics.cpp
+++ b/test_problems/stoichSolidKinetics/stoichSolidKinetics.cpp
@@ -59,7 +59,7 @@ void testProblem()
     fe3o4_s->setState_TP(Temp, OneAtm);
     soln->thermo()->setState_TP(Temp, OneAtm);
 
-    size_t igco2 = gasTP->speciesIndex("CO2");
+    size_t igco2 = gasTP->speciesIndex("CO2", true);
 
     vector<double> work(gasTP->nSpecies(), 0.0);
 

--- a/test_problems/stoichSolidKinetics/stoichSolidKinetics.cpp
+++ b/test_problems/stoichSolidKinetics/stoichSolidKinetics.cpp
@@ -59,7 +59,7 @@ void testProblem()
     fe3o4_s->setState_TP(Temp, OneAtm);
     soln->thermo()->setState_TP(Temp, OneAtm);
 
-    size_t igco2 = gasTP->speciesIndex("CO2", true);
+    size_t igco2 = gasTP->speciesIndex("CO2");
 
     vector<double> work(gasTP->nSpecies(), 0.0);
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

This PR aims to establish a more uniform approach to index lookups, where the current `npos` check (utilized for internal methods) is transitioned towards standard exception handling (suitable for user-facing APIs).

- Mimic the implementation of the `clone` flag in #1921 ... a `raise` flag is currently set to `false` and will switch to a `true` default in Cantera 3.2. This is implemented for various index lookups in `Phase`, `MultiPhase`, and `Kinetics`.
- Make more widespread use of `checkABCIndex` 
- Deprecate some additional legacy CLib helper functions
- Applies to indexing of `Element`, `Species`, `Reaction`, and `Component`.
- Immediately switch `Reactor::componentIndex`/`Reactor::speciesIndex` to throw exceptions: almost all uses are in user-facing APIs (and a transition for `ExtensibleXYZReactor` would be a breaking change).
- Make exception messages more consistent.

One major advantage of this approach is that exception handling at user-facing APIs will become significantly easier, e.g., in #1997 (the MATLAB API itself is still hand-coded, but other APIs, such as .NET, would require cumbersome workarounds).

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #2004

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

Historically, exception handling was separated into three functions, although the  `checkABC` was rarely used, and `checkABCArraySize`, which isn't directly related, only appeared in the CLib interface. For `Phase::speciesIndex`, this looks as follows:
```C++
//! Returns the index of a species named 'name' within the Phase object.
size_t speciesIndex(const string& name) const;

//! Check that the specified species index is in range.
bool checkSpeciesIndex(size_t k) const;

//! Check that an array size is at least nSpecies().
void checkSpeciesArraySize(size_t kk) const;
```

This PR proposes to integrate exception handling into `speciesIndex`. 
```C++
//! Returns the index of a species named 'name' within the Phase object.
size_t speciesIndex(const string& name, bool raise) const;
```
After Cantera 3.2, this PR anticipates a default argument of `bool raise=true`.

`checkSpeciesIndex` is still useful as an internal function (making it `protected` would be within the scope of this PR), and is updated to return the correct size as:
```C++
//! Check that the specified species index is in range.
size_t checkSpeciesIndex(size_t k) const;
```

Regarding `checkABCArraySize`, the generated CLib goes a different route, where size checking is enabled by the `uses` field of the YAML specification. This could be further streamlined if Cantera/enhancements#237 were to be implemented.

As an aside, the Python API widely uses a `ThermoPhase.species_index(int)` et al. to validate indices, which unnecessarily complicates the interface, but remains intact.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
