### PR TITLE
Document Python type annotations and checks.

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -215,7 +215,7 @@ doxylink = {
 
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3', None),
-    'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
+    'pandas': ('https://pandas.pydata.org/pandas-docs/version/2.3', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
     'pint': ('https://pint.readthedocs.io/en/stable/', None),
 }

--- a/doc/sphinx/develop/compiling/compilation-reqs.md
+++ b/doc/sphinx/develop/compiling/compilation-reqs.md
@@ -135,6 +135,7 @@ compile Cantera on your operating system.
   - doxygen  # needed for code generation and documentation
   - jinja2  # needed for code generation
   # - pandas  # optional (needed for pandas interface and some examples)
+  # - pandas-stubs  # optional (needed for type checking)
   # - scipy  # optional (needed for some examples)
   # - matplotlib  # optional (needed for plots and some examples)
   # - python-graphviz  # optional (needed for reaction path diagrams and some examples)
@@ -151,11 +152,14 @@ compile Cantera on your operating system.
   # - sphinxcontrib-bibtex  # optional (needed for documentation)
   # - sphinxcontrib-matlabdomain  # optional (needed for documentation)
   # - sphinxcontrib-doxylink  # optional (needed for documentation)
-  # - graphviz  # optional (needed for documentation)
+  # - graphviz  # optional (needed for documentation and type checking)
   # - texlive-core  # optional (needed for documentation)
   # - perl  # optional (needed for documentation)
   # - coolprop  # optional (needed for some examples)
-  # - pint  # optional (needed for some examples)
+  # - pint  # optional (needed for some examples and type checking)
+  # - lxml  # optional (needed for type checking)
+  # - mypy[reports]  # optional (needed for type checking)
+  # - pyright  # optional (needed for type checking)
   # - pip:  # optional (list of PyPI managed packages)
   #   - "git+https://github.com/Cantera/sphinx-tags.git@main"  # optional (needed for documentation)
   ```

--- a/doc/sphinx/develop/index.md
+++ b/doc/sphinx/develop/index.md
@@ -52,6 +52,7 @@ reactor-integration
 - [](vscode-tips)
 - [](writing-tests)
 - [](running-tests)
+- [](type-checking)
 - [](writing-examples)
 - [](doc-formatting)
 - [](continuous-integration)
@@ -65,6 +66,7 @@ style-guidelines
 vscode-tips
 writing-tests
 running-tests
+type-checking
 writing-examples
 doc-formatting
 continuous-integration

--- a/doc/sphinx/develop/running-tests.md
+++ b/doc/sphinx/develop/running-tests.md
@@ -3,6 +3,7 @@
 
 # Running Tests and Debugging
 
+(sec-using-build-dir)=
 ## Using Cantera from the Build Directory
 
 After compiling Cantera from source, it is convenient to use the Cantera Python module

--- a/doc/sphinx/develop/style-guidelines.md
+++ b/doc/sphinx/develop/style-guidelines.md
@@ -160,6 +160,11 @@ above, both are used.
 * The minimum Python version that Cantera supports is Python 3.12, so code should only
   use features added in Python 3.12 or earlier
 * Please use double quotes in all new Python code
+* Type annotations are mandatory for any external interfaces:
+  * Utilize type annotations directly in all new pure Python code (`.py` files)
+  * For Cython code (`.pyx` files), add the annotations to the corresponding type stubs
+    (`.pyi` files)
+  * See [](sec-python-type-annotations) for more information
 
 ### Sphinx comments
 

--- a/doc/sphinx/develop/type-checking.md
+++ b/doc/sphinx/develop/type-checking.md
@@ -6,8 +6,8 @@ within third-party Python scripts and libraries, and thus aims for full type cov
 of the external interface. These annotations indicate the intended types for all inputs
 and outputs without restricting the runtime behavior of the code.
 
-A secondary benefit of type annotations is to facilitate static analysis of Python code
-in order to catch potential dynamic typing-related errors using tools like
+A secondary benefit of type annotations is to facilitate static analysis of Cantera's
+Python code in order to catch potential typing-related errors using tools like
 [mypy](https://mypy.readthedocs.io/en/latest/index.html),
 [pyright](https://microsoft.github.io/pyright/), [ty](https://docs.astral.sh/ty/), and
 [pyrefly](https://pyrefly.org/). These are only able to analyze pure Python code, so
@@ -17,18 +17,45 @@ they are of limited utility due to Cantera's extensive use of Cython syntax.
 
 Annotations should be added directly to all pure Python code (`.py` files). For Cython
 code (`.pyx` files), annotation support is limited and optional; instead, type stubs
-(`.pyi` files) must be added and maintained to document the external interface.
-
-Any changes to the externally-facing API must include explicit type annotations. Types
-should be as narrow as feasible to fit the desired usage. For example, when an input
-should be a tuple of two float values, prefer using `tuple[float, float]` over
-`Iterable[float]` even if the method would technically work with any iterable. Usage of
-`Any` types and `type: ignore` directives require an appropriate justification. Type
+(`.pyi` files) must be added and maintained to document the external interface. Any
+changes to the externally-facing API must include explicit type annotations. Type
 annotations of implementation details is optional but encouraged for pure Python code,
 and may be necessary in some situations to ensure the static type checks pass.
 
-Ensure all type annotations to be added are compatible with the lowest-supported Python
-version (currently 3.12).
+Ensure the syntax and features support the lowest-support Python version (currently
+3.12), referencing the [Python](https://typing.python.org/en/latest/) and
+[mypy](https://mypy.readthedocs.io/en/latest/index.html) documentation for guidance and
+current best practices. Some additional recommendations which are more specific to
+Cantera include:
+
+* Type aliases should generally be prepended with an underscore.
+* Aliases and special functions such as parametric `TypeGuard`s which will be used in
+  many parts of the code should be placed in `_types.py`.
+* Aliases representing any object which can be coerced into an object of type `{}`
+  should be named `{}Like`, in keeping with `ArrayLike` from `NumPy`.
+  * Examples: `ArrayLike`, `CompositionLike`, `_Func1Like`
+* Prefer false positives to false negatives. In other words, if a type is too
+  restrictive for a valid, if uncommon, usage, it should be switched for a more broad
+  alternative.
+  * Example: The `_TransportModel` alias could be a set of string literals which
+    enumerate all built-in transport models, but this would incorrectly flag any custom
+    extensions. It is therefore generalized to a `str` type.
+  * Exception: For input collections with a strict format it is often better to
+    restrict the type beyond what might be accepted at runtime. For example:
+      * A `TypedDict` provides better documentation of a dictionary of options than
+        something like `dict[str, str | float | dict[str, str | float]]`.
+      * For the thermodynamic state setters, `tuple[float, float, CompositionLike]` is
+        more informative than the alternative `Sequence[float | CompositionLike]`.
+      * Clever use of `Protocol`s may also help to achieve optimal typing.
+* The following should be avoided when possible:
+  * Use of `Any` should be rare, and is typically reserved for dictionaries with
+    complex or flexible contents (such as `kwargs`).
+  * Use of `type: ignore` directives should be considered temporary workarounds and
+    targeted for removal in future pull requests.
+  * In the context of a pull request it is good practice to insert these as a
+    placeholder for items where the developer requires assistance, allowing the CI
+    job to progress and catch any other issues. Developers are encouraged to add a
+    code comment elaborating on why it was deemed necessary.
 
 ## Verifying Type Annotations
 
@@ -38,27 +65,54 @@ discuss each command, its purpose, and how to run it locally.
 
 ### Local Setup
 
+Due to the use of compiled Cython code, most checks are performed on the built library
+rather than running directly against the source code. It is thus recommended to add the
+build directory to the environment variables following [](sec-using-build-dir):
+
+::::{tab-set}
+:::{tab-item} Linux
+:sync: linux
+```sh
+export LD_LIBRARY_PATH=$(pwd)/build/lib
+export PYTHONPATH=$(pwd)/build/python
+```
+:::
+
+:::{tab-item} macOS
+:sync: macos
+```sh
+export DYLD_LIBRARY_PATH=$(pwd)/build/lib
+export PYTHONPATH=$(pwd)/build/python
+```
+:::
+
+:::{tab-item} Windows (PowerShell)
+:sync: windows
+```pwsh
+$Env:PYTHONPATH = (Get-Location).Path + '\build\python'
+```
+:::
+::::
+
 Currently Cantera primarily uses the `mypy` type checker with an additional check from
-`pyright`, both of which can be installed via `pip` or `conda`. Note that
-`mypy>=1.19.0` is required, and additional reporting formats can be generated if the
-optional dependencies are installed with `mypy[reports]`.
+`pyright`. They can be installed with
 
-Some of the optional external dependencies provide type hints which are also employed
-by Cantera when available. It is therefore recommended to install them when developing
-within the Python interface:
-
-```yaml
-dependencies:
-- graphviz
-- pandas
-- pandas-stubs
-- pint
-- typing_extensions
+```sh
+conda install mypy>=1.19.0 lxml pyright
 ```
 
-Due to the use of compiled Cython code, most checks are performed on the built library
-rather than running directly against the source code. It is thus recommended to follow
-[](sec-using-build-dir).
+or
+
+```sh
+pip install mypy[reports]>=1.19.0 pyright
+```
+
+Some of the optional external dependencies provide type hints which are also employed
+by Cantera when available, and thus must be installed for the type checks to pass:
+
+```sh
+conda install graphviz pandas pandas-stubs pint typing_extensions
+```
 
 ### Static Type Correctness
 
@@ -100,6 +154,10 @@ These are omitted from the results by adding the `--ignoreexternal` option:
 ```sh
 pyright --ignoreexternal --verifytypes cantera
 ```
+
+Note that this check will additionally print various static type errors prior to the
+coverage report. This is expected due to differences between `mypy` and `pyright`, and
+it is not necessary to address these `pyright`-specific errors at this time.
 
 The second check is a more thorough coverage report, similar in format to the unit test
 coverage reports, generated using Mypy. This report highlights warnings and errors on a

--- a/doc/sphinx/develop/type-checking.md
+++ b/doc/sphinx/develop/type-checking.md
@@ -1,0 +1,155 @@
+(sec-python-type-annotations)=
+# Python Type Annotations
+
+Cantera employs type annotations in the Python interface primarily to support its use
+within third-party Python scripts and libraries, and thus aims for full type coverage
+of the external interface. These annotations indicate the intended types for all inputs
+and outputs without restricting the runtime behavior of the code.
+
+A secondary benefit of type annotations is to facilitate static analysis of Python code
+in order to catch potential dynamic typing-related errors using tools like
+[mypy](https://mypy.readthedocs.io/en/latest/index.html),
+[pyright](https://microsoft.github.io/pyright/), [ty](https://docs.astral.sh/ty/), and
+[pyrefly](https://pyrefly.org/). These are only able to analyze pure Python code, so
+they are of limited utility due to Cantera's extensive use of Cython syntax.
+
+## Adding Type Annotations
+
+Annotations should be added directly to all pure Python code (`.py` files). For Cython
+code (`.pyx` files), annotation support is limited and optional; instead, type stubs
+(`.pyi` files) must be added and maintained to document the external interface.
+
+Any changes to the externally-facing API must include explicit type annotations. Types
+should be as narrow as feasible to fit the desired usage. For example, when an input
+should be a tuple of two float values, prefer using `tuple[float, float]` over
+`Iterable[float]` even if the method would technically work with any iterable. Usage of
+`Any` types and `type: ignore` directives require an appropriate justification. Type
+annotations of implementation details is optional but encouraged for pure Python code,
+and may be necessary in some situations to ensure the static type checks pass.
+
+Ensure all type annotations to be added are compatible with the lowest-supported Python
+version (currently 3.12).
+
+## Verifying Type Annotations
+
+The `type-checking` CI job runs a set of checks on the type annotations, and developers
+should ensure these checks also pass locally prior to pushing. In this section we will
+discuss each command, its purpose, and how to run it locally.
+
+### Local Setup
+
+Currently Cantera primarily uses the `mypy` type checker with an additional check from
+`pyright`, both of which can be installed via `pip` or `conda`. Note that
+`mypy>=1.19.0` is required, and additional reporting formats can be generated if the
+optional dependencies are installed with `mypy[reports]`.
+
+Some of the optional external dependencies provide type hints which are also employed
+by Cantera when available. It is therefore recommended to install them when developing
+within the Python interface:
+
+```yaml
+dependencies:
+- graphviz
+- pandas
+- pandas-stubs
+- pint
+- typing_extensions
+```
+
+Due to the use of compiled Cython code, most checks are performed on the built library
+rather than running directly against the source code. It is thus recommended to follow
+[](sec-using-build-dir).
+
+### Static Type Correctness
+
+This is the standard type-checking pass for a Python library which scans the raw
+source code for type-related errors such as missing annotations, attempts to access
+nonexistant methods/attributes, or empty collections (such as lists or dictionaries)
+whose type could not be inferred.
+
+This check can be run without first building Cantera by navigating to the
+`interfaces/cython` directory and executing:
+
+```sh
+mypy -p cantera
+```
+
+Which will analyze the entire package and print the results to `stdout`. You can also
+analyze specific files with `mypy [filename]`. Mypy should report no issues and will
+print relevant information if any are found.
+
+When not inside the cython directory, the `-p` option will attempt to check the built
+library instead. Note that the configuration settings for `mypy` are included within
+the `pyproject.toml` file in the `interfaces/cython` folder, which from the
+root directory can be passed in on the command line like so:
+
+```sh
+mypy --config-file interfaces/cython/pyproject.toml -p cantera
+```
+
+### External Interface Type Coverage
+
+These checks examine the public interface looking for missing or underspecified
+annotations.
+
+The first check uses Pyright's `--verifytypes` feature to print a quick summary of the
+type coverage. Ideally there will be 100% coverage with known types; however, many
+types originate from external libraries which may not themselves be fully defined.
+These are omitted from the results by adding the `--ignoreexternal` option:
+
+```sh
+pyright --ignoreexternal --verifytypes cantera
+```
+
+The second check is a more thorough coverage report, similar in format to the unit test
+coverage reports, generated using Mypy. This report highlights warnings and errors on a
+per-line basis. While the CI generates a Cobertura-format XML file, the HTML format is
+more straightforward for developers to view:
+
+```sh
+mypy --config-file interfaces/cython/pyproject.toml --html-report type_check/ -p cantera
+```
+
+This will generate a static HTML site with the index at `type_check/index.html`. As
+with the static type check, this can also be run from `interfaces/cython` without first
+building the code.
+
+### Runtime Type Stub Correctness
+
+The final category of type checks utilizes Mypy's `stubtest` utility to import Cantera
+and compare the runtime code against the type annotations provided by the type stubs.
+Because the Cython code cannot be analyzed statically, this provides a means to verify
+the stubs are both correctly implemented and cover the public interface.
+
+Because it performs runtime analysis, this can only be run on the built library. The
+basic command is:
+
+```sh
+stubtest --mypy-config-file interfaces/cython/pyproject.toml \
+--ignore-disjoint-bases --allowlist interfaces/cython/.mypyignore \
+--concise cantera
+```
+
+Where the `--concise` option may be omitted to make `stubtest` print more details for
+any identified issues. The `--allowlist` option points to a file containing a manually
+curated list of methods to skip analyzing due to known and presently-unfixable errors;
+for example, Cython methods have signatures which cannot be inspected at runtime, with
+input parameters showing up as `(*args, **kwargs)`.
+
+If `stubtest` reports any errors and it's not clear how to fix them, the allow list
+can be automatically updated with the following commands:
+
+```sh
+# Remove everything from the allowlist except the pattern matches:
+sed -i '16,$d' interfaces/cython/.mypyignore
+
+# Generate a new allowlist and append it to the file:
+stubtest --mypy-config-file interfaces/cython/pyproject.toml \
+--ignore-disjoint-bases --allowlist interfaces/cython/.mypyignore \
+--generate-allowlist cantera >> interfaces/cython/.mypyignore
+```
+
+This will ensure a consistent ordering. At present it is acceptable to add all stub
+errors to the list to be addressed in later pull requests. Note that once a stub error
+is fixed or otherwise rendered unnecessary, `stubtest` will raise an error until it is
+removed from the allowlist.


### PR DESCRIPTION
**Changes proposed in this pull request**

- Adds developer documentation for Python type annotations, including:
  - Adding type check related optional dependencies to the example `environment.yaml` file.
  - Describing the current scope of mandatory type annotations (external interfaces).
  - Describing the purpose of each type checking step.
  - Showing how to run the type checking steps locally.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes Cantera/enhancements#251

**AI Statement (required)**

- **No generative AI was used.** This contribution was written entirely without AI assistance.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
