### PR TITLE
Improve exceptions for abcName()

### DIFF
--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -175,7 +175,7 @@ public:
     /*!
      * @param kGlob   global species index
      */
-    string speciesName(const size_t kGlob) const;
+    string speciesName(size_t kGlob) const;
 
     //! Returns the Number of atoms of global element @e mGlob in
     //! global species @e kGlob.
@@ -208,7 +208,7 @@ public:
     /*!
      *   @param iph  phase Index
      */
-    string phaseName(const size_t iph) const;
+    string phaseName(size_t iph) const;
 
     //! Returns the index, given the phase name
     /*!

--- a/include/cantera/equil/vcs_VolPhase.h
+++ b/include/cantera/equil/vcs_VolPhase.h
@@ -427,7 +427,7 @@ public:
     /*!
      * @param e Element index.
      */
-    string elementName(const size_t e) const;
+    string elementName(size_t e) const;
 
     //! Type of the element constraint with index @c e.
     /*!

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -307,14 +307,32 @@ public:
 
     //! Return the name of the kth species in the kinetics manager.
     /*!
-     *  k is an integer from 0 to ktot - 1, where ktot is the number of
+     * k is an integer from 0 to ktot - 1, where ktot is the number of
      * species in the kinetics manager, which is the sum of the number of
      * species in all phases participating in the kinetics manager. If k is
      * out of bounds, the string "<unknown>" is returned.
      *
      * @param k species index
+     * @todo Update docstring after %Cantera 3.2 to reflect that future versions
+     *      raise exception.
      */
     string kineticsSpeciesName(size_t k) const;
