### PR TITLE
Fix intermittent CI failures and add Python 3.14 CI jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,7 +85,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         os: ['ubuntu-24.04']
         numpy: ['']
         cython: ['!=3.1.2'] # Specifier can be dropped after 3.1.3 or 3.2.0 is released
@@ -251,6 +251,9 @@ jobs:
             extra-build-args: cxx_flags='-std=c++20'
           - macos-version: 'macos-15'
             python-version: '3.11'
+          - macos-version: 'macos-15'
+            python-version: '3.14'
+            extra-build-args: cxx_flags='-std=c++20'
           # - macos-version: 'macos-15-intel'
           #   python-version: '3.1x'  # sporadic failures: tracked in post-merge-tests
       fail-fast: false
@@ -607,6 +610,10 @@ jobs:
           python-version: "3.12"
           numpy: ""
           libhdf5: "libhdf5-103-1t64"
+        - os: "ubuntu-24.04"
+          python-version: "3.14"
+          numpy: ""
+          libhdf5: "libhdf5-103-1t64"
         - os: "ubuntu-22.04"
           python-version: "3.13"
           numpy: ""
@@ -642,19 +649,35 @@ jobs:
         run: python3 -m pip install -U pip setuptools wheel
       - name: Install Python dependencies
         run: |
-            python3 -m pip install numpy${{ matrix.numpy }} ruamel.yaml pandas pyarrow \
-              matplotlib scipy pint graphviz CoolProp
+            python3 -m pip install numpy${{ matrix.numpy }} ruamel.yaml \
+              matplotlib scipy pint graphviz
+            python3 -m pip install numpy${{ matrix.numpy }} pandas pyarrow || touch SKIP_PANDAS
+            python3 -m pip install numpy${{ matrix.numpy }} CoolProp || touch SKIP_COOLPROP
             python3 -m pip install --pre --no-index --find-links dist cantera
       - name: Run the examples
         # See https://unix.stackexchange.com/a/392973 for an explanation of the -exec part.
         # Skip 1D_packed_bed.py due to difficulty installing scikits.odes.
         # Increase figure limit to handle flame_speed_convergence_analysis.py.
-        # Skip equations_of_state.py in cases where CoolProp is broken (temporarily, for Python 3.13)
+        # Skip examples for Python releases where pandas/pyarrow or CoolProp are not available
         run: |
           echo "Running on `cat /proc/cpuinfo | grep 'model name' | head -n 1 | cut -d ':' -f 2`"
           ln -s libcantera_shared.so build/lib/libcantera_shared.so.3
           rm samples/python/reactors/1D_packed_bed.py
-          python3 -m CoolProp || rm samples/python/thermo/equations_of_state.py
+          if [ -e SKIP_PANDAS ]; then
+            rm samples/python/kinetics/diamond_cvd.py
+            rm samples/python/kinetics/jet_stirred_reactor.py
+            rm samples/python/kinetics/sofc.py
+            rm samples/python/onedim/diffusion_flame_continuation.py
+            rm samples/python/onedim/flame_initial_guess.py
+            rm samples/python/onedim/flame_speed_convergence_analysis.py
+            rm samples/python/onedim/flamespeed_sensitivity.py
+            rm samples/python/reactors/continuous_reactor.py
+            rm samples/python/reactors/reactor2.py
+            rm samples/python/thermo/vapordome.py
+          fi
+          if [ -e SKIP_COOLPROP ]; then
+            rm samples/python/thermo/equations_of_state.py
+          fi
           echo "figure.max_open_warning: 100" > matplotlibrc
           export LD_LIBRARY_PATH=build/lib
           find samples/python -type f -iname "*.py" \
@@ -847,7 +870,7 @@ jobs:
       BOOST_URL: https://github.com/boostorg/boost/releases/download/boost-1.87.0/boost-1.87.0-b2-nodocs.7z
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -651,6 +651,7 @@ jobs:
         # Increase figure limit to handle flame_speed_convergence_analysis.py.
         # Skip equations_of_state.py in cases where CoolProp is broken (temporarily, for Python 3.13)
         run: |
