### PR TITLE
Fix corner cases in installation process

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2070,7 +2070,7 @@ def postInstallMessage(target, source, env):
     if env["installed_docs"]:
         name = "HTML documentation"
         install_message.append(locations_message.format(
-            name="HTML documentation", location=env_dict["inst_docdir"]
+            name="HTML documentation", location=env_dict["ct_docdir"]
         ))
 
     if env["python_package"] == "y":

--- a/SConstruct
+++ b/SConstruct
@@ -793,10 +793,10 @@ if "help" in COMMAND_LINE_TARGETS:
 
         sys.exit(0)
 
-if "sphinx" in COMMAND_LINE_TARGETS or text2bool(ARGUMENTS.get("sphinx_docs", "n")):
-    # need to buffer all options before system-dependent selections are applied
-    windows_options_full = deepcopy(windows_options)
-    config_options_full = deepcopy(config_options)
+# Need to buffer all options before system-dependent selections are applied. Only used
+# for populating Sphinx docs.
+windows_options_full = deepcopy(windows_options)
+config_options_full = deepcopy(config_options)
 
 # **************************************
 # *** Read user-configurable options ***

--- a/SConstruct
+++ b/SConstruct
@@ -1994,7 +1994,7 @@ if env['CC'] != 'cl':
     VariantDir('build/platform', 'platform/posix', duplicate=0)
     SConscript('build/platform/SConscript')
 
-if env['doxygen_docs'] or env['sphinx_docs']:
+if env['doxygen_docs'] or env['sphinx_docs'] or "install" in COMMAND_LINE_TARGETS:
     SConscript('doc/SConscript')
 
 # Sample programs (also used from test_problems/SConscript)
@@ -2067,7 +2067,7 @@ def postInstallMessage(target, source, env):
             name=name, location=env_dict[location]
         ))
 
