### PR TITLE
Fix species slicing error with Numpy 2.4.0 dev version

### DIFF
--- a/interfaces/cython/cantera/solutionbase.pyx
+++ b/interfaces/cython/cantera/solutionbase.pyx
@@ -54,7 +54,7 @@ cdef class _SolutionBase:
         cxx_soln.get().setKinetics(newKinetics(stringify("none")))
         cxx_soln.get().setTransportModel(stringify("none"))
         _assign_Solution(self, cxx_soln, True)
-        self._selected_species = np.ndarray(0, dtype=np.uint64)
+        self._selected_species = np.ndarray(0, dtype=np.intp)
 
     def _cinit(self, infile="", name="", adjacent=(), origin=None, yaml=None,
                thermo=None, species=(), kinetics=None, reactions=(), **kwargs):
@@ -82,7 +82,7 @@ cdef class _SolutionBase:
             _assign_Solution(self, CxxNewSolution(), True)
             self._init_parts(thermo, species, kinetics, transport, adjacent, reactions)
 
-        self._selected_species = np.ndarray(0, dtype=np.uint64)
+        self._selected_species = np.ndarray(0, dtype=np.intp)
 
     def __init__(self, *args, **kwargs):
         if isinstance(self, Transport) and kwargs.get("init", True):
@@ -395,9 +395,8 @@ cdef class _SolutionBase:
         def __set__(self, species):
             if isinstance(species, (str, int)):
                 species = (species,)
-            self._selected_species = np.ndarray(len(species), dtype=np.uint64)
-            for i,spec in enumerate(species):
-                self._selected_species[i] = self.species_index(spec)
+            selection = [self.species_index(spec) for spec in species]
+            self._selected_species = np.array(selection, dtype=np.intp)
 
     def __getstate__(self):
         """Save complete information of the current phase for pickling."""
@@ -480,7 +479,7 @@ cdef object _wrap_Solution(shared_ptr[CxxSolution] cxx_soln):
 
     cdef _SolutionBase soln = cls(init=False)
     _assign_Solution(soln, cxx_soln, True)
-    soln._selected_species = np.ndarray(0, dtype=np.uint64)
+    soln._selected_species = np.ndarray(0, dtype=np.intp)
 
     cdef InterfacePhase iface
     if isinstance(soln, Interface):

--- a/interfaces/cython/cantera/solutionbase.pyx
+++ b/interfaces/cython/cantera/solutionbase.pyx
@@ -395,7 +395,7 @@ cdef class _SolutionBase:
         def __set__(self, species):
             if isinstance(species, (str, int)):
                 species = (species,)
-            self._selected_species.resize(len(species))
+            self._selected_species = np.ndarray(len(species), dtype=np.uint64)
             for i,spec in enumerate(species):
                 self._selected_species[i] = self.species_index(spec)
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Fixes an error in the `Solution` species slicing feature due to changes being introduced in Numpy 2.4.0. These changes are currently causing some of the post-merge tests that use the development version of numpy to fail with error messages like the following:

```pytb
____________________ TestTransport.test_species_visosities _____________________
[gw2] linux -- Python 3.14.0 /home/runner/work/cantera/cantera/.venv/bin/python3

self = <python.test_transport.TestTransport object at 0x7fcad0734050>
phase = <cantera.composite.Solution object at 0x7fcad2f42e50>

    def test_species_visosities(self, phase):
        for species_name in phase.species_names:
            # check that species viscosity matches overall for single-species
            # state
            phase.X = {species_name: 1}
            phase.TP = 800, 2*ct.one_atm
            visc = phase.viscosity
>           assert phase[species_name].species_viscosities[0] == approx(visc)
                   ^^^^^^^^^^^^^^^^^^^

test/python/test_transport.py:212: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
build/python/cantera/solutionbase.pyx:371: in cantera.solutionbase._SolutionBase.__getitem__
    copy.selected_species = selection
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   self._selected_species.resize(len(species))
E   ValueError: cannot resize an array that references or is referenced
E   by another array in this way.
E   Use the np.resize function or refcheck=False

build/python/cantera/solutionbase.pyx:398: ValueError
```

Since the post-merge workflow doesn't normally run on PRs, I manually ran this on [my fork](https://github.com/speth/cantera/actions/runs/19836253058), where you can see that the tests all pass.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