+
+    /**
+     * Return the name of the kth species in the kinetics manager.
+     * k is an integer from 0 to ktot - 1, where ktot is the number of
+     * species in the kinetics manager, which is the sum of the number of
+     * species in all phases participating in the kinetics manager.
+     *
+     * @param k species index
+     * @param raise  If `true`, raise exception if the species index is out of bounds.
+     * @since New in %Cantera 3.2.
+     * @deprecated  To be removed after %Cantera 3.2. Only used for transitional
+     *      behavior.
+     * @exception Throws an IndexError if the specified species index is out of bounds
+     *      and `raise` is `true`.
+     */
+    string kineticsSpeciesName(size_t k, bool raise) const;
 
     /**
      * This routine will look up a species number based on the input

--- a/interfaces/cython/cantera/kinetics.pxd
+++ b/interfaces/cython/cantera/kinetics.pxd
@@ -26,8 +26,8 @@ cdef extern from "cantera/kinetics/Kinetics.h" namespace "Cantera":
         int nPhases()
         int phaseIndex(string&, cbool) except +translate_exception
         int kineticsSpeciesIndex(int, int)
-        int kineticsSpeciesIndex(string)
-        string kineticsSpeciesName(int)
+        int kineticsSpeciesIndex(string, bool)
+        string kineticsSpeciesName(int, bool)
 
         CxxThermoPhase& thermo(int)
 

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -130,7 +130,7 @@ cdef class Kinetics(_SolutionBase):
         """
         cdef int k
         if isinstance(species, (str, bytes)):
-            return self.kinetics.kineticsSpeciesIndex(stringify(species))
+            return self.kinetics.kineticsSpeciesIndex(stringify(species), True)
         else:
             k = species
             self._check_kinetics_species_index(k)
@@ -142,7 +142,7 @@ cdef class Kinetics(_SolutionBase):
         Name of the species with index ``k`` in the arrays returned by methods
         of class `Kinetics`.
         """
-        return pystr(self.kinetics.kineticsSpeciesName(k))
+        return pystr(self.kinetics.kineticsSpeciesName(k, True))
 
     property kinetics_species_names:
         """

--- a/interfaces/sourcegen/src/sourcegen/headers/ctkin.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctkin.yaml
@@ -8,8 +8,7 @@ base: Kinetics
 parents: []  # List of parent classes
 derived: {InterfaceKinetics: kin}  # Specialization/prefix dictionary
 recipes:
-- name: getType
-  wraps: kineticsType  # inconsistent API (preexisting)
+- name: kineticsType  # Renamed in Cantera 3.2 (previously getType)
 - name: nReactions
 - name: reaction  # New in Cantera 3.2
   uses: nReactions
@@ -69,7 +68,6 @@ recipes:
 - name: getDeltaSSEnthalpy  # Changed in Cantera 3.2 (previously part of getDelta)
 - name: getDeltaSSGibbs  # Changed in Cantera 3.2 (previously part of getDelta)
 - name: getDeltaSSEntropy  # Changed in Cantera 3.2 (previously part of getDelta)
-# - name: getSourceTerms  # <--- used by MATLAB interface for "massProdRate"
 # - name: start  # <--- unused except for FORTRAN API
 # service functions
 - name: del

--- a/interfaces/sourcegen/src/sourcegen/headers/generator.py
+++ b/interfaces/sourcegen/src/sourcegen/headers/generator.py
@@ -257,7 +257,9 @@ class HeaderGenerator:
         if ret_key in self._config.ret_type_crosswalk:
             ret_type = self._config.ret_type_crosswalk[ret_key]
             if what.startswith("const "):
-                ret_type = f"const {ret_type}"
+                # retain const unless it is a primitive
+                if what[6:] not in {"bool", "size_t", "int", "double"}:
+                    ret_type = f"const {ret_type}"
             if ret_type == "void":
                 returns = Param(
                     "int32_t", "", "Zero for success or -1 for exception handling.")

--- a/interfaces/sourcegen/src/sourcegen/yaml/generator.py
+++ b/interfaces/sourcegen/src/sourcegen/yaml/generator.py
@@ -1,10 +1,4 @@
-"""
-Generator for YAML output.
-
-Used for illustration purposes: the `CLibSourceGenerator` is used to preprocess YAML
-header specifications, which yields the `HeaderFile` objects used by this source
-generator.
-"""
+"""Generator for YAML summary output."""
 
 # This file is part of Cantera. See License.txt in the top-level directory or
 # at https://cantera.org/license.txt for license and copyright information.

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -733,7 +733,10 @@ void MultiPhase::checkElementArraySize(size_t mm) const
 
 string MultiPhase::elementName(size_t m) const
 {
-    return m_enames[m];
+    if (m < m_nel) {
+        return m_enames[m];
+    }
+    throw IndexError("MultiPhase::elementName", "element", m, m_nel);
 }
 
 size_t MultiPhase::elementIndex(const string& name) const
@@ -779,7 +782,10 @@ void MultiPhase::checkSpeciesArraySize(size_t kk) const
 
 string MultiPhase::speciesName(const size_t k) const
 {
-    return m_snames[k];
+    if (k < m_nsp) {
+        return m_snames[k];
+    }
+    throw IndexError("MultiPhase::speciesName", "species", k, m_nsp);
 }
 
 double MultiPhase::nAtoms(const size_t kGlob, const size_t mGlob) const
@@ -794,7 +800,10 @@ void MultiPhase::getMoleFractions(double* const x) const
 
 string MultiPhase::phaseName(const size_t iph) const
 {
-    return m_phase[iph]->name();
+    if (iph < m_phase.size()) {
+        return m_phase[iph]->name();
+    }
+    throw IndexError("MultiPhase::phaseName", "phase", iph, m_phase.size());
 }
 
 int MultiPhase::phaseIndex(const string& pName) const

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -780,7 +780,7 @@ void MultiPhase::checkSpeciesArraySize(size_t kk) const
     }
 }
 
-string MultiPhase::speciesName(const size_t k) const
+string MultiPhase::speciesName(size_t k) const
 {
     if (k < m_nsp) {
         return m_snames[k];
@@ -798,7 +798,7 @@ void MultiPhase::getMoleFractions(double* const x) const
     std::copy(m_moleFractions.begin(), m_moleFractions.end(), x);
 }
 
-string MultiPhase::phaseName(const size_t iph) const
+string MultiPhase::phaseName(size_t iph) const
 {
     if (iph < m_phase.size()) {
         return m_phase[iph]->name();

--- a/src/equil/vcs_VolPhase.cpp
+++ b/src/equil/vcs_VolPhase.cpp
@@ -754,7 +754,7 @@ size_t vcs_VolPhase::nElemConstraints() const
     return m_numElemConstraints;
 }
 
-string vcs_VolPhase::elementName(const size_t e) const
+string vcs_VolPhase::elementName(size_t e) const
 {
 
     if (e < m_elementNames.size()) {

--- a/src/equil/vcs_VolPhase.cpp
+++ b/src/equil/vcs_VolPhase.cpp
@@ -756,7 +756,11 @@ size_t vcs_VolPhase::nElemConstraints() const
 
 string vcs_VolPhase::elementName(const size_t e) const
 {
-    return m_elementNames[e];
+
+    if (e < m_elementNames.size()) {
+        return m_elementNames[e];
+    }
+    throw IndexError("vcs_VolPhase::elementName", "element", e, m_elementNames.size());
 }
 
 //! This function decides whether a phase has charged species or not.

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -334,10 +334,24 @@ double Kinetics::checkDuplicateStoich(map<int, double>& r1, map<int, double>& r2
 
 string Kinetics::kineticsSpeciesName(size_t k) const
 {
+    string ret = kineticsSpeciesName(k, false);
+    if (ret == "<unknown>") {
+        warn_deprecated("Kinetics::kineticsSpeciesName", "Behavior will change from "
+            "returning '<unknown>' to throwing an exception after Cantera 3.2.");
+    }
+    return ret;
+}
+
+string Kinetics::kineticsSpeciesName(size_t k, bool raise) const
+{
     for (size_t n = m_start.size()-1; n != npos; n--) {
         if (k >= m_start[n]) {
             return thermo(n).speciesName(k - m_start[n]);
         }
+    }
+    if (raise) {
+        // always throw exception after Cantera 3.2.
+        throw IndexError("Kinetics::kineticsSpeciesName", "totalSpecies", k, m_kk);
     }
     return "<unknown>";
 }

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -649,9 +649,8 @@ string ReactingSurf1D::componentName(size_t n) const
 {
     if (n < m_nsp) {
         return m_sphase->speciesName(n);
-    } else {
-        return "<unknown>";
     }
+    throw IndexError("ReactingSurf1D::componentName", "component", n, m_nsp);
 }
 
 size_t ReactingSurf1D::componentIndex(const string& name, bool checkAlias) const

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -74,16 +74,19 @@ void Domain1D::resize(size_t nv, size_t np)
 
 string Domain1D::componentName(size_t n) const
 {
-    if (m_name[n] != "") {
-        return m_name[n];
-    } else {
-        return fmt::format("component {}", n);
+    if (n < m_nv) {
+        if (m_name[n] != "") {
+            return m_name[n];
+        } else {
+            return fmt::format("component {}", n);
+        }
     }
+    throw IndexError("Domain1D::componentName", "component", n, m_nv);
 }
 
 size_t Domain1D::componentIndex(const string& name, bool checkAlias) const
 {
-    for (size_t n = 0; n < nComponents(); n++) {
+    for (size_t n = 0; n < m_nv; n++) {
         if (name == componentName(n)) {
             return n;
         }
@@ -94,7 +97,7 @@ size_t Domain1D::componentIndex(const string& name, bool checkAlias) const
 
 bool Domain1D::hasComponent(const string& name, bool checkAlias) const
 {
-    for (size_t n = 0; n < nComponents(); n++) {
+    for (size_t n = 0; n < m_nv; n++) {
         if (name == componentName(n)) {
             return true;
         }

--- a/src/oneD/Flow1D.cpp
+++ b/src/oneD/Flow1D.cpp
@@ -868,7 +868,7 @@ string Flow1D::componentName(size_t n) const
         if (n >= c_offset_Y && n < (c_offset_Y + m_nsp)) {
             return m_thermo->speciesName(n - c_offset_Y);
         } else {
-            return "<unknown>";
+            throw IndexError("Flow1D::componentName", "component", n, m_nv);
         }
     }
 }

--- a/src/oneD/OneDim.cpp
+++ b/src/oneD/OneDim.cpp
@@ -37,6 +37,9 @@ size_t OneDim::domainIndex(const string& name) const
 }
 
 std::tuple<string, size_t, string> OneDim::component(size_t i) const {
+    if (i >= m_size) {
+        throw IndexError("OneDim::component", "components", i, m_size);
+    }
     const auto& [n, j, k] = m_componentInfo[i];
     Domain1D& dom = domain(n);
     return make_tuple(dom.id(), j, dom.componentName(k));

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -51,7 +51,10 @@ void Phase::checkElementArraySize(size_t mm) const
 
 string Phase::elementName(size_t m) const
 {
-    return m_elementNames[checkElementIndex(m)];
+    if (m < m_mm) {
+        return m_elementNames[m];
+    }
+    throw IndexError("Phase::elementName", "element", m, m_mm);
 }
 
 size_t Phase::elementIndex(const string& name) const
@@ -170,8 +173,10 @@ size_t Phase::speciesIndex(const string& name, bool raise) const
 
 string Phase::speciesName(size_t k) const
 {
-    checkSpeciesIndex(k);
-    return m_speciesNames[k];
+    if (k < m_kk) {
+        return m_speciesNames[k];
+    }
+    throw IndexError("Phase::speciesName", "species", k, m_kk);
 }
 
 const vector<string>& Phase::speciesNames() const

--- a/src/zeroD/ConstPressureMoleReactor.cpp
+++ b/src/zeroD/ConstPressureMoleReactor.cpp
@@ -139,8 +139,7 @@ string ConstPressureMoleReactor::componentName(size_t k) {
             }
         }
     }
-    throw CanteraError("ConstPressureMoleReactor::componentName",
-                       "Index is out of bounds.");
+    throw IndexError("ConstPressureMoleReactor::componentName", "component", k, m_nv);
 }
 
 double ConstPressureMoleReactor::upperBound(size_t k) const {

--- a/src/zeroD/ConstPressureReactor.cpp
+++ b/src/zeroD/ConstPressureReactor.cpp
@@ -165,8 +165,7 @@ string ConstPressureReactor::componentName(size_t k) {
             }
         }
     }
-    throw CanteraError("ConstPressureReactor::componentName",
-                       "Index is out of bounds.");
+    throw IndexError("ConstPressureReactor::componentName", "component", k, m_nv);
 }
 
 double ConstPressureReactor::upperBound(size_t k) const {

--- a/src/zeroD/FlowReactor.cpp
+++ b/src/zeroD/FlowReactor.cpp
@@ -382,7 +382,7 @@ string FlowReactor::componentName(size_t k)
             }
         }
     }
-    throw CanteraError("FlowReactor::componentName", "Index {} is out of bounds.", k);
+    throw IndexError("FlowReactor::componentName", "component", k, m_nv);
 }
 
 }

--- a/src/zeroD/IdealGasConstPressureMoleReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureMoleReactor.cpp
@@ -265,8 +265,8 @@ string IdealGasConstPressureMoleReactor::componentName(size_t k) {
             }
         }
     }
-    throw CanteraError("IdealGasConstPressureMoleReactor::componentName",
-                       "Index is out of bounds.");
+    throw IndexError("IdealGasConstPressureMoleReactor::componentName",
+        "components", k, m_nv);
 }
 
 double IdealGasConstPressureMoleReactor::upperBound(size_t k) const {

--- a/src/zeroD/MoleReactor.cpp
+++ b/src/zeroD/MoleReactor.cpp
@@ -318,7 +318,7 @@ string MoleReactor::componentName(size_t k) {
             }
         }
     }
-    throw CanteraError("MoleReactor::componentName", "Index is out of bounds.");
+    throw IndexError("MoleReactor::componentName", "component", k, m_nv);
 }
 
 double MoleReactor::upperBound(size_t k) const {

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -526,7 +526,7 @@ string Reactor::componentName(size_t k) {
             }
         }
     }
-    throw CanteraError("Reactor::componentName", "Index is out of bounds.");
+    throw IndexError("Reactor::componentName", "component", k, m_nv);
 }
 
 double Reactor::upperBound(size_t k) const {

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -627,18 +627,22 @@ size_t ReactorNet::globalComponentIndex(const string& component, size_t reactor)
 
 string ReactorNet::componentName(size_t i) const
 {
+    size_t iTot = 0;
+    size_t i0 = i;
     for (auto r : m_reactors) {
         if (i < r->neq()) {
             return r->name() + ": " + r->componentName(i);
         } else {
             i -= r->neq();
         }
+        iTot += r->neq();
     }
-    throw CanteraError("ReactorNet::componentName", "Index out of bounds");
+    throw IndexError("ReactorNet::componentName", "component", i0, iTot);
 }
 
 double ReactorNet::upperBound(size_t i) const
 {
+    size_t iTot = 0;
     size_t i0 = i;
     for (auto r : m_reactors) {
         if (i < r->neq()) {
@@ -646,12 +650,14 @@ double ReactorNet::upperBound(size_t i) const
         } else {
             i -= r->neq();
         }
+        iTot += r->neq();
     }
-    throw CanteraError("ReactorNet::upperBound", "Index {} out of bounds", i0);
+    throw IndexError("ReactorNet::upperBound", "upperBound", i0, iTot);
 }
 
 double ReactorNet::lowerBound(size_t i) const
 {
+    size_t iTot = 0;
     size_t i0 = i;
     for (auto r : m_reactors) {
         if (i < r->neq()) {
@@ -659,8 +665,9 @@ double ReactorNet::lowerBound(size_t i) const
         } else {
             i -= r->neq();
         }
+        iTot += r->neq();
     }
-    throw CanteraError("ReactorNet::lowerBound", "Index {} out of bounds", i0);
+    throw IndexError("ReactorNet::lowerBound", "lowerBound", i0, iTot);
 }
 
 void ReactorNet::resetBadValues(double* y) {

--- a/test/clib/test_clib.cpp
+++ b/test/clib/test_clib.cpp
@@ -166,9 +166,9 @@ TEST(ct, new_interface)
     ASSERT_EQ(thermoType, "ideal-surface");
 
     int32_t kin_surf = sol_kinetics(surf);
-    buflen = kin_getType(kin_surf, 0, 0) + 1; // include \0
+    buflen = kin_kineticsType(kin_surf, 0, 0) + 1; // include \0
     buf.resize(buflen);
-    kin_getType(kin_surf, buflen, buf.data());
+    kin_kineticsType(kin_surf, buflen, buf.data());
     string kinType(buf.data());
     ASSERT_EQ(kinType, "surface");
 }

--- a/test/equil/equil_gas.cpp
+++ b/test/equil/equil_gas.cpp
@@ -65,6 +65,26 @@ TEST_F(OverconstrainedEquil, DISABLED_MultiphaseEquil)
     EXPECT_NEAR(2*mu[0], mu[1], 1e-7*std::abs(mu[0]));
 }
 
+TEST_F(OverconstrainedEquil, exceptions)
+{
+    setup();
+    MultiPhase mphase;
+    mphase.addPhase(gas.get(), 10.0);
+    mphase.init();
+
+    ASSERT_THROW(mphase.elementName(200), IndexError);
+    ASSERT_THROW(mphase.elementIndex("spam"), CanteraError);
+    ASSERT_EQ(mphase.elementIndex("spam", false), npos);
+    ASSERT_THROW(mphase.elementIndex("spam", true), CanteraError);
+
+    ASSERT_THROW(mphase.speciesName(200), IndexError);
+
+    ASSERT_THROW(mphase.phaseName(200), IndexError);
+    ASSERT_THROW(mphase.phaseIndex("spam"), CanteraError);
+    ASSERT_EQ(mphase.phaseIndex("spam", false), npos);
+    ASSERT_THROW(mphase.phaseIndex("spam", true), CanteraError);
+}
+
 TEST_F(OverconstrainedEquil, BasisOptimize)
 {
     setup();

--- a/test/kinetics/kineticsFromScratch.cpp
+++ b/test/kinetics/kineticsFromScratch.cpp
@@ -327,6 +327,9 @@ TEST_F(KineticsFromScratch, third_body_composition)
     Composition prod = R->products;
     EXPECT_EQ(prod.count("H2O"), (size_t) 0);
     EXPECT_EQ(reac.count("M"), (size_t) 0);
+
+    ASSERT_THROW(kin.kineticsSpeciesName(200), IndexError);
+    ASSERT_THROW(kin.kineticsSpeciesIndex("spam"), CanteraError);
 }
 
 TEST_F(KineticsFromScratch, add_falloff_reaction1)

--- a/test/oneD/test_oneD.cpp
+++ b/test/oneD/test_oneD.cpp
@@ -106,6 +106,9 @@ TEST(onedim, flame_types)
     ASSERT_EQ(symm->type(), "axisymmetric-flow");
     auto burner = newDomain<Flow1D>("unstrained-flow", sol, "flow");
     ASSERT_EQ(burner->type(), "unstrained-flow");
+
+    ASSERT_THROW(burner->componentName(200), IndexError);
+    ASSERT_THROW(burner->componentIndex("spam"), CanteraError);
 }
 
 TEST(onedim, ion_flame_types)

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -1789,7 +1789,7 @@ class TestFlowReactor:
         with pytest.raises(ct.CanteraError, match="Component 'spam' not found"):
             r.component_index('spam')
 
-        with pytest.raises(ct.CanteraError, match='out of bounds'):
+        with pytest.raises(ct.CanteraError, match="outside valid range"):
             r.component_name(200)
 
 class TestFlowReactor2:

--- a/test/thermo/phaseConstructors.cpp
+++ b/test/thermo/phaseConstructors.cpp
@@ -99,6 +99,11 @@ TEST_F(ConstructFromScratch, AddElements)
     ASSERT_EQ((size_t) 2, p.nElements());
     ASSERT_EQ("H", p.elementName(0));
     ASSERT_EQ((size_t) 1, p.elementIndex("O"));
+
+    ASSERT_THROW(p.elementName(200), IndexError);
+    ASSERT_THROW(p.elementIndex("spam"), CanteraError);
+    ASSERT_EQ(p.elementIndex("spam", false), npos);
+    ASSERT_THROW(p.elementIndex("spam", true), CanteraError);
 }
 
 TEST_F(ConstructFromScratch, throwUndefindElements)
@@ -120,6 +125,11 @@ TEST_F(ConstructFromScratch, throwUndefindElements)
     ASSERT_EQ(2, p.nAtoms(2, 1)); // O in O2
     ASSERT_EQ(2, p.nAtoms(0, 0)); // H in H2O
     ASSERT_THROW(p.addSpecies(sCO), CanteraError);
+
+    ASSERT_THROW(p.speciesName(200), IndexError);
+    ASSERT_THROW(p.speciesIndex("spam"), CanteraError);
+    ASSERT_EQ(p.speciesIndex("spam", false), npos);
+    ASSERT_THROW(p.speciesIndex("spam", true), CanteraError);
 }
 
 TEST_F(ConstructFromScratch, ignoreUndefinedElements)

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -52,6 +52,15 @@ TEST(zerodim, test_guards)
     EXPECT_THROW(Valve().updateMassFlowRate(0.), CanteraError);
 }
 
+TEST(zerodim, reactor)
+{
+    auto gas = newSolution("h2o2.yaml", "ohmech", "none");
+    auto reactor = newReactor4("Reactor", gas, true, "my-reactor");
+
+    ASSERT_THROW(reactor->componentName(200), IndexError);
+    ASSERT_THROW(reactor->componentIndex("spam"), CanteraError);
+}
+
 TEST(zerodim, reservoir)
 {
     auto gas = newSolution("gri30.yaml", "gri30", "none");


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

This is a minor follow-up PR to #2010. I had noticed that exception handling for `*Name(size_t k)` was pretty inconsistent. In some instances, an exception was raised, in other cases, an `<unknown>` was returned, and in other cases, the index wasn't checked at all (i.e., undefined behavior). This PR updates the code so that it consistently throws an `IndexError` if the index is out of bounds.

The only instance where transitional behavior is implemented is `kineticsSpeciesName` (it's only user-facing, but some user code could check for `<unknown>`). For 0D and 1D instances of `componentName`, the implementation was inconsistent (some instances raised exceptions while others didn't), so I opted to raise exceptions for all, so all specializations follow the same approach.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
