### PR TITLE
Conserve sum of mass fractions in FlowReactor

### DIFF
--- a/doc/sphinx/reference/reactors/pfr.md
+++ b/doc/sphinx/reference/reactors/pfr.md
@@ -82,7 +82,12 @@ gravitational potential energy are neglected.
 $$
 \rho u \frac{d Y_k}{dz} = - Y_k \dot{m}_s
                           + \dot{\omega}_k W_k + \sum_j \frac{A_{s,j}}{V} \dot{s}_k W_k
+                          + \xi Y_k \sum_j \frac{d Y_j}{dz}
 $$ (pfr-species)
+where the final term imposes the constraint that the sum of mass fractions should be
+constant (and equal to 1) and $\xi = 0.1 \rho u / \epsilon_r$ is a scaling factor to
+balance the magnitude of this term with respect to the other terms in the conservation
+equation.
 
 ## Surface Phase Species Equations
 

--- a/samples/python/reactors/1D_pfr_surfchem.py
+++ b/samples/python/reactors/1D_pfr_surfchem.py
@@ -83,7 +83,7 @@ ax[1, 0].set(xlabel='Distance (m)', ylabel='Velocity (m/s)')
 
 # plot gas density along the flow direction
 ax_rho = ax[1,0].twinx()
-h_rho = ax_rho.plot(soln.x, soln.density * 1000, color='C1', label='density')
+h_rho = ax_rho.plot(soln.x, soln.density / 1000, color='C1', label='density')
 ax_rho.set(ylabel=r'Density ($\mathregular{g/cm^3}$)')
 ax_rho.legend(handles=h_vel+h_rho)
 
@@ -91,7 +91,7 @@ ax_rho.legend(handles=h_vel+h_rho)
 minor_idx = []
 major_idx = []
 for i, name in enumerate(gas.species_names):
-    mean = np.mean(soln(name).Y)
+    mean = np.mean(soln(name).X)
     if mean >= 0.001:
         major_idx.append(i)
     elif mean >= 1e-10:
@@ -99,17 +99,17 @@ for i, name in enumerate(gas.species_names):
 
 # plot major gas species along the flow direction
 for j in major_idx:
-    ax[0, 1].plot(soln.x, soln.Y[:,j], label=gas.species_name(j))
+    ax[0, 1].plot(soln.x, soln.X[:,j], label=gas.species_name(j))
 ax[0, 1].legend(fontsize=8, loc='best')
-ax[0, 1].set(xlabel='Distance (m)', ylabel='Mass Fraction',
+ax[0, 1].set(xlabel='Distance (m)', ylabel='Mole Fraction',
              title='Gas phase major species')
 
 # plot minor gas species along the flow direction
 for k, i in enumerate(minor_idx):
     style = '-' if k < 10 else '--'
-    ax[1, 1].plot(soln.x, soln.Y[:,i], label=gas.species_name(i), linestyle=style)
+    ax[1, 1].plot(soln.x, soln.X[:,i], label=gas.species_name(i), linestyle=style)
 ax[1, 1].legend(fontsize=7.5, loc='best')
-ax[1, 1].set(xlabel='Distance (m)', ylabel='Mass Fraction',
+ax[1, 1].set(xlabel='Distance (m)', ylabel='Mole Fraction',
              title='Gas phase minor species')
 
 # plot the site fraction of the surface species along the flow direction

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -1722,6 +1722,7 @@ class TestFlowReactor:
             net.step()
             i += 1
             assert r.speed * r.density * r.area == approx(10)
+            assert sum(r.phase.Y) == approx(1.0)
 
         stats = net.solver_stats
         assert stats['steps'] == i
@@ -1763,16 +1764,19 @@ class TestFlowReactor:
         X = r.phase['CH4', 'H2', 'CO'].X
         assert X == approx([0.10578801, 0.001654415, 0.012103974])
         assert r.phase.density * r.area * r.speed == approx(mdot)
+        assert sum(r.phase.Y) == approx(1.0)
 
         sim.advance(1e-5)
         X = r.phase['CH4', 'H2', 'CO'].X
         assert X == approx([0.07748481, 0.048165072, 0.01446654])
         assert r.phase.density * r.area * r.speed == approx(mdot)
+        assert sum(r.phase.Y) == approx(1.0)
 
         sim.advance(1e-3)
         X = r.phase['CH4', 'H2', 'CO'].X
         assert X == approx([0.01815402, 0.21603645, 0.045640395])
         assert r.phase.density * r.area * r.speed == approx(mdot)
+        assert sum(r.phase.Y) == approx(1.0)
 
     def test_component_names(self):
         surf = ct.Interface('methane_pox_on_pt.yaml', 'Pt_surf')
@@ -1816,6 +1820,7 @@ class TestFlowReactor2:
         r, rsurf, sim = self.make_reactors(gas, surf)
 
         sim.advance(0.1)
+        assert sum(r.phase.Y) == approx(1.0)
         with pytest.raises(ct.CanteraError, match="backwards in time"):
             sim.advance(0.09)
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Modify species equations in `FlowReactor` to impose a constraint on the sum of the mass fractions (or specifically, that $\frac{d}{dt} \sum Y_k = 0$
- Fix some plotting units in `1D_pfr_surfchem.py` example
- Add a regression test for this example based on the results in the original Sandia report

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

- Resolves #1996

**If applicable, provide an example illustrating new features this pull request is introducing**

Updated plot from `1D_pfr_surfchem.py`

<img width="900" height="600" alt="pfr_output" src="https://github.com/user-attachments/assets/53f7e04d-7c12-40ba-969a-daee50a0298d" />

Note that the scale of variation of the pressure (green line) is ~0.01 Pa.

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
