### PR TITLE
Mark Fortran experimental and add MATLAB doc fixes

### DIFF
--- a/doc/sphinx/matlab/constants.rst
+++ b/doc/sphinx/matlab/constants.rst
@@ -3,6 +3,13 @@
 
 Physical Constants
 ==================
+
+.. caution::
+    The MATLAB toolbox is an experimental part of the Cantera API and may be changed
+    without notice. It includes breaking changes from the legacy MATLAB API. While
+    almost all features of the legacy MATLAB API are implemented, the toolbox does not
+    include all functionality available for the C++ and Python interfaces.
+
 These values are the same as those in the Cantera C++ header file
 `ct_defs.h <../../cxx/d9/ddc/ct__defs_8h.html>`_.
 

--- a/doc/sphinx/matlab/index.md
+++ b/doc/sphinx/matlab/index.md
@@ -3,6 +3,9 @@
 
 ```{caution}
 The MATLAB toolbox is an experimental part of Cantera and may be changed without notice.
+It includes breaking changes from the legacy MATLAB API. While almost all features of
+the legacy MATLAB API are implemented, the toolbox does not include all functionality
+available for the C++ and Python interfaces.
 ```
 
 The _experimental_ MATLAB toolbox for Cantera is currently in preview and replaces the

--- a/doc/sphinx/matlab/kinetics.rst
+++ b/doc/sphinx/matlab/kinetics.rst
@@ -3,6 +3,13 @@
 
 Chemical Kinetics
 =================
+
+.. caution::
+    The MATLAB toolbox is an experimental part of the Cantera API and may be changed
+    without notice. It includes breaking changes from the legacy MATLAB API. While
+    almost all features of the legacy MATLAB API are implemented, the toolbox does not
+    include all functionality available for the C++ and Python interfaces.
+
 .. contents::
    :local:
 

--- a/doc/sphinx/matlab/onedim.rst
+++ b/doc/sphinx/matlab/onedim.rst
@@ -3,6 +3,13 @@
 
 One-dimensional Reacting Flows
 ==============================
+
+.. caution::
+    The MATLAB toolbox is an experimental part of the Cantera API and may be changed
+    without notice. It includes breaking changes from the legacy MATLAB API. While
+    almost all features of the legacy MATLAB API are implemented, the toolbox does not
+    include all functionality available for the C++ and Python interfaces.
+
 .. contents::
    :local:
 

--- a/doc/sphinx/matlab/phases.rst
+++ b/doc/sphinx/matlab/phases.rst
@@ -3,6 +3,13 @@
 
 Objects Representing Phases
 ===========================
+
+.. caution::
+    The MATLAB toolbox is an experimental part of the Cantera API and may be changed
+    without notice. It includes breaking changes from the legacy MATLAB API. While
+    almost all features of the legacy MATLAB API are implemented, the toolbox does not
+    include all functionality available for the C++ and Python interfaces.
+
 .. contents::
    :local:
 

--- a/doc/sphinx/matlab/thermo.rst
+++ b/doc/sphinx/matlab/thermo.rst
@@ -5,6 +5,12 @@ Thermodynamic Properties
 ========================
 These classes are used to describe the thermodynamic state of a system.
 
+.. caution::
+    The MATLAB toolbox is an experimental part of the Cantera API and may be changed
+    without notice. It includes breaking changes from the legacy MATLAB API. While
+    almost all features of the legacy MATLAB API are implemented, the toolbox does not
+    include all functionality available for the C++ and Python interfaces.
+
 Phases
 ------
 

--- a/doc/sphinx/matlab/transport.rst
+++ b/doc/sphinx/matlab/transport.rst
@@ -3,4 +3,11 @@
 
 Transport Properties
 ====================
+
+.. caution::
+    The MATLAB toolbox is an experimental part of the Cantera API and may be changed
+    without notice. It includes breaking changes from the legacy MATLAB API. While
+    almost all features of the legacy MATLAB API are implemented, the toolbox does not
+    include all functionality available for the C++ and Python interfaces.
+
 .. autoclass:: Transport

--- a/doc/sphinx/matlab/utilities.rst
+++ b/doc/sphinx/matlab/utilities.rst
@@ -3,6 +3,13 @@
 
 Utility Functions
 =================
+
+.. caution::
+    The MATLAB toolbox is an experimental part of the Cantera API and may be changed
+    without notice. It includes breaking changes from the legacy MATLAB API. While
+    almost all features of the legacy MATLAB API are implemented, the toolbox does not
+    include all functionality available for the C++ and Python interfaces.
+
 .. contents::
    :local:
 

--- a/doc/sphinx/matlab/zeroD.rst
+++ b/doc/sphinx/matlab/zeroD.rst
@@ -3,6 +3,13 @@
 
 Zero-Dimensional Reactor Networks
 =================================
+
+.. caution::
+    The MATLAB toolbox is an experimental part of the Cantera API and may be changed
+    without notice. It includes breaking changes from the legacy MATLAB API. While
+    almost all features of the legacy MATLAB API are implemented, the toolbox does not
+    include all functionality available for the C++ and Python interfaces.
+
 .. contents::
    :local:
 

