### PR TITLE
Deprecate various unused / redundant functions

### DIFF
--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -1256,6 +1256,7 @@ public:
     /*!
      *  @param[out] conc  Vector of activity concentrations. Length is equal
      *               to the number of species in the kinetics object
+     *  @deprecated  To be removed after %Cantera 3.2.
      */
     virtual void getActivityConcentrations(double* const conc) {
         throw NotImplementedError("Kinetics::getActivityConcentrations");

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -268,6 +268,7 @@ protected:
 //! Create a new empty Reaction object
 /*!
  * @param type string identifying type of reaction.
+ * @deprecated  To be removed after %Cantera 3.2.
  */
 unique_ptr<Reaction> newReaction(const string& type);
 

--- a/include/cantera/numerics/BandMatrix.h
+++ b/include/cantera/numerics/BandMatrix.h
@@ -141,6 +141,7 @@ public:
      *
      * @returns a success flag. 0 indicates a success; ~0 indicates some
      *         error occurred, see the LAPACK documentation
+     * @deprecated After %Cantera 3.2, the return type will be `void`
      */
     int factor() override;
 
@@ -150,6 +151,7 @@ public:
      * @param x  OUTPUT solution to the problem
      * @return a success flag. 0 indicates a success; ~0 indicates some error
      *     occurred, see the LAPACK documentation
+     * @deprecated After %Cantera 3.2, the return type will be `void`
      */
     int solve(const double* const b, double* const x);
 
@@ -161,6 +163,7 @@ public:
      * @param ldb   Leading dimension of `b`. Default is nColumns()
      * @returns a success flag. 0 indicates a success; ~0 indicates some error
      *     occurred, see the LAPACK documentation
+     * @deprecated After %Cantera 3.2, the return type will be `void`
      */
     int solve(double* b, size_t nrhs=1, size_t ldb=0) override;
 

--- a/include/cantera/numerics/DenseMatrix.h
+++ b/include/cantera/numerics/DenseMatrix.h
@@ -36,6 +36,10 @@ namespace Cantera
  * The dense matrix class adds matrix operations onto the Array2D class. These
  * matrix operations are carried out by the appropriate BLAS and LAPACK routines
  *
+ * @deprecated After %Cantera 3.2, all errors will be handled by throwing exceptions.
+ *     The #m_useReturnErrorCode and #m_printLevel member variables will be removed,
+ *     and the `solve` and `invert` methods will be changed to return `void`.
+ *
  * Error handling from BLAS and LAPACK are handled via the following
  * formulation. Depending on a variable, a singular matrix or other terminal
  * error condition from LAPACK is handled by either throwing an exception or
@@ -140,6 +144,8 @@ public:
      * this is set to 1, then an exception is not thrown. Routines return with
      * an error code, that is up to the calling routine to handle correctly.
      * Negative return codes always throw an exception.
+     *
+     * @deprecated To be removed after %Cantera 3.2. Errors always throw exceptions.
      */
     int m_useReturnErrorCode = 0;
 
@@ -149,6 +155,7 @@ public:
      *
      * Level of printing that is carried out. Only error conditions are printed
      * out, if this value is nonzero.
+     * @deprecated To be removed after %Cantera 3.2. Errors always throw exceptions.
      */
     int m_printLevel = 0;
 };
@@ -172,6 +179,7 @@ public:
  * @param b    RHS(s) to be solved.
  * @param nrhs Number of right hand sides to solve
  * @param ldb  Leading dimension of b, if nrhs > 1
+ * @deprecated After %Cantera 3.2, the return type will be `void`.
  */
 int solve(DenseMatrix& A, double* b, size_t nrhs=1, size_t ldb=0);
 
@@ -179,6 +187,7 @@ int solve(DenseMatrix& A, double* b, size_t nrhs=1, size_t ldb=0);
 /*!
  * @param A   Dense matrix to be factored
  * @param b   Dense matrix of RHS's. Each column is a RHS
+ * @deprecated After %Cantera 3.2, the return type will be `void`.
  */
 int solve(DenseMatrix& A, DenseMatrix& b);
 
@@ -211,6 +220,7 @@ void increment(const DenseMatrix& A, const double* const b, double* const prod);
  *  @param A   Invert the matrix A and store it back in place
  *  @param nn  Size of A. This defaults to -1, which means that the number of
  *             rows is used as the default size of n