-    if env["sphinx_docs"] or env["doxygen_docs"]:
+    if env["installed_docs"]:
         name = "HTML documentation"
         install_message.append(locations_message.format(
             name="HTML documentation", location=env_dict["inst_docdir"]

--- a/doc/SConscript
+++ b/doc/SConscript
@@ -133,5 +133,8 @@ if localenv['sphinx_docs']:
     localenv.AlwaysBuild(sphinxdocs)
     if localenv['doxygen_docs']:
         localenv.Depends(sphinxdocs, docs)
-    install(localenv.RecursiveInstall, '$inst_docdir/html',
-            '#build/doc/html', exclude=['\\.map', '\\.md5'])
+
+doc_files = install(localenv.RecursiveInstall, '$inst_docdir',
+                    '#build/doc/html', exclude=['\\.map', '\\.md5'])
+
+env['installed_docs'] = bool(doc_files)

--- a/interfaces/clib/SConscript
+++ b/interfaces/clib/SConscript
@@ -16,7 +16,6 @@ vars = {
 }
 env.Substfile(
     "#build/doc/Doxyfile_xml", "#doc/doxygen/Doxyfile.in", SUBST_DICT=vars)
-logger.info("Generating Doxygen tagfile.")
 tags = env.Command(
         "#build/doc/Cantera.tag", "#build/doc/Doxyfile_xml", "doxygen $SOURCE")
 cxx_files = list(env.Glob("#doc/doxygen/*") +
@@ -44,7 +43,6 @@ install(env.RecursiveInstall, "$inst_incdir/../cantera_clib",
         "#interfaces/clib/include/cantera_clib")
 
 # Run sourcegen without installation
-logger.info("Running sourcegen to generate CLib files.")
 sourcegen = env.Command(
     generated_files,
     tags,

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -184,7 +184,7 @@ if env["stage_dir"]:
     install_cmd.append(f"--root={stage_dir.resolve()}")
 
 install_cmd.extend(("--no-build-isolation", "--no-deps", "-v", "--force-reinstall",
-                    "build/python"))
+                    "$SOURCE"))
 
 mod_inst = install(localenv.Command, "dummy", mod, " ".join(install_cmd))
 env["install_python_action"] = mod_inst

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -85,7 +85,14 @@ build_cmd = ("$python_cmd_esc -m pip wheel -v --no-build-isolation --no-deps "
 # pip's check for a correct version of Python.
 if parse_version(localenv["py_version_short"]) >= env["python_max_version"]:
     build_cmd += " --ignore-requires-python"
-wheel_name = ("Cantera-${cantera_version}-cp${py_version_nodot}"
+
+# Setuptools 75.3.1 and later always lowercase the package name
+if localenv["setuptools_version"] >= parse_version("75.3.1"):
+    pkg_name = "cantera"
+else:
+    pkg_name = "Cantera"
+
+wheel_name = (pkg_name + "-${cantera_version}-cp${py_version_nodot}"
               "-cp${py_version_nodot}-${py_plat}.whl")
 mod = build(localenv.Command(f"#build/python/dist/{wheel_name}", "setup.cfg",
                              build_cmd))

--- a/platform/posix/SConscript
+++ b/platform/posix/SConscript
@@ -47,6 +47,12 @@ localenv["pc_prefix"] = localenv["prefix"]
 localenv["pc_libdirs"] = " ".join(f"-L{dir}" for dir in pc_libdirs if dir)
 localenv["pc_libs"] = " ".join(f"-l{lib}" for lib in pc_libs)
 localenv["pc_cflags"] = " ".join(compiler_flag_list(pc_cflags, env["CC"], flag_excludes))
+if localenv["prefix"] == "/usr":
+    localenv["pc_rpath"] = ""
+    localenv["pc_lib_include"] = "-I${includedir}"
+else:
+    localenv["pc_rpath"] = "-Wl,-rpath,${libdir} "
+    localenv["pc_lib_include"] = " -isystem ${includedir}"
 
 pc = build(localenv.SubstFile("cantera.pc", "cantera.pc.in"))
 install("$inst_libdir/pkgconfig", pc)

--- a/platform/posix/cantera.pc.in
+++ b/platform/posix/cantera.pc.in
@@ -8,5 +8,5 @@ Description: Cantera library
 URL: https://cantera.org
 Version: @cantera_version@
 
-Libs: -L${libdir} -Wl,-rpath,${libdir} @pc_libdirs@ @pc_libs@
-Cflags: @pc_cflags@ -isystem ${includedir}
+Libs: -L${libdir} @pc_rpath@ @pc_libdirs@ @pc_libs@
+Cflags: @pc_lib_include@ @pc_cflags@

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -1298,12 +1298,14 @@ def setup_python_env(env):
         import json
         import site
         import sys
+        import setuptools
         vars = get_config_vars()
         vars["plat"] = get_platform()
         vars["numpy_include"] = numpy.get_include()
         vars["site_packages"] = [d for d in site.getsitepackages() if d.endswith("-packages")]
         vars["user_site_packages"] = site.getusersitepackages()
         vars["abiflags"] = getattr(sys, "abiflags", "")
+        vars["setuptools_version"] = setuptools.__version__
         print(json.dumps(vars))
         """)
         _python_info = json.loads(get_command_output(env["python_cmd"], "-c", script))
@@ -1331,6 +1333,7 @@ def setup_python_env(env):
     env["py_base"] = info["installed_base"]
     env["site_packages"] = info["site_packages"]
     env["user_site_packages"] = info["user_site_packages"]
+    env["setuptools_version"] = parse_version(info["setuptools_version"])
     if env["OS"] != "Windows":
         env["py_libpath"] = [info["LIBPL"], info["LIBDIR"]]
         py_lib = "python" + info["py_version_short"] + info["abiflags"]


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix building/installing when `sphinx_docs=y` is specified via `cantera.conf`
- Install docs when running `scons install` after previously running `scons doxygen sphinx` (as opposed to using the sticky `sphinx_docs=y and doxygen_docs=y` options)
- Avoid adding `-isystem /usr` to pkg-config compiler flags, which can break the compilation
- Avoid unnecessarily rebuilding the Python wheel during `scons install`
- Fix incremental builds always rebuilding the Python wheel on Linux (or other OSes with fully case-sensitive filesystems)

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

- Resolves #1871 
- Resolves #1802
- Resolves #2032

**Checklist**

- [x] The pull request includes a clear description of this code change
- [X] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