--- a/interfaces/matlab/+ct/+oneD/Boundary.m
+++ b/interfaces/matlab/+ct/+oneD/Boundary.m
@@ -1,7 +1,8 @@
 classdef (Abstract) Boundary < ct.oneD.Domain
-    % Create a Boundary domain. ::
+    % Boundary Class.
     %
-    %     >> m = ct.oneD.Boundary(type, phase, name)
+    % Base class for objects representing domain boundaries. The constructor is called
+    % by derived classes and cannot be used directly.
     %
     % :param type:
     %    String type of Boundary. Possible values are:

--- a/interfaces/matlab/+ct/+oneD/Domain.m
+++ b/interfaces/matlab/+ct/+oneD/Domain.m
@@ -1,7 +1,8 @@
 classdef (Abstract) Domain < handle
-    % Domain Class ::
+    % Domain Class.
     %
-    %     >> d = ct.oneD.Domain(type, phase, id)
+    % Base class for objects representing boundaries and flow domains. The constructor
+    % is called by derived classes and cannot be used directly.
     %
     % :param type:
     %    String type of domain. Possible values are:

--- a/interfaces/matlab/+ct/+oneD/Flow.m
+++ b/interfaces/matlab/+ct/+oneD/Flow.m
@@ -1,7 +1,8 @@
 classdef (Abstract) Flow < ct.oneD.Domain
-    % Create a Flow domain. ::
+    % Flow Class.
     %
-    %     >> m = ct.oneD.Flow(type, phase, name)
+    % Base class for objects representing flow domains. The constructor is called
+    % by derived classes and cannot be used directly.
     %
     % :param type:
     %    String type of domain. Possible values are:

--- a/interfaces/matlab/+ct/+zeroD/Connector.m
+++ b/interfaces/matlab/+ct/+zeroD/Connector.m
@@ -1,9 +1,8 @@
 classdef (Abstract) Connector < handle
-    % Connector Class ::
+    % Connector Class.
     %
-    %     >> c = ct.zeroD.Connector(typ, r1, r2, name)
-    %
-    % Base class for walls and flow devices.
+    % Base class for walls and flow devices. The constructor is called
+    % by derived classes and cannot be used directly.
     %
     % See also: :mat:class:`ct.zeroD.FlowDevice`, :mat:class:`ct.zeroD.Wall`
     %

--- a/interfaces/matlab/+ct/+zeroD/FlowDevice.m
+++ b/interfaces/matlab/+ct/+zeroD/FlowDevice.m
@@ -1,9 +1,9 @@
 classdef (Abstract) FlowDevice < ct.zeroD.Connector
-    % FlowDevice Class ::
+    % FlowDevice Class.
     %
-    %     >> x = ct.zeroD.FlowDevice(typ, name)
+    % Base class for devices that allow flow between reactors. The constructor is called
+    % by derived classes and cannot be used directly.
     %
-    % Base class for devices that allow flow between reactors.
     % :mat:class:`ct.zeroD.FlowDevice` objects are assumed to be adiabatic,
     % non-reactive, and have negligible internal volume, so that they are
     % internally always in steady-state even if the upstream and downstream

--- a/interfaces/matlab/+ct/+zeroD/ReactorBase.m
+++ b/interfaces/matlab/+ct/+zeroD/ReactorBase.m
@@ -1,4 +1,8 @@
 classdef (Abstract) ReactorBase < handle
+    % ReactorBase Class.
+    %
+    % Base class for objects representing reactors. The constructor is called
+    % by derived classes and cannot be used directly.
 
     properties (SetAccess = immutable)
 

--- a/interfaces/matlab/Base/+ct/Kinetics.m
+++ b/interfaces/matlab/Base/+ct/Kinetics.m
@@ -1,11 +1,9 @@
 classdef (Abstract) Kinetics < handle
-    % Kinetics Class ::
+    % Kinetics Class.
     %
-    %     >> k = ct.Kinetics(id)
-    %
-    % Retrieve instance of class :mat:class:`ct.Kinetics` associated with a
+    % Instance of class :mat:class:`ct.Kinetics` associated with a
     % :mat:class:`ct.Solution` object. The constructor is called whenever a new
-    % :mat:class:`ct.Solution` is instantiated and should not be used directly.
+    % :mat:class:`ct.Solution` is instantiated and cannot be used directly.
     %
     % Class :mat:class:`ct.Kinetics` represents kinetics managers, which manage
     % reaction mechanisms. The reaction mechanism attributes are specified in a

--- a/interfaces/matlab/Base/+ct/ThermoPhase.m
+++ b/interfaces/matlab/Base/+ct/ThermoPhase.m
@@ -1,11 +1,9 @@
 classdef (Abstract) ThermoPhase < handle
-    % ThermoPhase Class ::
+    % ThermoPhase Class.
     %
