### PR TITLE
Add workaround for older versions of typing_etensions

### DIFF
--- a/interfaces/cython/cantera/_types.py
+++ b/interfaces/cython/cantera/_types.py
@@ -7,6 +7,7 @@ from typing import (
     Any,
     Concatenate,
     Literal,
+    ParamSpec,
     TypeAlias,
     TypedDict,
     TypeGuard,
@@ -18,7 +19,13 @@ from typing import (
 import numpy as np
 from numpy.typing import ArrayLike as ArrayLike
 from numpy.typing import NDArray
-from typing_extensions import ParamSpec, TypeForm
+try:
+    # Requires typing_extensions >= 4.13, or possibly Python >= 3.15
+    from typing_extensions import TypeForm
+except ImportError:
+    # Wrong, but better than crashing with an ImportError at runtime
+    from typing_extensions import Type as TypeForm
+
 
 Array: TypeAlias = NDArray[np.float64]
 Index: TypeAlias = EllipsisType | int | slice | tuple[EllipsisType | int | slice, ...]


### PR DESCRIPTION


<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Import `Type` instead of `TypeForm` if the latter is unavailable. This does not provide the correct typing information, but it avoids import errors when older versions of `typing_extensions` are installed.
- ParamSpec is available in Python proper starting with 3.10, so we can just import that from `typing`

**If applicable, fill in the issue number this pull request is fixing**

This should fix the "post-merge" CI failures on `fedora:latest` (Fedora 42).

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
