### PR TITLE
Fix handling of empty SpeciesThermo objects in Python

### DIFF
--- a/interfaces/cython/cantera/speciesthermo.pyx
+++ b/interfaces/cython/cantera/speciesthermo.pyx
@@ -7,7 +7,7 @@ import numpy as np
 from ._utils cimport *
 from .constants import gas_constant
 
-# These match the definitions in speciesThermoTyeps.h
+# These match the definitions in speciesThermoTypes.h
 cdef int SPECIES_THERMO_CONSTANT_CP = 1
 cdef int SPECIES_THERMO_NASA2 = 4
 cdef int SPECIES_THERMO_SHOMATE2 = 8
@@ -269,7 +269,7 @@ cdef wrapSpeciesThermo(shared_ptr[CxxSpeciesThermo] spthermo):
     elif thermo_type == SPECIES_THERMO_SHOMATE2:
         st = ShomatePoly2(init=False)
     else:
-        st = SpeciesThermo()
+        return None
 
     st._assign(spthermo)
     return st

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -1750,6 +1750,10 @@ class TestSpeciesThermo:
             assert st.h(T) == approx(st2.h(T))
             assert st.s(T) == approx(st2.s(T))
 
+def test_null_species_thermo():
+    # Some species don't use a SpeciesThermoInterp object
+    liq = ct.Solution('debye-huckel-all.yaml', 'debye-huckel-B-dot-ak-IAPWS')
+    assert liq.species('H2O(L)').thermo is None
 
 @pytest.fixture(scope='class')
 def setup_quantity_tests(request):


### PR DESCRIPTION
Fixes #1980

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Modify `Species.thermo` to return `None` when the species holds a pointer to an empty base class `SpeciesThermoInterpType` instance. This is equivalent to the way a `nullptr` for the `SpeciesThermoInterpType` is handled.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

- Fixes #1980 

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