-    %     >> t = ct.ThermoPhase(id)
-    %
-    % Retrieve instance of class :mat:class:`ct.ThermoPhase` associated with a
+    % Instance of class :mat:class:`ct.ThermoPhase` associated with a
     % :mat:class:`ct.Solution` object. The constructor is called whenever a new
-    % :mat:class:`ct.Solution` is instantiated and should not be used directly.
+    % :mat:class:`ct.Solution` is instantiated and cannot be used directly.
     %
     % :param id:
     %     Integer ID of the solution holding the :mat:class:`ct.ThermoPhase` object.

--- a/interfaces/matlab/Base/+ct/Transport.m
+++ b/interfaces/matlab/Base/+ct/Transport.m
@@ -1,11 +1,9 @@
 classdef (Abstract) Transport < handle
-    % Transport Class ::
+    % Transport Class.
     %
-    %     >> tr = ct.Transport(id)
-    %
-    % Retrieve instance of class :mat:class:`ct.Transport` associated with a
+    % Instance of class :mat:class:`ct.Transport` associated with a
     % :mat:class:`ct.Solution` object. The constructor is called whenever a new
-    % :mat:class:`ct.Solution` is instantiated and should not be used directly.
+    % :mat:class:`ct.Solution` is instantiated and cannot be used directly.
     %
     % :param id:
     %     Integer ID of the solution holding the :mat:class:`ct.Transport` object.

--- a/samples/f90/README.rst
+++ b/samples/f90/README.rst
@@ -2,3 +2,7 @@ Fortran Examples
 ================
 
 Examples for both Fortran 77 and Fortran 90.
+
+.. caution::
+    The Fortran interface is an experimental part of the Cantera API and may be changed
+    or removed without notice.

--- a/src/fortran/cantera.f90
+++ b/src/fortran/cantera.f90
@@ -2,6 +2,9 @@
 ! an application program. It's primary purpose is to provide generic
 ! procedure names that map to specific procedures depending on the
 ! argument types.
+!
+! @warning  The Fortran API is an experimental part of %Cantera and
+!   may be changed or removed without notice.
 
 ! This file is part of Cantera. See License.txt in the top-level directory or
 ! at https://cantera.org/license.txt for license and copyright information.

--- a/src/fortran/cantera_funcs.f90
+++ b/src/fortran/cantera_funcs.f90
@@ -1,6 +1,9 @@
 ! This file is part of Cantera. See License.txt in the top-level directory or
 ! at https://cantera.org/license.txt for license and copyright information.
 
+! @warning  The Fortran API is an experimental part of %Cantera and
+!   may be changed or removed without notice.
+
 module cantera_funcs
 
   use cantera_thermo

--- a/src/fortran/cantera_kinetics.f90
+++ b/src/fortran/cantera_kinetics.f90
@@ -1,6 +1,9 @@
 ! This file is part of Cantera. See License.txt in the top-level directory or
 ! at https://cantera.org/license.txt for license and copyright information.
 
+! @warning  The Fortran API is an experimental part of %Cantera and
+!   may be changed or removed without notice.
+
 module cantera_kinetics
 
   use cantera_thermo

--- a/src/fortran/cantera_thermo.f90
+++ b/src/fortran/cantera_thermo.f90
@@ -1,6 +1,9 @@
 ! This file is part of Cantera. See License.txt in the top-level directory or
 ! at https://cantera.org/license.txt for license and copyright information.
 
+! @warning  The Fortran API is an experimental part of %Cantera and
+!   may be changed or removed without notice.
+
 module cantera_thermo
 
   use fct

--- a/src/fortran/cantera_transport.f90
+++ b/src/fortran/cantera_transport.f90
@@ -1,6 +1,9 @@
 ! This file is part of Cantera. See License.txt in the top-level directory or
 ! at https://cantera.org/license.txt for license and copyright information.
 
+! @warning  The Fortran API is an experimental part of %Cantera and
+!   may be changed or removed without notice.
+
 module cantera_transport
 
   use cantera_thermo

--- a/src/fortran/fct.cpp
+++ b/src/fortran/fct.cpp
@@ -5,6 +5,9 @@
  *   library functions is provided that are declared "extern C". All
  *   Cantera objects are stored and referenced by integers - no
  *   pointers are passed to or from the calling application.
+ *
+ *   @warning  The Fortran API is an experimental part of %Cantera and
+ *      may be changed or removed without notice.
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/fortran/fct_interface.f90
+++ b/src/fortran/fct_interface.f90
@@ -1,6 +1,9 @@
 ! This file is part of Cantera. See License.txt in the top-level directory or
 ! at https://cantera.org/license.txt for license and copyright information.
 
+! @warning  The Fortran API is an experimental part of %Cantera and
+!   may be changed or removed without notice.
+
 module fct
 interface
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Mark Fortran API experimental
- Fix docstrings for MATLAB classes that cannot be instantiated by themselves
- Add 'Caution' admonitions to the MATLAB documentation

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes Cantera/enhancements#248; partially addresses Cantera/enhancements#249.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