+ *  @deprecated After %Cantera 3.2, the return type will be `void`.
  */
 int invert(DenseMatrix& A, size_t nn=npos);
 

--- a/include/cantera/numerics/GeneralMatrix.h
+++ b/include/cantera/numerics/GeneralMatrix.h
@@ -109,6 +109,7 @@ public:
      * @param nrhs Number of right-hand sides to solve, default 1
      * @param ldb  Leading dimension of the right-hand side array. Defaults to
      *              nRows()
+     * @deprecated After %Cantera 3.2, the return type will be `void`
      */
     virtual int solve(double* b, size_t nrhs=1, size_t ldb=0) = 0;
 

--- a/include/cantera/numerics/SteadyStateSystem.h
+++ b/include/cantera/numerics/SteadyStateSystem.h
@@ -68,7 +68,7 @@ public:
     //! - -2 failure (maximum number of damping steps was reached)
     //! - -3 failure (solution was up against the bounds
     //!
-    //! @deprecated To be removed after Cantera 3.2. Use setInitialGuess(), solve(int),
+    //! @deprecated To be removed after %Cantera 3.2. Use setInitialGuess(), solve(int),
     //!     and getState() instead.
     int solve(double* x0, double* x1, int loglevel);
 

--- a/include/cantera/numerics/SystemJacobian.h
+++ b/include/cantera/numerics/SystemJacobian.h
@@ -225,7 +225,7 @@ protected:
     string m_precon_side = "none";
 };
 