+          echo "Running on `cat /proc/cpuinfo | grep 'model name' | head -n 1 | cut -d ':' -f 2`"
           ln -s libcantera_shared.so build/lib/libcantera_shared.so.3
           rm samples/python/reactors/1D_packed_bed.py
           python3 -m CoolProp || rm samples/python/thermo/equations_of_state.py
@@ -1054,10 +1055,13 @@ jobs:
         post-cleanup: none
       if: matrix.os == 'windows-2022'
     - name: Install Brew dependencies (macOS)
-      run: brew install --display-times hdf5
+      run: |
+        echo "Running on `sysctl -n machdep.cpu.brand_string`"
+        brew install --display-times hdf5
       if: matrix.os == 'macos-14'
     - name: Install Apt dependencies (Ubuntu)
       run: |
+        echo "Running on `cat /proc/cpuinfo | grep 'model name' | head -n 1 | cut -d ':' -f 2`"
         sudo apt update
         sudo apt install libhdf5-dev libfmt-dev libopenblas0-openmp
       if: matrix.os == 'ubuntu-22.04'
@@ -1094,7 +1098,9 @@ jobs:
       run: tar -xzf doxygen.tar.gz
       working-directory: build/doc
     - name: Build the .NET interface
-      run: dotnet build
+      run: |
+        python3 -c 'import platform; print(f"Running on {platform.processor()}")'
+        dotnet build
       working-directory: interfaces/dotnet
     - name: Test the .NET interface
       run: dotnet test

--- a/samples/matlab_experimental/catcomb.m
+++ b/samples/matlab_experimental/catcomb.m
@@ -75,6 +75,7 @@ surf_phase.TP = {tsurf, surf_phase.P};
 % composition fixed to generate a good starting estimate for the
 % coverages.
 
+surf_phase.coverages = 'PT(S): 0.5, O(S): 0.5'
 surf_phase.advanceCoverages(1.0);
 
 %%

--- a/samples/python/onedim/catalytic_combustion.py
+++ b/samples/python/onedim/catalytic_combustion.py
@@ -65,6 +65,7 @@ gas.TPX = tinlet, p, comp1
 
 # integrate the coverage equations in time for 1 s, holding the gas
 # composition fixed to generate a good starting estimate for the coverages.
+surf_phase.coverages = {'PT(S)': 0.5, 'O(S)':0.5}
 surf_phase.advance_coverages(1.0)
 
 # create the object that simulates the stagnation flow, and specify an initial

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -51,9 +51,9 @@ void IonFlow::_init(ThermoPhase* ph, size_t nsp, size_t points)
     // instabilities. Tolerance on electrons is even tighter to account for the
     // low "molecular" weight.
     for (size_t k : m_kCharge) {
-        setBounds(c_offset_Y + k, -1e-14, 1.0);
+        setBounds(c_offset_Y + k, -1e-10, 1.0);
     }
-    setBounds(c_offset_Y + m_kElectron, -1e-18, 1.0);
+    setBounds(c_offset_Y + m_kElectron, -1e-14, 1.0);
 
     m_refiner->setActive(c_offset_E, false);
     m_mobility.resize(m_nsp*m_points);


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Add CPU info printout for CI jobs that run examples from pre-compiled Cantera Python module
- Use a better initial guess for surface coverages in `catalytic_combustion.py` to avoid occasional integration errors
- Relax the default solution bounds for ionized species / electrons in 1D solver; these are still tighter than the tolerances for neutral species, but the severe limits on negative values created difficulties in finding acceptable damped steps that kept these components in bounds.
- Add "normal" CI runs for Python 3.14. This includes some logic for skipping examples that depend on packages where installing from PyPI doesn't work.

**If applicable, fill in the issue number this pull request is fixing**

- Fixes #1999 
- Fixes #1991 
- Resolves #1994 

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
