### PR TITLE
Fix "advance limits" tests on arm64 Linux

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,7 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         os: ['ubuntu-24.04']
+        architecture: ['x64']
         numpy: ['']
         cython: ['!=3.1.2'] # Specifier can be dropped after 3.1.3 or 3.2.0 is released
         scons: ['']
@@ -60,6 +61,9 @@ jobs:
           os: 'ubuntu-22.04'
           numpy: "'<2.2'"
           cython: '!=3.1.2' # Specifier can be dropped after 3.1.3 or 3.2.0 is released
+        - python-version: '3.14'
+          os: 'ubuntu-24.04-arm'
+          architecture: 'arm64'
       fail-fast: false
     steps:
     - uses: actions/checkout@v5
@@ -83,7 +87,7 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: x64
+        architecture: ${{ matrix.architecture }}
     - name: Install Apt dependencies
       run: |
         sudo apt update

--- a/SConstruct
+++ b/SConstruct
@@ -1002,11 +1002,11 @@ def get_processor_name():
         command ="sysctl -n machdep.cpu.brand_string"
         return subprocess.check_output(command, shell=True).decode().strip()
     elif platform.system() == "Linux":
-        command = "cat /proc/cpuinfo"
+        command = "lscpu || cat /proc/cpuinfo"
         all_info = subprocess.check_output(command, shell=True).decode().strip()
         for line in all_info.split("\n"):
-            if "model name" in line:
-                return re.sub(".*model name.*:", "", line, 1).strip()
+            if "model name" in line.lower():
+                return re.sub(".*model name.*:", "", line, 1, re.IGNORECASE).strip()
     return ""
 
 env["CPU"] = get_processor_name()

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -290,7 +290,7 @@ double ReactorNet::advance(double time, bool applylimit)
         for (size_t j = 0; j < m_nv; j++) {
             double lim = m_advancelimits[j];
             if (lim > 0.0) {
-                double delta = abs(ycurr[j] - m_ybase[j]);
+                double delta = std::abs(ycurr[j] - m_ybase[j]);
                 double ratio = delta / lim;
                 if (ratio > max_ratio) {
                     max_ratio = ratio;
@@ -414,7 +414,7 @@ void ReactorNet::evalRootFunctions(double t, const double* y, double* gout)
         for (size_t i = 0; i < m_nv; i++) {
             double lim = m_advancelimits[i];
             if (lim > 0.0) {
-                double delta = abs(y[i] - m_ybase[i]);
+                double delta = std::abs(y[i] - m_ybase[i]);
                 double ratio = delta / lim;
                 if (ratio > max_ratio) {
                     max_ratio = ratio;


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Add CI testing on Linux with arm64 processor
- Fix getting processor info for arm64 Linux systems (`/proc/cpuinfo` has nothing useful)
- Fix `abs` calls in advance limit evaluation to avoid erroneously getting the integer version

On this last point, I'd like to give a shout out to ChatGPT Codex for identifying the underlying problem and saving me a lot of painful debugging by logging in the CI builders. I told it what tests were failing, and that the errors only occurred for this particular platform, and it provided the following analysis, which I think is spot on:

> Looks like the only place where the limit logic actually evaluates how far the state has moved is in `ReactorNet::evalRootFunctions` (`src/zeroD/ReactorNet.cpp` (line 417)) and in the verbose logging right after a root trigger (`src/zeroD/ReactorNet.cpp` (line 293)). Both spots use the unqualified abs:
> ```c++
> double delta = abs(y[i] - m_ybase[i]);
> double ratio = delta / lim;
> ```
> Everywhere else in the tree we call `std::abs`, but here we don't. Whether this still works depends on what the system headers inject into the global namespace. On the platforms where the tests pass, `<cmath>` ends up providing a `::abs(double)` overload so the call does the right thing. On the GNU/Linux arm64 builds we’re shipping through CI, libstdc++ apparently doesn’t leak the floating‑point overloads into the global namespace, so the compiler silently picks the integer overload (`int abs(int)`), truncates the `double` difference to an `int`, and then promotes the integer result back to a `double`. Because every change in these tests is far smaller than 1.0, that truncation yields `delta == 0` for the entire run, so `max_ratio` never grows beyond zero, the root function stays at 1, and CVODE never sees a zero crossing. From the test’s perspective that looks exactly like “advance limits aren’t being applied”.
> 
> This would also explain why the failure only occurs on that one configuration: different libstdc++/libc++ implementations make different choices about whether abs escapes into the global namespace, so the bug is architecture/libstdc++‐dependent rather than CPU‑dependent per se.
> 
> If you swap those two `abs` calls for `std::abs` (or `fabs`) so that they must take the floating‑point overload, `max_ratio` will be computed correctly everywhere and CVODE’s root finder should once again stop the integration as soon as a component moves by more than its limit.
> 

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