-//! @deprecated To be removed after Cantera 3.2. Renamed to SystemJacobian.
+//! @deprecated To be removed after %Cantera 3.2. Renamed to SystemJacobian.
 class PreconditionerBase : public SystemJacobian
 {
     PreconditionerBase() {

--- a/include/cantera/oneD/Flow1D.h
+++ b/include/cantera/oneD/Flow1D.h
@@ -283,29 +283,29 @@ public:
 
     //! Get the solving stage (used by IonFlow specialization)
     //! @since New in %Cantera 3.0
-    //! @deprecated To be removed after Cantera 3.2. Use doElectricField() instead.
+    //! @deprecated To be removed after %Cantera 3.2. Use doElectricField() instead.
     virtual size_t getSolvingStage() const;
 
     //! Solving stage mode for handling ionized species (used by IonFlow specialization)
     //! - @c stage=1: the fluxes of charged species are set to zero
     //! - @c stage=2: the electric field equation is solved, and the drift flux for
     //!     ionized species is evaluated
-    //! @deprecated To be removed after Cantera 3.2. Use solveElectricField() instead.
+    //! @deprecated To be removed after %Cantera 3.2. Use solveElectricField() instead.
     virtual void setSolvingStage(const size_t stage);
 
     //! Set to solve electric field in a point (used by IonFlow specialization)
-    //! @deprecated After Cantera 3.2, the argument will be removed; the option of
+    //! @deprecated After %Cantera 3.2, the argument will be removed; the option of
     //!     solving the electric field applies to the whole domain.
     virtual void solveElectricField(size_t j=npos);
 
     //! Set to fix voltage in a point (used by IonFlow specialization)
-    //! @deprecated After Cantera 3.2, the argument will be removed; the option of
+    //! @deprecated After %Cantera 3.2, the argument will be removed; the option of
     //!     solving the electric field applies to the whole domain.
     virtual void fixElectricField(size_t j=npos);
 
     //! Retrieve flag indicating whether electric field is solved or not (used by
     //! IonFlow specialization)
-    //! @deprecated After Cantera 3.2, the argument will be removed; the option of
+    //! @deprecated After %Cantera 3.2, the argument will be removed; the option of
     //!     solving the electric field applies to the whole domain.
     virtual bool doElectricField(size_t j=npos) const;
 

--- a/include/cantera/oneD/OneDim.h
+++ b/include/cantera/oneD/OneDim.h
@@ -35,7 +35,7 @@ public:
     //! Add a domain. Domains are added left-to-right.
     void addDomain(shared_ptr<Domain1D> d);
 
-    //! @deprecated To be removed after Cantera 3.2. Use linearSolver() instead.
+    //! @deprecated To be removed after %Cantera 3.2. Use linearSolver() instead.
     shared_ptr<SystemJacobian> getJacobian() {
         warn_deprecated("OneDim::getJacobian",
                         "To be removed after Cantera 3.2. Use linearSolver() instead.");
@@ -65,7 +65,7 @@ public:
     double weightedNorm(const double* step) const override;
 
     //! Return a reference to the Jacobian evaluator of an OneDim object.
-    //! @deprecated To be removed after Cantera 3.2. Superseded by linearSolver()
+    //! @deprecated To be removed after %Cantera 3.2. Superseded by linearSolver()
     //! @ingroup derivGroup
     MultiJac& jacobian();
 

--- a/include/cantera/thermo/CoverageDependentSurfPhase.h
+++ b/include/cantera/thermo/CoverageDependentSurfPhase.h
@@ -295,6 +295,8 @@ public:
      * @f[
      *      g^o_k(T,\theta) = h^o_k(T,\theta) + Ts^o_k(T,\theta)
      * @f]
+     * @deprecated  To be removed after %Cantera 3.2. Use getStandardChemPotentials()
+     *     instead.
      */
     void getPureGibbs(double* g) const override;
 

--- a/include/cantera/thermo/IdealSolidSolnPhase.h
+++ b/include/cantera/thermo/IdealSolidSolnPhase.h
@@ -359,9 +359,7 @@ public:
      * @param mu0   Output vector of standard state chemical potentials.
      *              Length: m_kk.
      */
-    void getStandardChemPotentials(double* mu0) const override {
-        getPureGibbs(mu0);
-    }
+    void getStandardChemPotentials(double* mu0) const override;
 
     //! Get the array of nondimensional Enthalpy functions for the standard
     //! state species at the current *T* and *P* of the solution.
@@ -418,6 +416,8 @@ public:
      * the reference pressure, @f$ P_{ref} @f$.
      *
      * @param gpure  Output vector of Gibbs functions for species. Length: m_kk.
+     * @deprecated  To be removed after %Cantera 3.2. Use getStandardChemPotentials()
+     *     instead.
      */
     void getPureGibbs(double* gpure) const override;
 

--- a/include/cantera/thermo/LatticePhase.h
+++ b/include/cantera/thermo/LatticePhase.h
@@ -19,7 +19,7 @@ namespace Cantera
 //! A simple thermodynamic model for a bulk phase, assuming a lattice of solid
 //! atoms
 /*!
- * @deprecated To be removed after Cantera 3.2. Can be replaced by use of
+ * @deprecated To be removed after %Cantera 3.2. Can be replaced by use of
  *     IdealSolidSolnPhase with the site density used to set the molar density of each
  *     constituent species.
  *

--- a/include/cantera/thermo/LatticeSolidPhase.h
+++ b/include/cantera/thermo/LatticeSolidPhase.h
@@ -19,7 +19,7 @@ namespace Cantera
 //! A phase that is comprised of a fixed additive combination of other lattice
 //! phases
 /*!
- * @deprecated To be removed after Cantera 3.2. No known usage exists, and the model
+ * @deprecated To be removed after %Cantera 3.2. No known usage exists, and the model
  *     does not satisfy several basic thermodynamic identities.
  *     See https://github.com/Cantera/cantera/issues/1310.
  *

--- a/include/cantera/thermo/MixtureFugacityTP.h
+++ b/include/cantera/thermo/MixtureFugacityTP.h
@@ -421,6 +421,7 @@ public:
     //! liquid side) for the current temperature.
     /*!
      * @returns the density with units of kg m-3
+     * @deprecated To be removed after %Cantera 3.1.
      */
     virtual double densSpinodalLiquid() const;
 
@@ -428,6 +429,7 @@ public:
     //! side) for the current temperature.
     /*!
      * @returns the density with units of kg m-3
+     * @deprecated To be removed after %Cantera 3.1.
      */
     virtual double densSpinodalGas() const;
 

--- a/include/cantera/thermo/MixtureFugacityTP.h
+++ b/include/cantera/thermo/MixtureFugacityTP.h
@@ -179,6 +179,8 @@ public:
      *
      * @param[out] gpure   Array of standard state Gibbs free energies. length =
      *     m_kk. units are J/kmol.
+     * @deprecated  To be removed after %Cantera 3.2. Use getStandardChemPotentials()
+     *     instead.
      */
     void getPureGibbs(double* gpure) const override;
 

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -953,6 +953,8 @@ public:
      * Units are Joules/kmol
      * @param gpure  Output vector of standard state Gibbs free energies.
      *               Length: m_kk.
+     * @deprecated  To be removed after %Cantera 3.2. Use getStandardChemPotentials()
+     *     instead.
      */
     virtual void getPureGibbs(double* gpure) const {
         throw NotImplementedError("ThermoPhase::getPureGibbs",

--- a/include/cantera/thermo/VPStandardStateTP.h
+++ b/include/cantera/thermo/VPStandardStateTP.h
@@ -191,11 +191,6 @@ public:
 
     void getEnthalpy_RT_ref(double* hrt) const override;
     void getGibbs_RT_ref(double* grt) const override;
-
-protected:
-    const vector<double>& Gibbs_RT_ref() const;
-
-public:
     void getGibbs_ref(double* g) const override;
     void getEntropy_R_ref(double* er) const override;
     void getCp_R_ref(double* cprt) const override;

--- a/include/cantera/thermo/WaterPropsIAPWS.h
+++ b/include/cantera/thermo/WaterPropsIAPWS.h
@@ -253,6 +253,7 @@ public:
      * @param rhoguess    guessed density of the water; -1.0: no guessed density
      * @returns the density. If an error is encountered in the calculation the
      *     value of -1.0 is returned.
+     * @deprecated To be removed after %Cantera 3.1.
      */
     double density_const(double pressure, int phase = -1, double rhoguess = -1.0) const;
 
@@ -341,6 +342,7 @@ public:
     //! liquid side) for the current temperature.
     /*!
      * @returns the density with units of kg m-3
+     * @deprecated To be removed after %Cantera 3.1.
      */
     double densSpinodalWater() const;
 
@@ -348,6 +350,7 @@ public:
     //! side) for the current temperature.
     /*!
      * @returns the density with units of kg m-3
+     * @deprecated To be removed after %Cantera 3.1.
      */
     double densSpinodalSteam() const;
 

--- a/include/cantera/thermo/WaterPropsIAPWS.h
+++ b/include/cantera/thermo/WaterPropsIAPWS.h
@@ -408,17 +408,6 @@ private:
     void corr(double temperature, double pressure, double& densLiq,
               double& densGas, double& delGRT);
 
-    //! Utility routine in the calculation of the saturation pressure
-    /*!
-     * @param temperature    temperature (kelvin)
-     * @param pressure       pressure (Pascal)
-     * @param densLiq        Output density of liquid
-     * @param densGas        output Density of gas
-     * @param pcorr          output corrected pressure
-     */
-    void corr1(double temperature, double pressure, double& densLiq,
-               double& densGas, double& pcorr);
-
     //! pointer to the underlying object that does the calculations.
     mutable WaterPropsIAPWSphi m_phi;
 

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -252,7 +252,7 @@ public:
     virtual void syncState();
 
     //! return a reference to the contents.
-    //! @deprecated  To be removed after Cantera 3.2. Replaceable by
+    //! @deprecated  To be removed after %Cantera 3.2. Replaceable by
     //!     ReactorBase->phase()->thermo().
     ThermoPhase& contents() {
         warn_deprecated("ReactorBase::contents", "To be removed after Cantera 3.2. "
@@ -265,7 +265,7 @@ public:
     }
 
     //! return a reference to the contents.
-    //! @deprecated  To be removed after Cantera 3.2. Replaceable by
+    //! @deprecated  To be removed after %Cantera 3.2. Replaceable by
     //!     ReactorBase->phase()->thermo().
     const ThermoPhase& contents() const {
         warn_deprecated("ReactorBase::contents", "To be removed after Cantera 3.2. "

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -37,11 +37,11 @@ public:
                    bool clone,
                    const string& name="(none)");
 
-    //! @deprecated To be removed after Cantera 3.2. Replaced by constructor where
+    //! @deprecated To be removed after %Cantera 3.2. Replaced by constructor where
     //!    contents and adjacent reactors are specified
     ReactorSurface(shared_ptr<Solution> sol, const string& name="(none)");
 
-    //! @deprecated To be removed after Cantera 3.2. Replaced by constructor where
+    //! @deprecated To be removed after %Cantera 3.2. Replaced by constructor where
     //!    contents and adjacent reactors are specified
     ReactorSurface(shared_ptr<Solution> sol, bool clone, const string& name="(none)");
 

--- a/interfaces/cython/cantera/utils.py
+++ b/interfaces/cython/cantera/utils.py
@@ -21,5 +21,8 @@ def add_module_directory() -> None:
     """
     Add the directory containing the module from which this function is called
     to the Cantera input file search path.
+
+    .. deprecated:: 3.2
+       To be removed after Cantera 3.2.
     """
     add_data_directory(os.path.dirname(os.path.abspath(_inspect.stack()[1][1])))

--- a/interfaces/cython/cantera/utils.py
+++ b/interfaces/cython/cantera/utils.py
@@ -9,10 +9,15 @@ from pathlib import Path
 from ._utils import add_data_directory
 from .composite import Solution
 
+# TODO: remove this module after Cantera 3.2.
+
 def import_phases(filename: Path | str, phase_names: _Iterable[str]) -> list[Solution]:
     """
     Import multiple phases from one file. The phase names should be
     entered as a list of strings.
+
+    .. deprecated:: 3.2
+       To be removed after Cantera 3.2.
     """
     return [Solution(filename, p) for p in phase_names]
 

--- a/samples/python/kinetics/sofc.py
+++ b/samples/python/kinetics/sofc.py
@@ -33,8 +33,6 @@ import pandas as pd
 import matplotlib.pyplot as plt
 from scipy.optimize import newton
 
-ct.add_module_directory()
-
 # parameters
 T = 1073.15  # T in K
 P = ct.one_atm  # One atm in Pa

--- a/samples/python/thermo/plasma_equilibrium.py
+++ b/samples/python/thermo/plasma_equilibrium.py
@@ -22,10 +22,9 @@ import csv
 # is a mixture of multiple species, and the condensed phases are all modeled
 # as incompressible stoichiometric substances. See file KOH.yaml for more
 # information.
-phases = ct.import_phases('KOH.yaml', ['K_solid', 'K_liquid', 'KOH_a', 'KOH_b',
-                                       'KOH_liquid', 'K2O2_solid', 'K2O_solid',
-                                       'KO2_solid', 'ice', 'liquid_water',
-                                       'KOH_plasma'])
+phase_names = ['K_solid', 'K_liquid', 'KOH_a', 'KOH_b', 'KOH_liquid', 'K2O2_solid',
+               'K2O_solid', 'KO2_solid', 'ice', 'liquid_water', 'KOH_plasma']
+phases = [ct.Solution('KOH.yaml', name) for name in phase_names]
 
 # create the Mixture object from the list of phases
 mix = ct.Mixture(phases)

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -110,6 +110,8 @@ void InterfaceKinetics::_update_rates_C()
 
 void InterfaceKinetics::getActivityConcentrations(double* const conc)
 {
+    warn_deprecated("InterfaceKinetics::getActivityConcentrations",
+        "To be removed after Cantera 3.2.");
     _update_rates_C();
     copy(m_actConc.begin(), m_actConc.end(), conc);
 }

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -884,6 +884,7 @@ bool ThirdBody::checkSpecies(const Reaction& rxn, const Kinetics& kin) const
 
 unique_ptr<Reaction> newReaction(const string& type)
 {
+    warn_deprecated("newReaction(string)", "To be removed after Cantera 3.2.");
     return make_unique<Reaction>();
 }
 

--- a/src/numerics/DenseMatrix.cpp
+++ b/src/numerics/DenseMatrix.cpp
@@ -132,6 +132,14 @@ vector<int>& DenseMatrix::ipiv()
 
 int solve(DenseMatrix& A, double* b, size_t nrhs, size_t ldb)
 {
+    if (A.m_printLevel) {
+        warn_deprecated("DenseMatrix::m_printLevel",
+                        "To be removed after Cantera 3.2.");
+    }
+    if (A.m_useReturnErrorCode) {
+        warn_deprecated("DenseMatrix::m_useReturnErrorCode",
+                        "To be removed after Cantera 3.2.");
+    }
     if (A.nColumns() != A.nRows()) {
         if (A.m_printLevel) {
             writelogf("solve(DenseMatrix& A, double* b): Can only solve a square matrix\n");
@@ -225,6 +233,14 @@ void increment(const DenseMatrix& A, const double* b, double* prod)
 
 int invert(DenseMatrix& A, size_t nn)
 {
+    if (A.m_printLevel) {
+        warn_deprecated("DenseMatrix::m_printLevel",
+                        "To be removed after Cantera 3.2.");
+    }
+    if (A.m_useReturnErrorCode) {
+        warn_deprecated("DenseMatrix::m_useReturnErrorCode",
+                        "To be removed after Cantera 3.2.");
+    }
     int info=0;
     #if CT_USE_LAPACK
         integer n = static_cast<int>(nn != npos ? nn : A.nRows());

--- a/src/thermo/CoverageDependentSurfPhase.cpp
+++ b/src/thermo/CoverageDependentSurfPhase.cpp
@@ -382,6 +382,8 @@ void CoverageDependentSurfPhase::getGibbs_RT(double* grt) const
 
 void CoverageDependentSurfPhase::getPureGibbs(double* g) const
 {
+    warn_deprecated("CoverageDependentSurfPhase::getPureGibbs",
+        "To be removed after Cantera 3.2. Use getStandardChemPotentials instead.");
     getGibbs_RT(g);
     for (size_t k = 0; k < m_kk; k++) {
         g[k] *= RT();

--- a/src/thermo/IdealGasPhase.cpp
+++ b/src/thermo/IdealGasPhase.cpp
@@ -144,6 +144,8 @@ void IdealGasPhase::getGibbs_RT(double* grt) const
 
 void IdealGasPhase::getPureGibbs(double* gpure) const
 {
+    warn_deprecated("IdealGasPhase::getPureGibbs",
+        "To be removed after Cantera 3.2. Use getStandardChemPotentials instead.");
     const vector<double>& gibbsrt = gibbs_RT_ref();
     scale(gibbsrt.begin(), gibbsrt.end(), gpure, RT());
     double tmp = log(pressure() / refPressure()) * RT();

--- a/src/thermo/IdealSolidSolnPhase.cpp
+++ b/src/thermo/IdealSolidSolnPhase.cpp
@@ -164,10 +164,17 @@ void IdealSolidSolnPhase::getPartialMolarVolumes(double* vbar) const
 
 void IdealSolidSolnPhase::getPureGibbs(double* gpure) const
 {
+    warn_deprecated("IdealSolidSolnPhase::getPureGibbs",
+        "To be removed after Cantera 3.2. Use getStandardChemPotentials instead.");
+        getStandardChemPotentials(gpure);
+}
+
+void IdealSolidSolnPhase::getStandardChemPotentials(double* g0) const
+{
     const vector<double>& gibbsrt = gibbs_RT_ref();
     double delta_p = (m_Pcurrent - m_Pref);
     for (size_t k = 0; k < m_kk; k++) {
-        gpure[k] = RT() * gibbsrt[k] + delta_p * m_speciesMolarVolume[k];
+        g0[k] = RT() * gibbsrt[k] + delta_p * m_speciesMolarVolume[k];
     }
 }
 

--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -91,6 +91,9 @@ void MixtureFugacityTP::getGibbs_RT(double* grt) const
 
 void MixtureFugacityTP::getPureGibbs(double* g) const
 {
+    warn_deprecated("MixtureFugacityTP::getPureGibbs",
+        "To be removed after Cantera 3.2. Use getStandardChemPotentials instead.");
+
     scale(m_g0_RT.begin(), m_g0_RT.end(), g, RT());
     double tmp = log(pressure() / refPressure()) * RT();
     for (size_t k = 0; k < m_kk; k++) {

--- a/src/thermo/PengRobinson.cpp
+++ b/src/thermo/PengRobinson.cpp
@@ -560,6 +560,8 @@ double PengRobinson::densityCalc(double T, double presPa, int phaseRequested,
 
 double PengRobinson::densSpinodalLiquid() const
 {
+    warn_deprecated("PengRobinson::densSpinodalLiquid",
+                    "To be removed after Cantera 3.1.");
     double Vroot[3];
     double T = temperature();
     int nsol = solveCubic(T, pressure(), m_a, m_b, m_aAlpha_mix, Vroot);
@@ -582,6 +584,8 @@ double PengRobinson::densSpinodalLiquid() const
 
 double PengRobinson::densSpinodalGas() const
 {
+    warn_deprecated("PengRobinson::densSpinodalGas",
+                    "To be removed after Cantera 3.1.");
     double Vroot[3];
     double T = temperature();
     int nsol = solveCubic(T, pressure(), m_a, m_b, m_aAlpha_mix, Vroot);

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -624,6 +624,8 @@ double RedlichKwongMFTP::densityCalc(double TKelvin, double presPa, int phaseReq
 
 double RedlichKwongMFTP::densSpinodalLiquid() const
 {
+    warn_deprecated("RedlichKwongMFTP::densSpinodalLiquid",
+                    "To be removed after Cantera 3.1.");
     double Vroot[3];
     double T = temperature();
     int nsol = solveCubic(T, pressure(), m_a_current, m_b_current, Vroot);
@@ -646,6 +648,8 @@ double RedlichKwongMFTP::densSpinodalLiquid() const
 
 double RedlichKwongMFTP::densSpinodalGas() const
 {
+    warn_deprecated("RedlichKwongMFTP::densSpinodalGas",
+                    "To be removed after Cantera 3.1.");
     double Vroot[3];
     double T = temperature();
     int nsol = solveCubic(T, pressure(), m_a_current, m_b_current, Vroot);

--- a/src/thermo/SingleSpeciesTP.cpp
+++ b/src/thermo/SingleSpeciesTP.cpp
@@ -119,6 +119,8 @@ void SingleSpeciesTP::getPartialMolarVolumes(double* vbar) const
 
 void SingleSpeciesTP::getPureGibbs(double* gpure) const
 {
+    warn_deprecated("SingleSpeciesTP::getPureGibbs",
+        "To be removed after Cantera 3.2. Use getStandardChemPotentials instead.");
     getGibbs_RT(gpure);
     gpure[0] *= RT();
 }

--- a/src/thermo/SurfPhase.cpp
+++ b/src/thermo/SurfPhase.cpp
@@ -127,6 +127,8 @@ double SurfPhase::logStandardConc(size_t k) const
 
 void SurfPhase::getPureGibbs(double* g) const
 {
+    warn_deprecated("SurfPhase::getPureGibbs",
+        "To be removed after Cantera 3.2. Use getStandardChemPotentials instead.");
     _updateThermo();
     copy(m_mu0.begin(), m_mu0.end(), g);
 }

--- a/src/thermo/VPStandardStateTP.cpp
+++ b/src/thermo/VPStandardStateTP.cpp
@@ -117,12 +117,6 @@ void VPStandardStateTP::getGibbs_ref(double* g) const
     scale(g, g+m_kk, g, RT());
 }
 
-const vector<double>& VPStandardStateTP::Gibbs_RT_ref() const
-{
-    updateStandardStateThermo();
-    return m_g0_RT;
-}
-
 void VPStandardStateTP::getEntropy_R_ref(double* sr) const
 {
     updateStandardStateThermo();

--- a/src/thermo/VPStandardStateTP.cpp
+++ b/src/thermo/VPStandardStateTP.cpp
@@ -63,6 +63,8 @@ void VPStandardStateTP::getGibbs_RT(double* grt) const
 
 void VPStandardStateTP::getPureGibbs(double* g) const
 {
+    warn_deprecated("VPStandardStateTP::getPureGibbs",
+        "To be removed after Cantera 3.2. Use getStandardChemPotentials instead.");
     updateStandardStateThermo();
     std::copy(m_gss_RT.begin(), m_gss_RT.end(), g);
     scale(g, g+m_kk, g, RT());

--- a/src/thermo/WaterPropsIAPWS.cpp
+++ b/src/thermo/WaterPropsIAPWS.cpp
@@ -113,6 +113,8 @@ double WaterPropsIAPWS::density(double temperature, double pressure,
 
 double WaterPropsIAPWS::density_const(double pressure, int phase, double rhoguess) const
 {
+    warn_deprecated("WaterPropsIAPWS::density_const",
+        "To be removed after Cantera 3.1.");
     double temperature = T_c / tau;
     double deltaGuess = 0.0;
     double deltaSave = delta;
@@ -334,6 +336,8 @@ int WaterPropsIAPWS::phaseState(bool checkState) const
 
 double WaterPropsIAPWS::densSpinodalWater() const
 {
+    warn_deprecated("WaterPropsIAPWS::densSpinodalWater",
+        "To be removed after Cantera 3.1.");
     double temperature = T_c/tau;
     double delta_save = delta;
     // return the critical density if we are above or even just a little below
@@ -422,6 +426,8 @@ double WaterPropsIAPWS::densSpinodalWater() const
 
 double WaterPropsIAPWS::densSpinodalSteam() const
 {
+    warn_deprecated("WaterPropsIAPWS::densSpinodalSteam",
+        "To be removed after Cantera 3.1.");
     double temperature = T_c/tau;
     double delta_save = delta;
     // return the critical density if we are above or even just a little below

--- a/src/zeroD/ConnectorFactory.cpp
+++ b/src/zeroD/ConnectorFactory.cpp
@@ -68,7 +68,7 @@ shared_ptr<FlowDevice> newFlowDevice(
 shared_ptr<FlowDevice> newFlowDevice(const string& model, const string& name)
 {
     warn_deprecated("newFlowDevice",
-                    "After Cantera 3.1, Reactors must be provided as parameters.");
+                    "After Cantera 3.2, Reactors must be provided as parameters.");
     return newFlowDevice(model, nullptr, nullptr, name);
 }
 
@@ -88,7 +88,7 @@ shared_ptr<WallBase> newWall(
 shared_ptr<WallBase> newWall(const string& model, const string& name)
 {
     warn_deprecated("newWall",
-                    "After Cantera 3.1, Reactors must be provided as parameters.");
+                    "After Cantera 3.2, Reactors must be provided as parameters.");
     return newWall(model, nullptr, nullptr, name);
 }
 

--- a/test/python/test_equilibrium.py
+++ b/test/python/test_equilibrium.py
@@ -155,10 +155,9 @@ class TestVCS_EquilTest(EquilTestCases):
 
 @pytest.fixture(scope='function')
 def koh_equil(request):
-    phases = ct.import_phases("KOH.yaml",
-            ['K_solid', 'K_liquid', 'KOH_a', 'KOH_b', 'KOH_liquid',
-             'K2O2_solid', 'K2O_solid', 'KO2_solid', 'ice', 'liquid_water',
-             'KOH_plasma'])
+    phase_names = ['K_solid', 'K_liquid', 'KOH_a', 'KOH_b', 'KOH_liquid', 'K2O2_solid',
+                'K2O_solid', 'KO2_solid', 'ice', 'liquid_water', 'KOH_plasma']
+    phases = [ct.Solution('KOH.yaml', name) for name in phase_names]
     request.cls.mix = ct.Mixture(phases)
 
 @pytest.mark.usefixtures('koh_equil')

--- a/test/python/test_kinetics.py
+++ b/test/python/test_kinetics.py
@@ -1052,8 +1052,10 @@ class TestLithiumIonBatteryKinetics:
                     return x0
 
         # Phases
-        anode, cathode, metal, electrolyte = ct.import_phases(
-            mech, ["anode", "cathode", "electron", "electrolyte"])
+        anode = ct.Solution(mech, "anode")
+        cathode = ct.Solution(mech, "cathode")
+        metal = ct.Solution(mech, "electron")
+        electrolyte = ct.Solution(mech, "electrolyte")
         anode_int = ct.Interface(
             mech, "edge_anode_electrolyte", adjacent=[anode, metal, electrolyte])
         cathode_int = ct.Interface(


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

Deprecating some methods that are either redundant or rarely if ever used. Deleting a couple of unused internal methods. Specifically

- Delete unreachable `WaterPropsIAPWS::corr1` method
- Deprecate unnecessary methods of `WaterPropsIAPWS`: `density_const`, `densSpinodalWater`, `densSpinodalSteam`.
- Deprecate `MixtureFugacityTP::densSpinodalLiquid` and `densSpinodalGas`
- Deprecate `ThermoPhase::getPureGibbs` method which mirrors `getStandardChemPotentials`
- Deprecate `Kinetics::getActivityConcentrations` -- these should be accessed via `ThermoPhase`
- Deprecate unused `newReaction(string)` constructor for creating "empty" reactions.
- Deprecate option of using integer return codes instead of exceptions for matrix operation errors in `BandMatrix` and `DenseMatrix`
- Deprecate Python methods `add_module_directory` and `import_phases`

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
