### PR TITLE
Fix surface density/concentration calculation for multi-site species

### DIFF
--- a/include/cantera/thermo/SurfPhase.h
+++ b/include/cantera/thermo/SurfPhase.h
@@ -27,6 +27,22 @@ namespace Cantera
  * The density of surface sites is given by the variable @f$ n_0 @f$,
  * which has SI units of kmol m-2.
  *
+ * While the site coverage fractions @f$ \theta_k @f$ are generally used to describe the
+ * composition of surface phases, %Cantera represents the state internally in terms of
+ * mass fractions for consistency with other phase models. Mole fractions are computed
+ * from coverages as:
+ * @f[
+ *     X_k = \frac{ \theta_k / s_k }{ \sum_i \theta_i / s_i }
+ * @f]
+ * where @f$ s_k @f$ is the number of sites occupied by species @f$ k @f$. Mass
+ * fractions and the mean molecular weight are then computed in the typical manner.
+ *
+ * The mass density of a surface phase is defined to have units of kg/m². It is computed
+ * as:
+ * @f[
+ *     \rho = \frac{ n_0 \overline{W} }{ \sum X_k s_k }
+ * @f]
+ *
  * ## Specification of Species Standard State Properties
  *
  * It is assumed that the reference state thermodynamics may be obtained by a
@@ -78,10 +94,10 @@ namespace Cantera
  * ## Application within Kinetics Managers
  *
  * The activity concentration,@f$  C^a_k @f$, used by the kinetics manager, is equal to
- * the actual concentration, @f$ C^s_k @f$, and is given by the following
- * expression.
+ * the actual concentration, @f$ C^s_k @f$, and is given as:
  * @f[
  *      C^a_k = C^s_k = \frac{\theta_k  n_0}{s_k}
+ *            = \frac{\rho X_k}{\overline{W}} = \rho \frac{Y_k}{W_k}
  * @f]
  *
  * The standard concentration for species *k* is:
@@ -291,7 +307,10 @@ public:
 
     //! Return a vector of surface coverages
     /*!
-     * Get the coverages.
+     * Get the coverages. These are calculated from the mole fractions as
+     * @f[
+     *   \theta_k = \frac{ X_k s_k }{ \sum X_j s_j }
+     * @f]
      *
      * @param theta Array theta must be at least as long as the number of
      *              species.

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -1181,6 +1181,30 @@ class TestInterfacePhase2:
         X_normalized = surf.X
         assert X_normalized * sum(theta) == approx(X_unnormalized)
 
+    def test_multi_site_density(self, surf):
+        surf.coverages = {"O2(s)": 1.0}  # O2(s) covers two sites
+        assert sum(surf.concentrations) == approx(0.5 * surf.site_density)
+
+        surf.coverages = {"Pt(s)": 1.0}  # Pt(s) covers one site
+        assert sum(surf.concentrations) == approx(surf.site_density)
+
+    def test_finite_difference_derivative(self, surf):
+        theta0 = np.array([0.5, 0.1, 0.1, 0.3])
+        surf.coverages = theta0
+        C0 = surf.concentrations
+        dtheta = 0.01
+
+        for k in range(surf.n_species):
+            theta = theta0.copy()
+            theta[k] += dtheta
+            surf.set_unnormalized_coverages(theta)
+            C = surf.concentrations
+            dC_dtheta = (C - C0) / dtheta
+            assert dC_dtheta[k] == approx(surf.site_density / surf.species(k).size)
+            for j in range(surf.n_species):
+                if j != k:
+                    assert abs(dC_dtheta[j]) < 1e-8 * surf.site_density
+
 
 class TestPlasmaPhase:
     @pytest.fixture(scope='function')


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Revise calculation of density for surface phases to correctly account for species that occupy multiple sites. This affects the concentrations (calculated in `Phase` as $C_k = \rho Y_k / W_k$) which in turn affects reaction rate calculations.

This resolves a regression introduced in #1350 that affects Cantera 3.0 and 3.1. The effect is most noticeable for phases where major species occupy multiple sites, such as in `SiF4_NH3_mec.yaml` where all the species have multiple occupancy.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

- Partially resolves #1996

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
