### PR TITLE
Handle removal of numpy.trapz

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -660,10 +660,8 @@ jobs:
           -exec sh -c 'for n; do echo "$n" | tee -a results.txt && python3 "$n" >> results.txt || exit 1; done' sh {} +
         env:
           # The pyparsing ignore setting is due to a new warning introduced in Matplotlib==3.6.0
-          # @todo: Remove the trapz-related ignore when dropping support for NumPy 1.x
-          #     and replacing np.trapz with np.trapezoid
           # Ignore NasaPoly2 warnings from n-hexane-NUIG-2015.yaml
-          PYTHONWARNINGS: "error,ignore:warn_name_set_on_empty_Forward::pyparsing,ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:,ignore:`trapz`:DeprecationWarning,ignore:NasaPoly2:UserWarning:"
+          PYTHONWARNINGS: "error,ignore:warn_name_set_on_empty_Forward::pyparsing,ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:,ignore:NasaPoly2:UserWarning:"
           MPLBACKEND: Agg
       - name: Save the results file for inspection
         uses: actions/upload-artifact@v4

--- a/samples/python/onedim/diffusion_flame_continuation.py
+++ b/samples/python/onedim/diffusion_flame_continuation.py
@@ -26,6 +26,10 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 logging.basicConfig(stream=sys.stdout)
 
+# Workaround to support both Numpy 1.x and 2.4.0+
+# TODO: Replace when dropping Numpy 1.x support
+trapezoid = getattr(np, "trapezoid", None) or np.trapz
+
 # %%
 # Flame Initialization
 # --------------------
@@ -162,7 +166,7 @@ for i in range(n_max):
     data.append({
         'T_max': max(f.T),
         'strain_rate': strain_rate,
-        'heat_release_rate': np.trapz(f.heat_release_rate, f.grid),
+        'heat_release_rate': trapezoid(f.heat_release_rate, f.grid),
         'n_points': len(f.grid),
         'flame_width': width,
         'Tc_increment': temperature_increment,

--- a/samples/python/onedim/premixed_counterflow_twin_flame.py
+++ b/samples/python/onedim/premixed_counterflow_twin_flame.py
@@ -25,6 +25,9 @@ from pathlib import Path
 import numpy as np
 import cantera as ct
 
+# Workaround to support both Numpy 1.x and 2.4.0+
+# TODO: Replace when dropping Numpy 1.x support
+trapezoid = getattr(np, "trapezoid", None) or np.trapz
 
 # Differentiation function for data that has variable grid spacing Used here to
 # compute normal strain-rate
@@ -63,7 +66,7 @@ def compute_consumption_speed(opposed_flame):
 
     integrand = opposed_flame.heat_release_rate / opposed_flame.cp
 
-    total_heat_release = np.trapz(integrand, opposed_flame.grid)
+    total_heat_release = trapezoid(integrand, opposed_flame.grid)
     Sc = total_heat_release / (Tb - Tu) / rho_u
 
     return Sc

--- a/samples/python/reactors/ic_engine.py
+++ b/samples/python/reactors/ic_engine.py
@@ -17,6 +17,10 @@ import numpy as np
 
 import matplotlib.pyplot as plt
 
+# Workaround to support both Numpy 1.x and 2.4.0+
+# TODO: Replace when dropping Numpy 1.x support
+trapezoid = getattr(np, "trapezoid", None) or np.trapz
+
 #########################################################################
 # Input Parameters
 #########################################################################
@@ -252,13 +256,13 @@ plt.show()
 ######################################################################
 
 # heat release
-Q = np.trapz(states.heat_release_rate * states.V, t)
+Q = trapezoid(states.heat_release_rate * states.V, t)
 output_str = '{:45s}{:>4.1f} {}'
 print(output_str.format('Heat release rate per cylinder (estimate):',
                         Q / t[-1] / 1000., 'kW'))
 
 # expansion power
-W = np.trapz(states.dWv_dt, t)
+W = trapezoid(states.dWv_dt, t)
 print(output_str.format('Expansion power per cylinder (estimate):',
                         W / t[-1] / 1000., 'kW'))
 
@@ -268,6 +272,6 @@ print(output_str.format('Efficiency (estimate):', eta * 100., '%'))
 
 # CO emissions
 MW = states.mean_molecular_weight
-CO_emission = np.trapz(MW * states.mdot_out * states('CO').X[:, 0], t)
-CO_emission /= np.trapz(MW * states.mdot_out, t)
+CO_emission = trapezoid(MW * states.mdot_out * states('CO').X[:, 0], t)
+CO_emission /= trapezoid(MW * states.mdot_out, t)
 print(output_str.format('CO emission (estimate):', CO_emission * 1.e6, 'ppm'))

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -17,6 +17,10 @@ from .utilities import (
     compareProfiles
 )
 
+# Workaround to support both Numpy 1.x and 2.4.0+
+# TODO: Replace when dropping Numpy 1.x support
+trapezoid = getattr(np, "trapezoid", None) or np.trapz
+
 class TestReactor:
     reactorClass = ct.Reactor
 
@@ -2442,7 +2446,7 @@ class TestReactorSensitivities:
         To = T[0]
         Tf = T[-1]
 
-        return (t[-1]*T[-1] - np.trapz(T,t)) / (T[-1] - T[0])
+        return (t[-1]*T[-1] - trapezoid(T,t)) / (T[-1] - T[0])
 
     def calc_dtdh(self, species):
         gas, r, net = self.setup_ignition_delay()
@@ -2465,14 +2469,12 @@ class TestReactorSensitivities:
 
         To = T[0]
         Tf = T[-1]
-        tig = (t[-1]*Tf - np.trapz(T,t))/(Tf-To)
-        dtdp = ((t[-1] - tig)*S[-1,:]*Tf - np.trapz(S*T[:,None], t, axis=0))/(Tf-To)
+        tig = (t[-1]*Tf - trapezoid(T,t))/(Tf-To)
+        dtdp = ((t[-1] - tig)*S[-1,:]*Tf - trapezoid(S*T[:,None], t, axis=0))/(Tf-To)
         return dtdp
 
-    # @todo: replace np.trapz with np.trapezoid when dropping support for NumPy 1.x
     @pytest.mark.skip(reason="Integration of sensitivity ODEs is unreliable, "
                               "see: https://github.com/Cantera/enhancements/issues/55")
-    @pytest.mark.filterwarnings("ignore:`trapz` is deprecated")
     def test_ignition_delay_sensitivity(self):
         species = ('H2', 'H', 'O2', 'H2O2', 'H2O', 'OH', 'HO2')
         dtigdh_cvodes = self.calc_dtdh(species)


### PR DESCRIPTION
As revealed by the "post-merge-tests" workflow, Numpy 2.4.0 will remove `trapz`. 

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

To maintain compatibility with Numpy 1.x for now, we need to dynamically select the correct function. Maintaining this compatibility version is important since the current Ubuntu LTS release (24.04) provides Numpy 1.26.4.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
