### PR TITLE
Introduce std::span usage in thermo classes

### DIFF
--- a/doc/sphinx/develop/clib-extensions.md
+++ b/doc/sphinx/develop/clib-extensions.md
@@ -265,3 +265,22 @@ The **sourcegen** utility uses a logging module to provide feedback. Add the ver
      existing crosswalks.
   1. Add new crosswalks to `config.yaml`, which may require updates of templates as
      well as the CLib source generator source code itself.
+
+## Debugging
+
+To run **sourcegen** in the VS Code debugger, the following configuration can be added
+to `.vscode/launch.json`:
+
+```json
+{
+    "name": "sourcegen CLib",
+    "type": "debugpy",
+    "request": "launch",
+    "module": "sourcegen",
+    "console": "integratedTerminal",
+    "args": ["--api=clib", "--verbose", "--output=interfaces/clib"],
+    "env": {
+        "PYTHONPATH": "${workspaceRoot}/interfaces/sourcegen"
+    },
+},
+```

--- a/doc/sphinx/userguide/thermodemo.cpp
+++ b/doc/sphinx/userguide/thermodemo.cpp
@@ -27,7 +27,7 @@ void thermo_demo(const string& file, const string& phase)
     // chemical potentials of the species
     size_t numSpecies = gas->nSpecies();
     vector<double> mu(numSpecies);
-    gas->getChemPotentials(mu.data());
+    gas->getChemPotentials(mu);
     for (size_t n = 0; n < numSpecies; n++) {
         std::cout << gas->speciesName(n) << " " << mu[n] << std::endl;
     }

--- a/include/cantera/base/ct_defs.h
+++ b/include/cantera/base/ct_defs.h
@@ -21,6 +21,7 @@
 // STL includes
 #include <cstdlib>
 #include <vector>
+#include <span>
 #include <map>
 #include <set>
 #include <string>

--- a/include/cantera/base/ctexceptions.h
+++ b/include/cantera/base/ctexceptions.h
@@ -163,6 +163,14 @@ private:
     size_t sz_, reqd_;
 };
 
+//! Wrapper for throwing ArraySizeError.
+//! Used to reduce boilerplate implementation and spurious lack of code coverage.
+inline void checkArraySize(const char* procedure, size_t available, size_t required)
+{
+    if (required > available) {
+        throw ArraySizeError(procedure, available, required);
+    }
+}
 
 //! An array index is out of range.
 /*!

--- a/include/cantera/cython/thermo_utils.h
+++ b/include/cantera/cython/thermo_utils.h
@@ -7,12 +7,29 @@
 #include "cantera/thermo/ThermoPhase.h"
 #include "wrappers.h"
 
+using Cantera::span;
+
 #define THERMO_1D(FUNC_NAME) ARRAY_FUNC(thermo, ThermoPhase, FUNC_NAME)
 
-THERMO_1D(getMassFractions)
-THERMO_1D(setMassFractions)
-THERMO_1D(getMoleFractions)
-THERMO_1D(setMoleFractions)
+inline void thermo_getMassFractions(Cantera::ThermoPhase* object, double* data)
+{
+    object->getMassFractions(span<double>(data, object->nSpecies()));
+}
+
+inline void thermo_setMassFractions(Cantera::ThermoPhase* object, double* data)
+{
+    object->setMassFractions(span<const double>(data, object->nSpecies()));
+}
+
+inline void thermo_getMoleFractions(Cantera::ThermoPhase* object, double* data)
+{
+    object->getMoleFractions(span<double>(data, object->nSpecies()));
+}
+
+inline void thermo_setMoleFractions(Cantera::ThermoPhase* object, double* data)
+{
+    object->setMoleFractions(span<const double>(data, object->nSpecies()));
+}
 THERMO_1D(getConcentrations)
 THERMO_1D(setConcentrations)
 

--- a/include/cantera/cython/thermo_utils.h
+++ b/include/cantera/cython/thermo_utils.h
@@ -5,50 +5,29 @@
 #define CT_PY_THERMO_UTILS_H
 
 #include "cantera/thermo/ThermoPhase.h"
-#include "wrappers.h"
-
 using Cantera::span;
 
-#define THERMO_1D(FUNC_NAME) ARRAY_FUNC(thermo, ThermoPhase, FUNC_NAME)
+#define THERMO_1D(FUNC_NAME) \
+    inline void thermo_ ## FUNC_NAME(Cantera::ThermoPhase* object, span<double> data) \
+    { object->FUNC_NAME(data.data()); }
 
-inline void thermo_getMassFractions(Cantera::ThermoPhase* object, double* data)
-{
-    object->getMassFractions(span<double>(data, object->nSpecies()));
-}
+#define THERMO_1D_SPAN(FUNC_NAME) \
+    inline void thermo_ ## FUNC_NAME(Cantera::ThermoPhase* object, span<double> data) \
+    { object->FUNC_NAME(data); }
 
-inline void thermo_setMassFractions(Cantera::ThermoPhase* object, double* data)
-{
-    object->setMassFractions(span<const double>(data, object->nSpecies()));
-}
+#define THERMO_1D_SPAN_CONST(FUNC_NAME) \
+    inline void thermo_ ## FUNC_NAME(Cantera::ThermoPhase* object, span<const double> data) \
+    { object->FUNC_NAME(data); }
 
-inline void thermo_getMoleFractions(Cantera::ThermoPhase* object, double* data)
-{
-    object->getMoleFractions(span<double>(data, object->nSpecies()));
-}
+THERMO_1D_SPAN(getMassFractions)
+THERMO_1D_SPAN_CONST(setMassFractions)
+THERMO_1D_SPAN(getMoleFractions)
+THERMO_1D_SPAN_CONST(setMoleFractions)
+THERMO_1D_SPAN(getConcentrations)
+THERMO_1D_SPAN_CONST(setConcentrations)
+THERMO_1D_SPAN(getMolecularWeights)
+THERMO_1D_SPAN(getCharges)
 
-inline void thermo_setMoleFractions(Cantera::ThermoPhase* object, double* data)
-{
-    object->setMoleFractions(span<const double>(data, object->nSpecies()));
-}
-inline void thermo_getConcentrations(Cantera::ThermoPhase* object, double* data)
-{
-    object->getConcentrations(span<double>(data, object->nSpecies()));
-}
-
-inline void thermo_setConcentrations(Cantera::ThermoPhase* object, double* data)
-{
-    object->setConcentrations(span<const double>(data, object->nSpecies()));
-}
-
-inline void thermo_getMolecularWeights(Cantera::ThermoPhase* object, double* data)
-{
-    object->getMolecularWeights(span<double>(data, object->nSpecies()));
-}
-
-inline void thermo_getCharges(Cantera::ThermoPhase* object, double* data)
-{
-    object->getCharges(span<double>(data, object->nSpecies()));
-}
 THERMO_1D(getChemPotentials)
 THERMO_1D(getElectrochemPotentials)
 THERMO_1D(getPartialMolarEnthalpies)

--- a/include/cantera/cython/thermo_utils.h
+++ b/include/cantera/cython/thermo_utils.h
@@ -5,29 +5,22 @@
 #define CT_PY_THERMO_UTILS_H
 
 #include "cantera/thermo/ThermoPhase.h"
-using Cantera::span;
+
+using std::span;
 
 #define THERMO_1D(FUNC_NAME) \
     inline void thermo_ ## FUNC_NAME(Cantera::ThermoPhase* object, span<double> data) \
-    { object->FUNC_NAME(data.data()); }
-
-#define THERMO_1D_SPAN(FUNC_NAME) \
-    inline void thermo_ ## FUNC_NAME(Cantera::ThermoPhase* object, span<double> data) \
     { object->FUNC_NAME(data); }
 
-#define THERMO_1D_SPAN_CONST(FUNC_NAME) \
-    inline void thermo_ ## FUNC_NAME(Cantera::ThermoPhase* object, span<const double> data) \
-    { object->FUNC_NAME(data); }
+THERMO_1D(getMassFractions)
+THERMO_1D(setMassFractions)
+THERMO_1D(getMoleFractions)
+THERMO_1D(setMoleFractions)
+THERMO_1D(getConcentrations)
+THERMO_1D(setConcentrations)
 
-THERMO_1D_SPAN(getMassFractions)
-THERMO_1D_SPAN_CONST(setMassFractions)
-THERMO_1D_SPAN(getMoleFractions)
-THERMO_1D_SPAN_CONST(setMoleFractions)
-THERMO_1D_SPAN(getConcentrations)
-THERMO_1D_SPAN_CONST(setConcentrations)
-THERMO_1D_SPAN(getMolecularWeights)
-THERMO_1D_SPAN(getCharges)
-
+THERMO_1D(getMolecularWeights)
+THERMO_1D(getCharges)
 THERMO_1D(getChemPotentials)
 THERMO_1D(getElectrochemPotentials)
 THERMO_1D(getPartialMolarEnthalpies)

--- a/include/cantera/cython/thermo_utils.h
+++ b/include/cantera/cython/thermo_utils.h
@@ -30,11 +30,25 @@ inline void thermo_setMoleFractions(Cantera::ThermoPhase* object, double* data)
 {
     object->setMoleFractions(span<const double>(data, object->nSpecies()));
 }
-THERMO_1D(getConcentrations)
-THERMO_1D(setConcentrations)
+inline void thermo_getConcentrations(Cantera::ThermoPhase* object, double* data)
+{
+    object->getConcentrations(span<double>(data, object->nSpecies()));
+}
 
-THERMO_1D(getMolecularWeights)
-THERMO_1D(getCharges)
+inline void thermo_setConcentrations(Cantera::ThermoPhase* object, double* data)
+{
+    object->setConcentrations(span<const double>(data, object->nSpecies()));
+}
+
+inline void thermo_getMolecularWeights(Cantera::ThermoPhase* object, double* data)
+{
+    object->getMolecularWeights(span<double>(data, object->nSpecies()));
+}
+
+inline void thermo_getCharges(Cantera::ThermoPhase* object, double* data)
+{
+    object->getCharges(span<double>(data, object->nSpecies()));
+}
 THERMO_1D(getChemPotentials)
 THERMO_1D(getElectrochemPotentials)
 THERMO_1D(getPartialMolarEnthalpies)

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -304,7 +304,7 @@ public:
      * @param mu Chemical potential vector. Length = num global species. Units
      *           = J/kmol.
      */
-    void getChemPotentials(double* mu) const;
+    void getChemPotentials(span<double> mu) const;
 
     //! Returns a vector of Valid chemical potentials.
     /*!

--- a/include/cantera/kinetics/BlowersMaselRate.h
+++ b/include/cantera/kinetics/BlowersMaselRate.h
@@ -23,11 +23,7 @@ struct BlowersMaselData : public ReactionData
     void update(double T) override;
     bool update(const ThermoPhase& phase, const Kinetics& kin) override;
     using ReactionData::update;
-
-    void resize(size_t nSpecies, size_t nReactions, size_t nPhases) override {
-        partialMolarEnthalpies.resize(nSpecies, 0.);
-        ready = true;
-    }
+    void resize(Kinetics& kin) override;
 
     bool ready = false; //!< boolean indicating whether vectors are accessible
     double density = NAN; //!< used to determine if updates are needed

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -37,12 +37,7 @@ struct FalloffData : public ReactionData
     void perturbThirdBodies(double deltaM);
 
     void restore() override;
-
-    void resize(size_t nSpecies, size_t nReactions, size_t nPhases) override {
-        conc_3b.resize(nReactions, NAN);
-        m_conc_3b_buf.resize(nReactions, NAN);
-        ready = true;
-    }
+    void resize(Kinetics& kin) override;
 
     void invalidateCache() override {
         ReactionData::invalidateCache();

--- a/include/cantera/kinetics/InterfaceRate.h
+++ b/include/cantera/kinetics/InterfaceRate.h
@@ -29,29 +29,14 @@ class AnyMap;
 struct InterfaceData : public BlowersMaselData
 {
     InterfaceData() = default;
-
     bool update(const ThermoPhase& bulk, const Kinetics& kin) override;
-
     void update(double T) override;
-
     void update(double T, const vector<double>& values) override;
-
     using BlowersMaselData::update;
-
     virtual void perturbTemperature(double deltaT);
-
-    void resize(size_t nSpecies, size_t nReactions, size_t nPhases) override {
-        coverages.resize(nSpecies, 0.);
-        logCoverages.resize(nSpecies, 0.);
-        partialMolarEnthalpies.resize(nSpecies, 0.);
-        electricPotentials.resize(nPhases, 0.);
-        standardChemPotentials.resize(nSpecies, 0.);
-        standardConcentrations.resize(nSpecies, 0.);
-        ready = true;
-    }
+    void resize(Kinetics& kin) override;
 
     double sqrtT = NAN; //!< square root of temperature
-
     vector<double> coverages; //!< surface coverages
     vector<double> logCoverages; //!< logarithm of surface coverages
     vector<double> electricPotentials; //!< electric potentials of phases

--- a/include/cantera/kinetics/LinearBurkeRate.h
+++ b/include/cantera/kinetics/LinearBurkeRate.h
@@ -43,12 +43,7 @@ struct LinearBurkeData : public ReactionData
     void perturbPressure(double deltaP);
 
     void restore() override;
-
-    virtual void resize(size_t nSpecies, size_t nReactions, size_t nPhases) override
-    {
-        moleFractions.resize(nSpecies, NAN);
-        ready = true;
-    }
+    virtual void resize(Kinetics& kin) override;
 
     void invalidateCache() override
     {

--- a/include/cantera/kinetics/MultiRate.h
+++ b/include/cantera/kinetics/MultiRate.h
@@ -61,8 +61,8 @@ public:
         return false;
     }
 
-    void resize(size_t nSpecies, size_t nReactions, size_t nPhases) override {
-        m_shared.resize(nSpecies, nReactions, nPhases);
+    void resize(Kinetics& kin) override {
+        m_shared.resize(kin);
         m_shared.invalidateCache();
     }
 

--- a/include/cantera/kinetics/MultiRateBase.h
+++ b/include/cantera/kinetics/MultiRateBase.h
@@ -42,11 +42,10 @@ public:
     //! @param rate  reaction rate object
     virtual bool replace(size_t rxn_index, ReactionRate& rate) = 0;
 
-    //! Update number of species and reactions
-    //! @param nSpecies  number of species
-    //! @param nReactions  number of reactions
-    //! @param nPhases  number of phases
-    virtual void resize(size_t nSpecies, size_t nReactions, size_t nPhases) = 0;
+    //! Update array sizes that depend on number of species, reactions or phases
+    //! @since Changed in %Cantera 4.0 to take a Kinetics object as argument instead of
+    //!     specific array sizes.
+    virtual void resize(Kinetics& kin) = 0;
 
     //! Evaluate all rate constants handled by the evaluator
     //! @param kf  array of rate constants

--- a/include/cantera/kinetics/ReactionData.h
+++ b/include/cantera/kinetics/ReactionData.h
@@ -98,8 +98,8 @@ struct ReactionData
         m_temperature_buf = -1.;
     }
 
-    //! Update number of species, reactions and phases
-    virtual void resize(size_t nSpecies, size_t nReactions, size_t nPhases) {}
+    //! Update array sizes that depend on number of species, reactions and phases
+    virtual void resize(Kinetics& kin) {}
 
     //! Force shared data and reaction rates to be updated next time. This is called by
     //! functions that change quantities affecting rate calculations that are normally

--- a/include/cantera/numerics/eigen_dense.h
+++ b/include/cantera/numerics/eigen_dense.h
@@ -4,7 +4,8 @@
 #ifndef CT_EIGEN_DENSE_H
 #define CT_EIGEN_DENSE_H
 
-#include "cantera/base/config.h"
+#include "cantera/base/ct_defs.h"
+
 #if CT_USE_SYSTEM_EIGEN
     #if CT_USE_SYSTEM_EIGEN_PREFIXED
     #include <eigen3/Eigen/Dense>
@@ -29,6 +30,12 @@ typedef Eigen::Map<Eigen::RowVectorXd> MappedRowVector;
 typedef Eigen::Map<const Eigen::RowVectorXd> ConstMappedRowVector;
 
 //! @}
+
+//! Convenience wrapper for accessing Eigen VectorXd data as a span
+//! @todo Remove once %Cantera requires Eigen 5.0 or newer.
+inline span<double> asSpan(Eigen::VectorXd& v) {
+    return span<double>(v.data(), v.size());
+}
 
 }
 

--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -404,7 +404,7 @@ public:
     void fromArray(const shared_ptr<SolutionArray>& arr) override;
 
     void _getInitialSoln(double* x) override {
-        m_sphase->getCoverages(x);
+        m_sphase->getCoverages(span<double>(x, m_nsp));
     }
 
     void _finalize(const double* x) override {

--- a/include/cantera/oneD/Flow1D.h
+++ b/include/cantera/oneD/Flow1D.h
@@ -466,7 +466,7 @@ protected:
             m_rho[j] = m_thermo->density();
             m_wtm[j] = m_thermo->meanMolecularWeight();
             m_cp[j] = m_thermo->cp_mass();
-            m_thermo->getPartialMolarEnthalpies(&m_hk(0, j));
+            m_thermo->getPartialMolarEnthalpies(span<double>(&m_hk(0, j), m_nsp));
             m_kin->getNetProductionRates(&m_wdot(0, j));
         }
     }

--- a/include/cantera/thermo/BinarySolutionTabulatedThermo.h
+++ b/include/cantera/thermo/BinarySolutionTabulatedThermo.h
@@ -223,7 +223,7 @@ protected:
      *  @returns          Linear interpolation of tabulated data at the current
      *                    mole fraction x.
      */
-    double interpolate(const double x, const vector<double>& inputData) const;
+    double interpolate(const double x, span<const double> inputData) const;
 
     //! Numerical derivative of the molar volume table
     /*!
@@ -235,7 +235,7 @@ protected:
      *  @param  derivedData  Output vector of tabulated data that is numerically
      *                       derived with respect to the mole fraction.
      */
-    void diff(const vector<double>& inputData, vector<double>& derivedData) const;
+    void diff(span<const double> inputData, span<double> derivedData) const;
 
     //! Current tabulated species index
     size_t m_kk_tab = npos;

--- a/include/cantera/thermo/BinarySolutionTabulatedThermo.h
+++ b/include/cantera/thermo/BinarySolutionTabulatedThermo.h
@@ -191,7 +191,7 @@ public:
      *
      * @param vbar  Output vector of partial molar volumes. Length: m_kk.
      */
-    void getPartialMolarVolumes(double* vbar) const override;
+    void getPartialMolarVolumes(span<double> vbar) const override;
 
     /**
      * Overloads the calcDensity() method of IdealSolidSoln to also consider non-ideal

--- a/include/cantera/thermo/ConstCpPoly.h
+++ b/include/cantera/thermo/ConstCpPoly.h
@@ -55,7 +55,7 @@ public:
      *                     the standard state for species n. Contains 4 parameters
      *                     in the order of setParameters() arguments.
      */
-    ConstCpPoly(double tlow, double thigh, double pref, const double* coeffs);
+    ConstCpPoly(double tlow, double thigh, double pref, span<const double> coeffs);
 
     /**
      * Set ConstCpPoly parameters.
@@ -77,20 +77,20 @@ public:
      *  - m_t[0] = tt;
      *
      */
-    void updateProperties(const double* tt, double* cp_R, double* h_RT,
-                          double* s_R) const override;
+    void updateProperties(span<const double> tt, double& cp_R, double& h_RT,
+                          double& s_R) const override;
 
-    void updatePropertiesTemp(const double temp, double* cp_R, double* h_RT,
-                              double* s_R) const override;
+    void updatePropertiesTemp(const double temp, double& cp_R,
+                              double& h_RT, double& s_R) const override;
 
     size_t nCoeffs() const override { return 4; }
 
     void reportParameters(size_t& n, int& type, double& tlow, double& thigh,
-                          double& pref, double* const coeffs) const override;
+                          double& pref, span<double> coeffs) const override;
 
     void getParameters(AnyMap& thermo) const override;
 
-    double reportHf298(double* const h298=nullptr) const override;
+    double reportHf298(span<double> h298={}) const override;
     void modifyOneHf298(const size_t k, const double Hf298New) override;
     void resetHf298() override;
 

--- a/include/cantera/thermo/ConstCpPoly.h
+++ b/include/cantera/thermo/ConstCpPoly.h
@@ -90,7 +90,7 @@ public:
 
     void getParameters(AnyMap& thermo) const override;
 
-    double reportHf298(span<double> h298={}) const override;
+    double reportHf298() const override;
     void modifyOneHf298(const size_t k, const double Hf298New) override;
     void resetHf298() override;
 

--- a/include/cantera/thermo/CoverageDependentSurfPhase.h
+++ b/include/cantera/thermo/CoverageDependentSurfPhase.h
@@ -240,10 +240,10 @@ public:
     //! \theta^{ref} @f$. With coverage fixed at a reference value,
     //! reference state properties are effectively only dependent on temperature.
     //! @{
-    void getEnthalpy_RT_ref(double* hrt) const override;
-    void getEntropy_R_ref(double* sr) const override;
-    void getCp_R_ref(double* cpr) const override;
-    void getGibbs_RT_ref(double* grt) const override;
+    void getEnthalpy_RT_ref(span<double> hrt) const override;
+    void getEntropy_R_ref(span<double> sr) const override;
+    void getCp_R_ref(span<double> cpr) const override;
+    void getGibbs_RT_ref(span<double> grt) const override;
     //! @}
 
     //! @name Methods calculating standard state thermodynamic properties
@@ -259,7 +259,7 @@ public:
      *            + \int_{298}^{T} c^{cov}_{p,k}(T,\theta)dT}{RT}
      * @f]
      */
-    void getEnthalpy_RT(double* hrt) const override;
+    void getEnthalpy_RT(span<double> hrt) const override;
 
     //! Get the nondimensionalized standard state entropy vector.
     /*!
@@ -270,7 +270,7 @@ public:
      *            - \ln\left(\frac{1}{\theta_{ref}}\right)
      * @f]
      */
-    void getEntropy_R(double* sr) const override;
+    void getEntropy_R(span<double> sr) const override;
 
     //! Get the nondimensionalized standard state heat capacity vector.
     /*!
@@ -279,7 +279,7 @@ public:
      *          = \frac{c^{ref}_{p,k}(T) + c^{cov}_{p,k}(T,\theta)}{RT}
      * @f]
      */
-    void getCp_R(double* cpr) const override;
+    void getCp_R(span<double> cpr) const override;
 
     //! Get the nondimensionalized standard state gibbs free energy vector.
     /*!
@@ -288,7 +288,7 @@ public:
      *          = \frac{h^o_k(T,\theta)}{RT} + \frac{s^o_k(T,\theta)}{R}
      * @f]
      */
-    void getGibbs_RT(double* grt) const override;
+    void getGibbs_RT(span<double> grt) const override;
 
     //! Get the standard state chemical potential vector. Units: J/kmol.
     /*!
@@ -296,7 +296,7 @@ public:
      *      \mu^o_k(T,\theta) = h^o_k(T,\theta) + Ts^o_k(T,\theta)
      * @f]
      */
-    void getStandardChemPotentials(double* mu0) const override;
+    void getStandardChemPotentials(span<double> mu0) const override;
     //! @}
 
     //! @name Methods calculating partial molar thermodynamic properties
@@ -310,7 +310,7 @@ public:
      *      \tilde{h}_k(T,\theta) = h^o_k(T,\theta)
      * @f]
      */
-    void getPartialMolarEnthalpies(double* hbar) const override;
+    void getPartialMolarEnthalpies(span<double> hbar) const override;
 
     //! Get the partial molar entropy vector. Units: J/kmol/K.
     /*!
@@ -318,7 +318,7 @@ public:
      *      \tilde{s}_k(T,\theta) = s^o_k(T,\theta) - R\ln(\theta_k)
      * @f]
      */
-    void getPartialMolarEntropies(double* sbar) const override;
+    void getPartialMolarEntropies(span<double> sbar) const override;
 
     //! Get the partial molar heat capacity vector. Units: J/kmol/K.
     /*!
@@ -326,7 +326,7 @@ public:
      *      \tilde{c}_{p,k}(T,\theta) = c^o_{p,k}(T,\theta)
      * @f]
      */
-    void getPartialMolarCp(double* cpbar) const override;
+    void getPartialMolarCp(span<double> cpbar) const override;
 
     //! Get the chemical potential vector. Units: J/kmol.
     /*!
@@ -334,7 +334,7 @@ public:
      *      \mu_k(T,\theta) = \mu^o_k(T,\theta) + RT\ln(\theta_k)
      * @f]
      */
-    void getChemPotentials(double* mu) const override;
+    void getChemPotentials(span<double> mu) const override;
     //! @}
 
     //! @name Methods calculating Phase thermodynamic properties

--- a/include/cantera/thermo/DebyeHuckel.h
+++ b/include/cantera/thermo/DebyeHuckel.h
@@ -455,7 +455,7 @@ public:
     //! to be molality-based here.
     //! @{
 
-    void getActivityConcentrations(double* c) const override;
+    void getActivityConcentrations(span<double> c) const override;
 
     //! Return the standard concentration for the kth species
     /*!
@@ -480,7 +480,7 @@ public:
      *
      * @param ac  Output vector of activities. Length: m_kk.
      */
-    void getActivities(double* ac) const override;
+    void getActivities(span<double> ac) const override;
 
     //! Get the array of non-dimensional molality-based activity coefficients at
     //! the current solution temperature, pressure, and solution concentration.
@@ -493,7 +493,7 @@ public:
      * @param acMolality Vector of Molality-based activity coefficients
      *                   Length: m_kk
      */
-    void getMolalityActivityCoefficients(double* acMolality) const override;
+    void getMolalityActivityCoefficients(span<double> acMolality) const override;
 
     //! @}
     //! @name Partial Molar Properties of the Solution
@@ -512,7 +512,7 @@ public:
      * @param mu  Output vector of species chemical
      *            potentials. Length: m_kk. Units: J/kmol
      */
-    void getChemPotentials(double* mu) const override;
+    void getChemPotentials(span<double> mu) const override;
 
     //! Returns an array of partial molar enthalpies for the species
     //! in the mixture. Units (J/kmol)
@@ -535,7 +535,7 @@ public:
      * @param hbar    Output vector of species partial molar enthalpies.
      *                Length: m_kk. units are J/kmol.
      */
-    void getPartialMolarEnthalpies(double* hbar) const override;
+    void getPartialMolarEnthalpies(span<double> hbar) const override;
 
     //! Returns an array of partial molar entropies of the species in the
     //! solution. Units: J/kmol/K.
@@ -565,9 +565,9 @@ public:
      *  @param sbar    Output vector of species partial molar entropies.
      *                 Length = m_kk. units are J/kmol/K.
      */
-    void getPartialMolarEntropies(double* sbar) const override;
+    void getPartialMolarEntropies(span<double> sbar) const override;
 
-    void getPartialMolarCp(double* cpbar) const override;
+    void getPartialMolarCp(span<double> cpbar) const override;
 
     //! Return an array of partial molar volumes for the species in the mixture.
     //! Units: m^3/kmol.
@@ -585,7 +585,7 @@ public:
      *  @param vbar   Output vector of species partial molar volumes.
      *                Length = m_kk. units are m^3/kmol.
      */
-    void getPartialMolarVolumes(double* vbar) const override;
+    void getPartialMolarVolumes(span<double> vbar) const override;
 
     //! @}
 

--- a/include/cantera/thermo/EEDFTwoTermApproximation.h
+++ b/include/cantera/thermo/EEDFTwoTermApproximation.h
@@ -150,7 +150,7 @@ protected:
      * \epsilon \sigma_k exp[(\epsilon_i - \epsilon)g_i] d \epsilon
      * \f]
      */
-    Eigen::SparseMatrix<double> matrix_P(const vector<double>& g, size_t k);
+    Eigen::SparseMatrix<double> matrix_P(span<const double> g, size_t k);
 
     //! The matrix of scattering-in
     /**
@@ -169,7 +169,7 @@ protected:
      * \epsilon_2 = \min(\max(\epsilon_{i+1/2}+u_k, \epsilon_{j-1/2}),\epsilon_{j+1/2})
      * \f]
      */
-    Eigen::SparseMatrix<double> matrix_Q(const vector<double>& g, size_t k);
+    Eigen::SparseMatrix<double> matrix_Q(span<const double> g, size_t k);
 
     //! Matrix A (Ax = b) of the equation of EEDF, which is discretized by the exponential scheme
     //! of Scharfetter and Gummel,

--- a/include/cantera/thermo/GibbsExcessVPSSTP.h
+++ b/include/cantera/thermo/GibbsExcessVPSSTP.h
@@ -107,7 +107,7 @@ public:
     //! @{
 
     Units standardConcentrationUnits() const override;
-    void getActivityConcentrations(double* c) const override;
+    void getActivityConcentrations(span<double> c) const override;
 
     /**
      * The standard concentration @f$ C^0_k @f$ used to normalize the
@@ -139,9 +139,9 @@ public:
      *
      * @param ac     Output vector of molality-based activities. Length: m_kk.
      */
-    void getActivities(double* ac) const override;
+    void getActivities(span<double> ac) const override;
 
-    void getActivityCoefficients(double* ac) const override;
+    void getActivityCoefficients(span<double> ac) const override;
 
     //! Get the array of temperature derivatives of the log activity coefficients
     /*!
@@ -151,11 +151,12 @@ public:
      * @param dlnActCoeffdT    Output vector of temperature derivatives of the
      *                         log Activity Coefficients. length = m_kk
      */
-    virtual void getdlnActCoeffdT(double* dlnActCoeffdT) const {
+    virtual void getdlnActCoeffdT(span<double> dlnActCoeffdT) const {
         throw NotImplementedError("GibbsExcessVPSSTP::getdlnActCoeffdT");
     }
 
-    void getdlnActCoeffdlnN(const size_t ld, double* const dlnActCoeffdlnN) override {
+    void getdlnActCoeffdlnN(const size_t ld,
+                            span<double> const dlnActCoeffdlnN) override {
         throw NotImplementedError("GibbsExcessVPSSTP::getdlnActCoeffdlnN: "
                                   "nonzero and nonimplemented");
     }
@@ -176,7 +177,7 @@ public:
      * @param dlnActCoeffdlnX    Output vector of derivatives of the
      *                         log Activity Coefficients. length = m_kk
      */
-    virtual void getdlnActCoeffdlnX(double* dlnActCoeffdlnX) const {
+    virtual void getdlnActCoeffdlnX(span<double> dlnActCoeffdlnX) const {
         throw NotImplementedError("GibbsExcessVPSSTP::getdlnActCoeffdlnX");
     }
 
@@ -194,7 +195,7 @@ public:
      *  @param vbar   Output vector of species partial molar volumes.
      *                Length = m_kk. units are m^3/kmol.
      */
-    void getPartialMolarVolumes(double* vbar) const override;
+    void getPartialMolarVolumes(span<double> vbar) const override;
     //! @}
 
     bool addSpecies(shared_ptr<Species> spec) override;

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -1102,17 +1102,18 @@ public:
      */
 
     void setBinarySalt(const string& sp1, const string& sp2,
-        size_t nParams, double* beta0, double* beta1, double* beta2,
-        double* Cphi, double alpha1, double alpha2);
+        span<const double> beta0, span<const double> beta1,
+        span<const double> beta2, span<const double> Cphi, double alpha1,
+        double alpha2);
     void setTheta(const string& sp1, const string& sp2,
-        size_t nParams, double* theta);
+        span<const double> theta);
     void setPsi(const string& sp1, const string& sp2,
-        const string& sp3, size_t nParams, double* psi);
+        const string& sp3, span<const double> psi);
     void setLambda(const string& sp1, const string& sp2,
-        size_t nParams, double* lambda);
-    void setMunnn(const string& sp, size_t nParams, double* munnn);
+        span<const double> lambda);
+    void setMunnn(const string& sp, span<const double> munnn);
     void setZeta(const string& sp1, const string& sp2,
-        const string& sp3, size_t nParams, double* psi);
+        const string& sp3, span<const double> psi);
 
     void setPitzerTempModel(const string& model);
     void setPitzerRefTemperature(double Tref) {
@@ -2009,13 +2010,12 @@ private:
      *
      * @param z1 charge of the first molecule
      * @param z2 charge of the second molecule
-     * @param etheta return pointer containing etheta
-     * @param etheta_prime Return pointer containing etheta_prime.
+     * @param[out] etheta return value of etheta
+     * @param[out] etheta_prime return value of etheta_prime
      *
      * This routine uses the internal variables, elambda[] and elambda1[].
      */
-    void calc_thetas(int z1, int z2,
-                     double* etheta, double* etheta_prime) const;
+    void calc_thetas(int z1, int z2, double& etheta, double& etheta_prime) const;
 
     //! Set up a counter variable for keeping track of symmetric binary
     //! interactions amongst the solute species.

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -872,7 +872,7 @@ public:
      * @param c Array of generalized concentrations. The
      *          units are kmol m-3 for both the solvent and the solute species
      */
-    void getActivityConcentrations(double* c) const override;
+    void getActivityConcentrations(span<double> c) const override;
 
     //! Return the standard concentration for the kth species
     /*!
@@ -966,7 +966,7 @@ public:
      *
      * @param ac  Output vector of activities. Length: m_kk.
      */
-    void getActivities(double* ac) const override;
+    void getActivities(span<double> ac) const override;
 
     //! @}
     //! @name  Partial Molar Properties of the Solution
@@ -985,7 +985,7 @@ public:
      * @param mu  Output vector of species chemical
      *            potentials. Length: m_kk. Units: J/kmol
      */
-    void getChemPotentials(double* mu) const override;
+    void getChemPotentials(span<double> mu) const override;
 
     //! Returns an array of partial molar enthalpies for the species
     //! in the mixture. Units (J/kmol)
@@ -1008,7 +1008,7 @@ public:
      * @param hbar    Output vector of species partial molar enthalpies.
      *                Length: m_kk. units are J/kmol.
      */
-    void getPartialMolarEnthalpies(double* hbar) const override;
+    void getPartialMolarEnthalpies(span<double> hbar) const override;
 
     //! Returns an array of partial molar entropies of the species in the
     //! solution. Units: J/kmol/K.
@@ -1035,7 +1035,7 @@ public:
      *  @param sbar    Output vector of species partial molar entropies.
      *                 Length = m_kk. units are J/kmol/K.
      */
-    void getPartialMolarEntropies(double* sbar) const override;
+    void getPartialMolarEntropies(span<double> sbar) const override;
 
     //! Return an array of partial molar volumes for the species in the mixture.
     //! Units: m^3/kmol.
@@ -1055,7 +1055,7 @@ public:
      * @param vbar   Output vector of species partial molar volumes.
      *               Length = m_kk. units are m^3/kmol.
      */
-    void getPartialMolarVolumes(double* vbar) const override;
+    void getPartialMolarVolumes(span<double> vbar) const override;
 
     //! Return an array of partial molar heat capacities for the species in the
     //! mixture.  Units: J/kmol/K
@@ -1076,7 +1076,7 @@ public:
      * @param cpbar   Output vector of species partial molar heat capacities at
      *                constant pressure. Length = m_kk. units are J/kmol/K.
      */
-    void getPartialMolarCp(double* cpbar) const override;
+    void getPartialMolarCp(span<double> cpbar) const override;
 
 public:
     //! @}
@@ -1260,7 +1260,7 @@ public:
      * @param acMolality Output vector containing the molality based activity coefficients.
      *                   length: m_kk.
      */
-    void getUnscaledMolalityActivityCoefficients(double* acMolality) const override;
+    void getUnscaledMolalityActivityCoefficients(span<double> acMolality) const override;
 
 private:
     //! Apply the current phScale to a set of activity Coefficients
@@ -1898,7 +1898,7 @@ private:
      * @param acMolality input/Output vector containing the molality based
      *                   activity coefficients. length: m_kk.
      */
-    void applyphScale(double* acMolality) const override;
+    void applyphScale(span<double> acMolality) const override;
 
 private:
     /**

--- a/include/cantera/thermo/IdealGasPhase.h
+++ b/include/cantera/thermo/IdealGasPhase.h
@@ -438,8 +438,8 @@ public:
      *           upon the implementation of the reaction rate expressions within
      *           the phase.
      */
-    void getActivityConcentrations(double* c) const override {
-        getConcentrations(span<double>(c, nSpecies()));
+    void getActivityConcentrations(span<double> c) const override {
+        getConcentrations(c);
     }
 
     //! Returns the standard concentration @f$ C^0_k @f$, which is used to
@@ -465,42 +465,42 @@ public:
      *
      * @param ac Output vector of activity coefficients. Length: m_kk.
      */
-    void getActivityCoefficients(double* ac) const override;
+    void getActivityCoefficients(span<double> ac) const override;
 
     //! @}
     //! @name Partial Molar Properties of the Solution
     //! @{
 
-    void getChemPotentials(double* mu) const override;
-    void getPartialMolarEnthalpies(double* hbar) const override;
-    void getPartialMolarEntropies(double* sbar) const override;
-    void getPartialMolarIntEnergies(double* ubar) const override;
-    void getPartialMolarCp(double* cpbar) const override;
-    void getPartialMolarVolumes(double* vbar) const override;
+    void getChemPotentials(span<double> mu) const override;
+    void getPartialMolarEnthalpies(span<double> hbar) const override;
+    void getPartialMolarEntropies(span<double> sbar) const override;
+    void getPartialMolarIntEnergies(span<double> ubar) const override;
+    void getPartialMolarCp(span<double> cpbar) const override;
+    void getPartialMolarVolumes(span<double> vbar) const override;
 
     //! @}
     //! @name  Properties of the Standard State of the Species in the Solution
     //! @{
 
-    void getStandardChemPotentials(double* mu) const override;
-    void getEnthalpy_RT(double* hrt) const override;
-    void getEntropy_R(double* sr) const override;
-    void getGibbs_RT(double* grt) const override;
-    void getIntEnergy_RT(double* urt) const override;
-    void getCp_R(double* cpr) const override;
-    void getStandardVolumes(double* vol) const override;
+    void getStandardChemPotentials(span<double> mu) const override;
+    void getEnthalpy_RT(span<double> hrt) const override;
+    void getEntropy_R(span<double> sr) const override;
+    void getGibbs_RT(span<double> grt) const override;
+    void getIntEnergy_RT(span<double> urt) const override;
+    void getCp_R(span<double> cpr) const override;
+    void getStandardVolumes(span<double> vol) const override;
 
     //! @}
     //! @name Thermodynamic Values for the Species Reference States
     //! @{
 
-    void getEnthalpy_RT_ref(double* hrt) const override;
-    void getGibbs_RT_ref(double* grt) const override;
-    void getGibbs_ref(double* g) const override;
-    void getEntropy_R_ref(double* er) const override;
-    void getIntEnergy_RT_ref(double* urt) const override;
-    void getCp_R_ref(double* cprt) const override;
-    void getStandardVolumes_ref(double* vol) const override;
+    void getEnthalpy_RT_ref(span<double> hrt) const override;
+    void getGibbs_RT_ref(span<double> grt) const override;
+    void getGibbs_ref(span<double> g) const override;
+    void getEntropy_R_ref(span<double> er) const override;
+    void getIntEnergy_RT_ref(span<double> urt) const override;
+    void getCp_R_ref(span<double> cprt) const override;
+    void getStandardVolumes_ref(span<double> vol) const override;
 
     //! @}
     //! @name NonVirtual Internal methods to Return References to Reference State Thermo
@@ -549,7 +549,7 @@ public:
     //! @}
 
     bool addSpecies(shared_ptr<Species> spec) override;
-    void setToEquilState(const double* mu_RT) override;
+    void setToEquilState(span<const double> mu_RT) override;
 
 protected:
     //! Reference state pressure

--- a/include/cantera/thermo/IdealGasPhase.h
+++ b/include/cantera/thermo/IdealGasPhase.h
@@ -503,6 +503,11 @@ public:
     void getStandardVolumes_ref(span<double> vol) const override;
 
     //! @}
+
+    bool addSpecies(shared_ptr<Species> spec) override;
+    void setToEquilState(span<const double> mu_RT) override;
+
+protected:
     //! @name NonVirtual Internal methods to Return References to Reference State Thermo
     //! @{
 
@@ -511,7 +516,7 @@ public:
      * This function is part of the layer that checks/recalculates the reference
      * state thermo functions.
      */
-    const vector<double>& enthalpy_RT_ref() const {
+    span<const double> enthalpy_RT_ref() const {
         updateThermo();
         return m_h0_RT;
     }
@@ -521,7 +526,7 @@ public:
      * This function is part of the layer that checks/recalculates the reference
      * state thermo functions.
      */
-    const vector<double>& gibbs_RT_ref() const {
+    span<const double> gibbs_RT_ref() const {
         updateThermo();
         return m_g0_RT;
     }
@@ -531,7 +536,7 @@ public:
      * This function is part of the layer that checks/recalculates the reference
      * state thermo functions.
      */
-    const vector<double>& entropy_R_ref() const {
+    span<const double> entropy_R_ref() const {
         updateThermo();
         return m_s0_R;
     }
@@ -541,17 +546,13 @@ public:
      * This function is part of the layer that checks/recalculates the reference
      * state thermo functions.
      */
-    const vector<double>& cp_R_ref() const {
+    span<const double> cp_R_ref() const {
         updateThermo();
         return m_cp0_R;
     }
 
     //! @}
 
-    bool addSpecies(shared_ptr<Species> spec) override;
-    void setToEquilState(span<const double> mu_RT) override;
-
-protected:
     //! Reference state pressure
     /*!
      *  Value of the reference state pressure in Pascals.

--- a/include/cantera/thermo/IdealGasPhase.h
+++ b/include/cantera/thermo/IdealGasPhase.h
@@ -439,7 +439,7 @@ public:
      *           the phase.
      */
     void getActivityConcentrations(double* c) const override {
-        getConcentrations(c);
+        getConcentrations(span<double>(c, nSpecies()));
     }
 
     //! Returns the standard concentration @f$ C^0_k @f$, which is used to

--- a/include/cantera/thermo/IdealMolalSoln.h
+++ b/include/cantera/thermo/IdealMolalSoln.h
@@ -146,7 +146,7 @@ public:
     //! @{
 
     Units standardConcentrationUnits() const override;
-    void getActivityConcentrations(double* c) const override;
+    void getActivityConcentrations(span<double> c) const override;
     double standardConcentration(size_t k=0) const override;
 
     /**
@@ -157,7 +157,7 @@ public:
      *
      * @param ac      Output activity coefficients. Length: m_kk.
      */
-    void getActivities(double* ac) const override;
+    void getActivities(span<double> ac) const override;
 
     /**
      * Get the array of non-dimensional molality-based activity coefficients at
@@ -169,7 +169,7 @@ public:
      * @param acMolality      Output Molality-based activity coefficients.
      *                        Length: m_kk.
      */
-    void getMolalityActivityCoefficients(double* acMolality) const override;
+    void getMolalityActivityCoefficients(span<double> acMolality) const override;
 
     //! @}
     //! @name  Partial Molar Properties of the Solution
@@ -197,7 +197,7 @@ public:
      *
      * @param mu     Output vector of species chemical potentials. Length: m_kk.
      */
-    void getChemPotentials(double* mu) const override;
+    void getChemPotentials(span<double> mu) const override;
 
     //! Returns an array of partial molar enthalpies for the species in the
     //! mixture.
@@ -216,7 +216,7 @@ public:
      * @param hbar   Output vector of partial molar enthalpies.
      *               Length: m_kk.
      */
-    void getPartialMolarEnthalpies(double* hbar) const override;
+    void getPartialMolarEnthalpies(span<double> hbar) const override;
 
     //! Returns an array of partial molar internal energies for the species in the
     //! mixture.
@@ -229,7 +229,7 @@ public:
      * @f]
      * @param hbar   Output vector of partial molar internal energies, length #m_kk
      */
-    void getPartialMolarIntEnergies(double* hbar) const override;
+    void getPartialMolarIntEnergies(span<double> hbar) const override;
 
     //! Returns an array of partial molar entropies of the species in the
     //! solution. Units: J/kmol.
@@ -259,7 +259,7 @@ public:
      * @param sbar Output vector of partial molar entropies.
      *             Length: m_kk.
      */
-    void getPartialMolarEntropies(double* sbar) const override;
+    void getPartialMolarEntropies(span<double> sbar) const override;
 
     // partial molar volumes of the species Units: m^3 kmol-1.
     /*!
@@ -269,7 +269,7 @@ public:
      * Units: m^3 kmol-1.
      *  @param vbar Output vector of partial molar volumes.
      */
-    void getPartialMolarVolumes(double* vbar) const override;
+    void getPartialMolarVolumes(span<double> vbar) const override;
 
     //! Partial molar heat capacity of the solution:. UnitsL J/kmol/K
     /*!
@@ -287,7 +287,7 @@ public:
      * @param cpbar  Output vector of partial molar heat capacities.
      *               Length: m_kk.
      */
-    void getPartialMolarCp(double* cpbar) const override;
+    void getPartialMolarCp(span<double> cpbar) const override;
 
     //! @}
 
@@ -329,7 +329,7 @@ public:
      *
      * @param smv Output vector of species molar volumes.
      */
-    void getSpeciesMolarVolumes(double* smv) const;
+    void getSpeciesMolarVolumes(span<double> smv) const;
 
 protected:
     //! Species molar volume @f$ m^3 kmol^{-1} @f$

--- a/include/cantera/thermo/IdealSolidSolnPhase.h
+++ b/include/cantera/thermo/IdealSolidSolnPhase.h
@@ -242,7 +242,7 @@ public:
      * @param c  Pointer to array of doubles of length m_kk, which on exit
      *           will contain the generalized concentrations.
      */
-    void getActivityConcentrations(double* c) const override;
+    void getActivityConcentrations(span<double> c) const override;
 
     /**
      * The standard concentration @f$ C^0_k @f$ used to normalize the
@@ -260,7 +260,7 @@ public:
     /*!
      * @param ac output vector of activity coefficients. Length: m_kk
      */
-    void getActivityCoefficients(double* ac) const override;
+    void getActivityCoefficients(span<double> ac) const override;
 
     /**
      * Get the species chemical potentials. Units: J/kmol.
@@ -278,7 +278,7 @@ public:
      *
      * @param mu  Output vector of chemical potentials.
      */
-    void getChemPotentials(double* mu) const override;
+    void getChemPotentials(span<double> mu) const override;
 
     //! @}
     //! @name  Partial Molar Properties of the Solution
@@ -301,7 +301,7 @@ public:
      * @param hbar Output vector containing partial molar enthalpies.
      *             Length: m_kk.
      */
-    void getPartialMolarEnthalpies(double* hbar) const override;
+    void getPartialMolarEnthalpies(span<double> hbar) const override;
 
     /**
      * Returns an array of partial molar entropies of the species in the
@@ -320,7 +320,7 @@ public:
      * @param sbar Output vector containing partial molar entropies.
      *             Length: m_kk.
      */
-    void getPartialMolarEntropies(double* sbar) const override;
+    void getPartialMolarEntropies(span<double> sbar) const override;
 
     /**
      * Returns an array of partial molar Heat Capacities at constant pressure of
@@ -329,7 +329,7 @@ public:
      *
      * @param cpbar  Output vector of partial heat capacities. Length: m_kk.
      */
-    void getPartialMolarCp(double* cpbar) const override;
+    void getPartialMolarCp(span<double> cpbar) const override;
 
     /**
      * returns an array of partial molar volumes of the species
@@ -340,7 +340,7 @@ public:
      *
      * @param vbar  Output vector of partial molar volumes. Length: m_kk.
      */
-    void getPartialMolarVolumes(double* vbar) const override;
+    void getPartialMolarVolumes(span<double> vbar) const override;
 
     //! @}
     //! @name  Properties of the Standard State of the Species in the Solution
@@ -359,7 +359,7 @@ public:
      * @param mu0   Output vector of standard state chemical potentials.
      *              Length: m_kk.
      */
-    void getStandardChemPotentials(double* mu0) const override;
+    void getStandardChemPotentials(span<double> mu0) const override;
 
     //! Get the array of nondimensional Enthalpy functions for the standard
     //! state species at the current *T* and *P* of the solution.
@@ -375,7 +375,7 @@ public:
      * @param hrt Vector of length m_kk, which on return hrt[k] will contain the
      *            nondimensional standard state enthalpy of species k.
      */
-    void getEnthalpy_RT(double* hrt) const override;
+    void getEnthalpy_RT(span<double> hrt) const override;
 
     //! Get the nondimensional Entropies for the species standard states at the
     //! current T and P of the solution.
@@ -386,7 +386,7 @@ public:
      * @param sr Vector of length m_kk, which on return sr[k] will contain the
      *           nondimensional standard state entropy for species k.
      */
-    void getEntropy_R(double* sr) const override;
+    void getEntropy_R(span<double> sr) const override;
 
     /**
      * Get the nondimensional Gibbs function for the species standard states at
@@ -402,9 +402,9 @@ public:
      * @param grt Vector of length m_kk, which on return sr[k] will contain the
      *           nondimensional standard state Gibbs function for species k.
      */
-    void getGibbs_RT(double* grt) const override;
+    void getGibbs_RT(span<double> grt) const override;
 
-    void getIntEnergy_RT(double* urt) const override;
+    void getIntEnergy_RT(span<double> urt) const override;
 
     /**
      * Get the nondimensional heat capacity at constant pressure function for
@@ -419,20 +419,20 @@ public:
      * @param cpr Vector of length m_kk, which on return cpr[k] will contain the
      *           nondimensional constant pressure heat capacity for species k.
      */
-    void getCp_R(double* cpr) const override;
+    void getCp_R(span<double> cpr) const override;
 
-    void getStandardVolumes(double* vol) const override;
+    void getStandardVolumes(span<double> vol) const override;
 
     //! @}
     //! @name Thermodynamic Values for the Species Reference States
     //! @{
 
-    void getEnthalpy_RT_ref(double* hrt) const override;
-    void getGibbs_RT_ref(double* grt) const override;
-    void getGibbs_ref(double* g) const override;
-    void getEntropy_R_ref(double* er) const override;
-    void getIntEnergy_RT_ref(double* urt) const override;
-    void getCp_R_ref(double* cprt) const override;
+    void getEnthalpy_RT_ref(span<double> hrt) const override;
+    void getGibbs_RT_ref(span<double> grt) const override;
+    void getGibbs_ref(span<double> g) const override;
+    void getEntropy_R_ref(span<double> er) const override;
+    void getIntEnergy_RT_ref(span<double> urt) const override;
+    void getCp_R_ref(span<double> cprt) const override;
 
     /**
      * Returns a reference to the vector of nondimensional enthalpies of the
@@ -480,7 +480,7 @@ public:
     void initThermo() override;
     void getParameters(AnyMap& phaseNode) const override;
     void getSpeciesParameters(const string& name, AnyMap& speciesNode) const override;
-    void setToEquilState(const double* mu_RT) override;
+    void setToEquilState(span<const double> mu_RT) override;
 
     //! Set the form for the standard and generalized concentrations
     /*!
@@ -515,7 +515,7 @@ public:
      * @param smv  output vector containing species molar volumes.
      *             Length: m_kk.
      */
-    void getSpeciesMolarVolumes(double* smv) const;
+    void getSpeciesMolarVolumes(span<double> smv) const;
 
     //! @}
 

--- a/include/cantera/thermo/IdealSolidSolnPhase.h
+++ b/include/cantera/thermo/IdealSolidSolnPhase.h
@@ -434,44 +434,6 @@ public:
     void getIntEnergy_RT_ref(span<double> urt) const override;
     void getCp_R_ref(span<double> cprt) const override;
 
-    /**
-     * Returns a reference to the vector of nondimensional enthalpies of the
-     * reference state at the current temperature. Real reason for its existence
-     * is that it also checks to see if a recalculation of the reference
-     * thermodynamics functions needs to be done.
-     */
-    const vector<double>& enthalpy_RT_ref() const;
-
-    /**
-     * Returns a reference to the vector of nondimensional enthalpies of the
-     * reference state at the current temperature. Real reason for its existence
-     * is that it also checks to see if a recalculation of the reference
-     * thermodynamics functions needs to be done.
-     */
-    const vector<double>& gibbs_RT_ref() const {
-        _updateThermo();
-        return m_g0_RT;
-    }
-
-    /**
-     * Returns a reference to the vector of nondimensional enthalpies of the
-     * reference state at the current temperature. Real reason for its existence
-     * is that it also checks to see if a recalculation of the reference
-     * thermodynamics functions needs to be done.
-     */
-    const vector<double>& entropy_R_ref() const;
-
-    /**
-     * Returns a reference to the vector of nondimensional enthalpies of the
-     * reference state at the current temperature. Real reason for its existence
-     * is that it also checks to see if a recalculation of the reference
-     * thermodynamics functions needs to be done.
-     */
-    const vector<double>& cp_R_ref() const {
-        _updateThermo();
-        return m_cp0_R;
-    }
-
     //! @}
     //! @name Utility Functions
     //! @{
@@ -521,6 +483,44 @@ public:
 
 protected:
     void compositionChanged() override;
+
+    /**
+     * Returns a reference to the vector of nondimensional enthalpies of the
+     * reference state at the current temperature. Real reason for its existence
+     * is that it also checks to see if a recalculation of the reference
+     * thermodynamics functions needs to be done.
+     */
+    span<const double> enthalpy_RT_ref() const;
+
+    /**
+     * Returns a reference to the vector of nondimensional enthalpies of the
+     * reference state at the current temperature. Real reason for its existence
+     * is that it also checks to see if a recalculation of the reference
+     * thermodynamics functions needs to be done.
+     */
+    span<const double> gibbs_RT_ref() const {
+        _updateThermo();
+        return m_g0_RT;
+    }
+
+    /**
+     * Returns a reference to the vector of nondimensional enthalpies of the
+     * reference state at the current temperature. Real reason for its existence
+     * is that it also checks to see if a recalculation of the reference
+     * thermodynamics functions needs to be done.
+     */
+    span<const double> entropy_R_ref() const;
+
+    /**
+     * Returns a reference to the vector of nondimensional enthalpies of the
+     * reference state at the current temperature. Real reason for its existence
+     * is that it also checks to see if a recalculation of the reference
+     * thermodynamics functions needs to be done.
+     */
+    span<const double> cp_R_ref() const {
+        _updateThermo();
+        return m_cp0_R;
+    }
 
     /**
      * The standard concentrations can have one of three different forms:

--- a/include/cantera/thermo/IdealSolnGasVPSS.h
+++ b/include/cantera/thermo/IdealSolnGasVPSS.h
@@ -68,7 +68,7 @@ protected:
 
 public:
     Units standardConcentrationUnits() const override;
-    void getActivityConcentrations(double* c) const override;
+    void getActivityConcentrations(span<double> c) const override;
 
     //! Returns the standard concentration @f$ C^0_k @f$, which is used to
     //! normalize the generalized concentration.
@@ -84,18 +84,18 @@ public:
      */
     double standardConcentration(size_t k=0) const override;
 
-    void getActivityCoefficients(double* ac) const override;
+    void getActivityCoefficients(span<double> ac) const override;
 
 
     //! @name  Partial Molar Properties of the Solution
     //! @{
 
-    void getChemPotentials(double* mu) const override;
-    void getPartialMolarEnthalpies(double* hbar) const override;
-    void getPartialMolarEntropies(double* sbar) const override;
-    void getPartialMolarIntEnergies(double* ubar) const override;
-    void getPartialMolarCp(double* cpbar) const override;
-    void getPartialMolarVolumes(double* vbar) const override;
+    void getChemPotentials(span<double> mu) const override;
+    void getPartialMolarEnthalpies(span<double> hbar) const override;
+    void getPartialMolarEntropies(span<double> sbar) const override;
+    void getPartialMolarIntEnergies(span<double> ubar) const override;
+    void getPartialMolarCp(span<double> cpbar) const override;
+    void getPartialMolarVolumes(span<double> vbar) const override;
     //! @}
 
 public:
@@ -110,7 +110,7 @@ public:
     bool addSpecies(shared_ptr<Species> spec) override;
     void initThermo() override;
     void getParameters(AnyMap& phaseNode) const override;
-    void setToEquilState(const double* lambda_RT) override;
+    void setToEquilState(span<const double> lambda_RT) override;
 
     //! @}
 

--- a/include/cantera/thermo/MargulesVPSSTP.h
+++ b/include/cantera/thermo/MargulesVPSSTP.h
@@ -319,7 +319,7 @@ public:
      * @param d2lnActCoeffdT2  Output vector of temperature 2nd derivatives of
      *                         the log Activity Coefficients. length = m_kk
      */
-    void getd2lnActCoeffdT2(double* d2lnActCoeffdT2) const;
+    void getd2lnActCoeffdT2(span<double> d2lnActCoeffdT2) const;
 
     void getdlnActCoeffdT(span<double> dlnActCoeffdT) const override;
 

--- a/include/cantera/thermo/MargulesVPSSTP.h
+++ b/include/cantera/thermo/MargulesVPSSTP.h
@@ -241,13 +241,13 @@ public:
     //! which depends only on temperature and pressure.
     //! @{
 
-    void getLnActivityCoefficients(double* lnac) const override;
+    void getLnActivityCoefficients(span<double> lnac) const override;
 
     //! @}
     //! @name  Partial Molar Properties of the Solution
     //! @{
 
-    void getChemPotentials(double* mu) const override;
+    void getChemPotentials(span<double> mu) const override;
 
     //! Returns an array of partial molar enthalpies for the species in the
     //! mixture.
@@ -265,7 +265,7 @@ public:
      * @param hbar  Vector of returned partial molar enthalpies
      *              (length m_kk, units = J/kmol)
      */
-    void getPartialMolarEnthalpies(double* hbar) const override;
+    void getPartialMolarEnthalpies(span<double> hbar) const override;
 
     //! Returns an array of partial molar entropies for the species in the
     //! mixture.
@@ -285,7 +285,7 @@ public:
      * @param sbar  Vector of returned partial molar entropies
      *              (length m_kk, units = J/kmol/K)
      */
-    void getPartialMolarEntropies(double* sbar) const override;
+    void getPartialMolarEntropies(span<double> sbar) const override;
 
     //! Returns an array of partial molar entropies for the species in the
     //! mixture.
@@ -307,9 +307,9 @@ public:
      * @param cpbar  Vector of returned partial molar heat capacities
      *              (length m_kk, units = J/kmol/K)
      */
-    void getPartialMolarCp(double* cpbar) const override;
+    void getPartialMolarCp(span<double> cpbar) const override;
 
-    void getPartialMolarVolumes(double* vbar) const override;
+    void getPartialMolarVolumes(span<double> vbar) const override;
 
     //! Get the array of temperature second derivatives of the log activity
     //! coefficients
@@ -321,7 +321,7 @@ public:
      */
     void getd2lnActCoeffdT2(double* d2lnActCoeffdT2) const;
 
-    void getdlnActCoeffdT(double* dlnActCoeffdT) const override;
+    void getdlnActCoeffdT(span<double> dlnActCoeffdT) const override;
 
     //! @}
     //! @name Initialization
@@ -356,11 +356,12 @@ public:
     //! @name  Derivatives of Thermodynamic Variables needed for Applications
     //! @{
 
-    void getdlnActCoeffds(const double dTds, const double* const dXds,
-                          double* dlnActCoeffds) const override;
-    void getdlnActCoeffdlnX_diag(double* dlnActCoeffdlnX_diag) const override;
-    void getdlnActCoeffdlnN_diag(double* dlnActCoeffdlnN_diag) const override;
-    void getdlnActCoeffdlnN(const size_t ld, double* const dlnActCoeffdlnN) override;
+    void getdlnActCoeffds(const double dTds, span<const double> dXds,
+                          span<double> dlnActCoeffds) const override;
+    void getdlnActCoeffdlnX_diag(span<double> dlnActCoeffdlnX_diag) const override;
+    void getdlnActCoeffdlnN_diag(span<double> dlnActCoeffdlnN_diag) const override;
+    void getdlnActCoeffdlnN(const size_t ld,
+                            span<double> const dlnActCoeffdlnN) override;
 
     //! @}
 

--- a/include/cantera/thermo/MetalPhase.h
+++ b/include/cantera/thermo/MetalPhase.h
@@ -59,36 +59,36 @@ public:
         return m_press;
     }
 
-    void getChemPotentials(double* mu) const override {
+    void getChemPotentials(span<double> mu) const override {
         for (size_t n = 0; n < nSpecies(); n++) {
             mu[n] = 0.0;
         }
     }
 
-    void getEnthalpy_RT(double* hrt) const override {
+    void getEnthalpy_RT(span<double> hrt) const override {
         for (size_t n = 0; n < nSpecies(); n++) {
             hrt[n] = 0.0;
         }
     }
 
-    void getEntropy_R(double* sr) const override {
+    void getEntropy_R(span<double> sr) const override {
         for (size_t n = 0; n < nSpecies(); n++) {
             sr[n] = 0.0;
         }
     }
 
-    void getStandardChemPotentials(double* mu0) const override {
+    void getStandardChemPotentials(span<double> mu0) const override {
         for (size_t n = 0; n < nSpecies(); n++) {
             mu0[n] = 0.0;
         }
     }
 
-    void getActivityConcentrations(double* c) const override {
+    void getActivityConcentrations(span<double> c) const override {
         for (size_t n = 0; n < nSpecies(); n++) {
             c[n] = 1.0;
         }
     }
-    void getPartialMolarEnthalpies(double *h) const override {
+    void getPartialMolarEnthalpies(span<double> h) const override {
         for (size_t n = 0; n < nSpecies(); n++) {
             h[n] = 0.0;
         }

--- a/include/cantera/thermo/MixtureFugacityTP.h
+++ b/include/cantera/thermo/MixtureFugacityTP.h
@@ -134,7 +134,7 @@ public:
      * @param mu   Output vector of standard state chemical potentials.
      *             length = m_kk. units are J / kmol.
      */
-    void getStandardChemPotentials(double* mu) const override;
+    void getStandardChemPotentials(span<double> mu) const override;
 
     //! Get the nondimensional Enthalpy functions for the species at their
     //! standard states at the current *T* and *P* of the solution.
@@ -146,7 +146,7 @@ public:
     * @param hrt     Output vector of standard state enthalpies.
     *                length = m_kk. units are unitless.
     */
-    void getEnthalpy_RT(double* hrt) const override;
+    void getEnthalpy_RT(span<double> hrt) const override;
 
     //! Get the array of nondimensional Enthalpy functions for the standard
     //! state species at the current *T* and *P* of the solution.
@@ -158,7 +158,7 @@ public:
      * @param sr     Output vector of nondimensional standard state entropies.
      *               length = m_kk.
      */
-    void getEntropy_R(double* sr) const override;
+    void getEntropy_R(span<double> sr) const override;
 
     //! Get the nondimensional Gibbs functions for the species at their standard
     //! states of solution at the current T and P of the solution.
@@ -170,7 +170,7 @@ public:
      * @param grt    Output vector of nondimensional standard state Gibbs free
      *               energies. length = m_kk.
      */
-    void getGibbs_RT(double* grt) const override;
+    void getGibbs_RT(span<double> grt) const override;
 
     //! Returns the vector of nondimensional internal Energies of the standard
     //! state at the current temperature and pressure of the solution for each
@@ -187,7 +187,7 @@ public:
      * @param urt    Output vector of nondimensional standard state internal
      *               energies. length = m_kk.
      */
-    void getIntEnergy_RT(double* urt) const override;
+    void getIntEnergy_RT(span<double> urt) const override;
 
     //! Get the nondimensional Heat Capacities at constant pressure for the
     //! standard state of the species at the current T and P.
@@ -200,7 +200,7 @@ public:
      *               Capacities at constant pressure for the standard state of
      *               the species. Length: m_kk.
      */
-    void getCp_R(double* cpr) const override;
+    void getCp_R(span<double> cpr) const override;
 
     //! Get the molar volumes of each species in their standard states at the
     //! current *T* and *P* of the solution.
@@ -214,7 +214,7 @@ public:
      * @param vol Output vector of species volumes. length = m_kk.
      *            units =  m^3 / kmol
      */
-    void getStandardVolumes(double* vol) const override;
+    void getStandardVolumes(span<double> vol) const override;
     //! @}
 
     //! Set the temperature of the phase
@@ -266,8 +266,8 @@ public:
     //! routine _updateRefStateThermo().
     //! @{
 
-    void getEnthalpy_RT_ref(double* hrt) const override;
-    void getGibbs_RT_ref(double* grt) const override;
+    void getEnthalpy_RT_ref(span<double> hrt) const override;
+    void getGibbs_RT_ref(span<double> grt) const override;
 
 protected:
     //! Returns the vector of nondimensional Gibbs free energies of the
@@ -281,10 +281,10 @@ protected:
     const vector<double>& gibbs_RT_ref() const;
 
 public:
-    void getGibbs_ref(double* g) const override;
-    void getEntropy_R_ref(double* er) const override;
-    void getCp_R_ref(double* cprt) const override;
-    void getStandardVolumes_ref(double* vol) const override;
+    void getGibbs_ref(span<double> g) const override;
+    void getEntropy_R_ref(span<double> er) const override;
+    void getCp_R_ref(span<double> cprt) const override;
+    void getStandardVolumes_ref(span<double> vol) const override;
 
     //! @}
     //! @name Initialization Methods - For Internal use
@@ -425,7 +425,7 @@ public:
      * @return          The saturation pressure at the given temperature
      */
     double satPressure(double TKelvin) override;
-    void getActivityConcentrations(double* c) const override;
+    void getActivityConcentrations(span<double> c) const override;
 
 protected:
     //! Calculate the pressure and the pressure derivative given the temperature

--- a/include/cantera/thermo/MixtureFugacityTP.h
+++ b/include/cantera/thermo/MixtureFugacityTP.h
@@ -268,19 +268,6 @@ public:
 
     void getEnthalpy_RT_ref(span<double> hrt) const override;
     void getGibbs_RT_ref(span<double> grt) const override;
-
-protected:
-    //! Returns the vector of nondimensional Gibbs free energies of the
-    //! reference state at the current temperature of the solution and the
-    //! reference pressure for the species.
-    /*!
-     * @return  Output vector contains the nondimensional Gibbs free energies
-     *          of the reference state of the species
-     *          length = m_kk, units = dimensionless.
-     */
-    const vector<double>& gibbs_RT_ref() const;
-
-public:
     void getGibbs_ref(span<double> g) const override;
     void getEntropy_R_ref(span<double> er) const override;
     void getCp_R_ref(span<double> cprt) const override;

--- a/include/cantera/thermo/MolalityVPSSTP.h
+++ b/include/cantera/thermo/MolalityVPSSTP.h
@@ -318,7 +318,7 @@ public:
      *
      * @param molal       Output vector of molalities. Length: m_kk.
      */
-    void getMolalities(double* const molal) const;
+    void getMolalities(span<double> molal) const;
 
     //! Set the molalities of the solutes in a phase
     /*!
@@ -352,7 +352,7 @@ public:
      *
      * @param molal   Input vector of molalities. Length: m_kk.
      */
-    void setMolalities(const double* const molal);
+    void setMolalities(span<const double> molal);
 
     //! Set the molalities of a phase
     /*!
@@ -386,7 +386,7 @@ public:
      */
     int activityConvention() const override;
 
-    void getActivityConcentrations(double* c) const override;
+    void getActivityConcentrations(span<double> c) const override;
     double standardConcentration(size_t k=0) const override;
 
     //! Get the array of non-dimensional activities (molality based for this
@@ -405,7 +405,7 @@ public:
      *
      * @param ac     Output vector of molality-based activities. Length: m_kk.
      */
-    void getActivities(double* ac) const override;
+    void getActivities(span<double> ac) const override;
 
     //! Get the array of non-dimensional activity coefficients at
     //! the current solution temperature, pressure, and solution concentration.
@@ -436,7 +436,7 @@ public:
      * @param ac  Output vector containing the mole-fraction based activity
      *            coefficients. length: m_kk.
      */
-    void getActivityCoefficients(double* ac) const override;
+    void getActivityCoefficients(span<double> ac) const override;
 
     //! Get the array of non-dimensional molality based activity coefficients at
     //! the current solution temperature, pressure, and solution concentration.
@@ -467,7 +467,7 @@ public:
      * @param acMolality Output vector containing the molality based activity
      *                   coefficients. length: m_kk.
      */
-    virtual void getMolalityActivityCoefficients(double* acMolality) const;
+    virtual void getMolalityActivityCoefficients(span<double> acMolality) const;
 
     //! Calculate the osmotic coefficient
     /*!
@@ -507,7 +507,7 @@ public:
      * @param molalities  Input vector of molalities of the solutes.
      *                    Length: m_kk.
      */
-    void setState_TPM(double t, double p, const double* const molalities);
+    void setState_TPM(double t, double p, span<const double> molalities);
 
     //! Set the temperature (K), pressure (Pa), and molalities.
     /*!
@@ -532,7 +532,8 @@ public:
      */
     void setState(const AnyMap& state) override;
 
-    void getdlnActCoeffdlnN(const size_t ld, double* const dlnActCoeffdlnN) override {
+    void getdlnActCoeffdlnN(const size_t ld,
+                            span<double> const dlnActCoeffdlnN) override {
         getdlnActCoeffdlnN_numderiv(ld, dlnActCoeffdlnN);
     }
 
@@ -551,7 +552,7 @@ protected:
      * @param acMolality Output vector containing the molality based activity
      *                   coefficients. length: m_kk.
      */
-    virtual void getUnscaledMolalityActivityCoefficients(double* acMolality) const;
+    virtual void getUnscaledMolalityActivityCoefficients(span<double> acMolality) const;
 
     //! Apply the current phScale to a set of activity Coefficients or
     //! activities
@@ -561,7 +562,7 @@ protected:
      * @param acMolality input/Output vector containing the molality based
      *                   activity coefficients. length: m_kk.
      */
-    virtual void applyphScale(double* acMolality) const;
+    virtual void applyphScale(span<double> acMolality) const;
 
 private:
     //! Returns the index of the Cl- species.

--- a/include/cantera/thermo/Mu0Poly.h
+++ b/include/cantera/thermo/Mu0Poly.h
@@ -94,7 +94,7 @@ public:
      *            - coeffs[7] = @f$ \mu^o(T_3) @f$ (J/kmol)
      *            - ........
      */
-    Mu0Poly(double tlow, double thigh, double pref, const double* coeffs);
+    Mu0Poly(double tlow, double thigh, double pref, span<const double> coeffs);
 
     //! Set parameters for @f$ \mu^o(T) @f$
     /*!
@@ -118,16 +118,16 @@ public:
      * Temperature Polynomial:
      *     tt[0] = temp (Kelvin)
      */
-    void updateProperties(const double* tt, double* cp_R, double* h_RT,
-                          double* s_R) const override;
+    void updateProperties(span<const double> tt, double& cp_R, double& h_RT,
+                          double& s_R) const override;
 
-    void updatePropertiesTemp(const double temp, double* cp_R, double* h_RT,
-                              double* s_R) const override;
+    void updatePropertiesTemp(const double temp, double& cp_R,
+                              double& h_RT, double& s_R) const override;
 
     size_t nCoeffs() const override;
 
     void reportParameters(size_t& n, int& type, double& tlow, double& thigh,
-                          double& pref, double* const coeffs) const override;
+                          double& pref, span<double> coeffs) const override;
 
     void getParameters(AnyMap& thermo) const override;
 

--- a/include/cantera/thermo/MultiSpeciesThermo.h
+++ b/include/cantera/thermo/MultiSpeciesThermo.h
@@ -80,8 +80,8 @@ public:
      * @param h_RT    Dimensionless enthalpy
      * @param s_R     Dimensionless entropy
      */
-    virtual void update_single(size_t k, double T, double* cp_R,
-                               double* h_RT, double* s_R) const;
+    virtual void update_single(size_t k, double T, double& cp_R,
+                               double& h_RT, double& s_R) const;
 
     //! Compute the reference-state properties for all species.
     /*!
@@ -94,7 +94,8 @@ public:
      * @param h_RT    Vector of Dimensionless enthalpies. (length m_kk).
      * @param s_R     Vector of Dimensionless entropies. (length m_kk).
      */
-    virtual void update(double T, double* cp_R, double* h_RT, double* s_R) const;
+    virtual void update(double T, span<double> cp_R, span<double> h_RT,
+                        span<double> s_R) const;
 
     //! Minimum temperature.
     /*!
@@ -139,8 +140,9 @@ public:
      * @param maxTemp   output - Maximum temperature
      * @param refPressure output - reference pressure (Pa).
      */
-    virtual void reportParams(size_t index, int& type, double* const c, double& minTemp,
-                              double& maxTemp, double& refPressure) const;
+    virtual void reportParams(size_t index, int& type, span<double> c,
+                              double& minTemp, double& maxTemp,
+                              double& refPressure) const;
 
     //! Report the 298 K Heat of Formation of the standard state of one species
     //! (J kmol-1)

--- a/include/cantera/thermo/Nasa9Poly1.h
+++ b/include/cantera/thermo/Nasa9Poly1.h
@@ -69,15 +69,15 @@ public:
      * @param coeffs       Vector of coefficients used to set the
      *                     parameters for the standard state.
      */
-    Nasa9Poly1(double tlow, double thigh, double pref, const double* coeffs);
+    Nasa9Poly1(double tlow, double thigh, double pref, span<const double> coeffs);
 
     //! Set the array of 9 polynomial coefficients
-    void setParameters(const vector<double>& coeffs);
+    void setParameters(span<const double> coeffs);
 
     int reportType() const override;
 
     size_t temperaturePolySize() const override { return 7; }
-    void updateTemperaturePoly(double T, double* T_poly) const override;
+    void updateTemperaturePoly(double T, span<double> T_poly) const override;
 
     /**
      * @copydoc SpeciesThermoInterpType::updateProperties
@@ -91,11 +91,11 @@ public:
      *   - tt[5] = 1.0/(t*t);
      *   - tt[6] = std::log(t);
      */
-    void updateProperties(const double* tt, double* cp_R, double* h_RT,
-                          double* s_R) const override;
+    void updateProperties(span<const double> tt, double& cp_R, double& h_RT,
+                          double& s_R) const override;
 
-    void updatePropertiesTemp(const double temp, double* cp_R, double* h_RT,
-                              double* s_R) const override;
+    void updatePropertiesTemp(const double temp, double& cp_R,
+                              double& h_RT, double& s_R) const override;
 
     //! This utility function reports back the type of parameterization and all
     //! of the parameters for the species
@@ -116,7 +116,7 @@ public:
      *       - coeffs[3+i] from i =0,9 are the coefficients themselves
      */
     void reportParameters(size_t& n, int& type, double& tlow, double& thigh,
-                          double& pref, double* const coeffs) const override;
+                          double& pref, span<double> coeffs) const override;
 
     void getParameters(AnyMap& thermo) const override;
 

--- a/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
+++ b/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
@@ -66,7 +66,7 @@ public:
      *                where `zone` runs from zero to `nzones`-1.
      */
     Nasa9PolyMultiTempRegion(double tlow, double thigh, double pref,
-                             const double* coeffs);
+                             span<const double> coeffs);
 
     //! Set the array of polynomial coefficients for each temperature region
     /*!
@@ -79,14 +79,14 @@ public:
     int reportType() const override;
 
     size_t temperaturePolySize() const override { return 7; }
-    void updateTemperaturePoly(double T, double* T_poly) const override;
+    void updateTemperaturePoly(double T, span<double> T_poly) const override;
 
     //! @copydoc Nasa9Poly1::updateProperties
-    void updateProperties(const double* tt, double* cp_R, double* h_RT,
-                          double* s_R) const override;
+    void updateProperties(span<const double> tt, double& cp_R, double& h_RT,
+                          double& s_R) const override;
 
-    void updatePropertiesTemp(const double temp, double* cp_R, double* h_RT,
-                              double* s_R) const override;
+    void updatePropertiesTemp(const double temp, double& cp_R,
+                              double& h_RT, double& s_R) const override;
 
     size_t nCoeffs() const override;
 
@@ -110,7 +110,7 @@ public:
      *        coeffs[index+2+i] from i =0,9 are the coefficients themselves
      */
     void reportParameters(size_t& n, int& type, double& tlow, double& thigh,
-                          double& pref, double* const coeffs) const override;
+                          double& pref, span<double> coeffs) const override;
 
     void getParameters(AnyMap& thermo) const override;
 

--- a/include/cantera/thermo/NasaPoly1.h
+++ b/include/cantera/thermo/NasaPoly1.h
@@ -144,7 +144,7 @@ public:
         thermo["data"].asVector<vector<double>>().push_back(m_coeff);
     }
 
-    double reportHf298(span<double> h298={}) const override {
+    double reportHf298() const override {
         double tt[6];
         double temp = 298.15;
         updateTemperaturePoly(temp, tt);
@@ -157,11 +157,7 @@ public:
         double h_RT = ct0 + 0.5*ct1 + 1.0/3.0*ct2 + 0.25*ct3 + 0.2*ct4
                       + m_coeff[5]*tt[4]; // last t
 
-        double h = h_RT * GasConstant * temp;
-        if (!h298.empty()) {
-            h298[0] = h;
-        }
-        return h;
+        return h_RT * GasConstant * temp;
     }
 
     void modifyOneHf298(const size_t k, const double Hf298New) override {

--- a/include/cantera/thermo/NasaPoly2.h
+++ b/include/cantera/thermo/NasaPoly2.h
@@ -131,17 +131,12 @@ public:
 
     void getParameters(AnyMap& thermo) const override;
 
-    double reportHf298(span<double> h298={}) const override {
-        double h;
+    double reportHf298() const override {
         if (298.15 <= m_midT) {
-            h = mnp_low.reportHf298();
+            return mnp_low.reportHf298();
         } else {
-            h = mnp_high.reportHf298();
+            return mnp_high.reportHf298();
         }
-        if (!h298.empty()) {
-            h298[0] = h;
-        }
-        return h;
     }
 
     void resetHf298() override {

--- a/include/cantera/thermo/PDSS_HKFT.h
+++ b/include/cantera/thermo/PDSS_HKFT.h
@@ -86,11 +86,11 @@ public:
 
     //! Set "a" coefficients (array of 4 elements). Units of each coefficient
     //! are [J/kmol/Pa, J/kmol, J*K/kmol/Pa, J*K/kmol]
-    void set_a(double* a);
+    void set_a(span<const double> a);
 
     //! Set "c" coefficients (array of 2 elements). Units of each coefficient
     //! are [J/kmol/K, J*K/kmol]
-    void set_c(double* c);
+    void set_c(span<const double> c);
     void setOmega(double omega); //!< Set omega [J/kmol]
 
     void getParameters(AnyMap& eosNode) const override;

--- a/include/cantera/thermo/PDSS_SSVol.h
+++ b/include/cantera/thermo/PDSS_SSVol.h
@@ -145,12 +145,12 @@ public:
     //! Set polynomial coefficients for the standard state molar volume as a
     //! function of temperature. Cubic polynomial (4 coefficients). Leading
     //! coefficient is the constant (temperature-independent) term [m^3/kmol].
-    void setVolumePolynomial(double* coeffs);
+    void setVolumePolynomial(span<const double> coeffs);
 
     //! Set polynomial coefficients for the standard state density as a function
     //! of temperature. Cubic polynomial (4 coefficients). Leading coefficient
     //! is the constant (temperature-independent) term [kg/m^3].
-    void setDensityPolynomial(double* coeffs);
+    void setDensityPolynomial(span<const double> coeffs);
 
     void getParameters(AnyMap& eosNode) const override;
 

--- a/include/cantera/thermo/PengRobinson.h
+++ b/include/cantera/thermo/PengRobinson.h
@@ -115,21 +115,21 @@ public:
      *
      * @param ac Output vector of activity coefficients. Length: m_kk.
      */
-    void getActivityCoefficients(double* ac) const override;
+    void getActivityCoefficients(span<double> ac) const override;
 
     //! @name  Partial Molar Properties of the Solution
     //! @{
 
-    void getChemPotentials(double* mu) const override;
-    void getPartialMolarEnthalpies(double* hbar) const override;
-    void getPartialMolarEntropies(double* sbar) const override;
-    void getPartialMolarIntEnergies(double* ubar) const override;
+    void getChemPotentials(span<double> mu) const override;
+    void getPartialMolarEnthalpies(span<double> hbar) const override;
+    void getPartialMolarEntropies(span<double> sbar) const override;
+    void getPartialMolarIntEnergies(span<double> ubar) const override;
     //! Calculate species-specific molar specific heats
     /*!
      *  This function is currently not implemented for Peng-Robinson phase.
      */
-    void getPartialMolarCp(double* cpbar) const override;
-    void getPartialMolarVolumes(double* vbar) const override;
+    void getPartialMolarCp(span<double> cpbar) const override;
+    void getPartialMolarVolumes(span<double> vbar) const override;
     //! @}
 
     //! Calculate species-specific critical temperature

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -202,7 +202,7 @@ public:
     int changeElementType(int m, int elem_type);
 
     //! Return a read-only reference to the vector of atomic weights.
-    const vector<double>& atomicWeights() const;
+    span<const double> atomicWeights() const;
 
     //! Number of elements.
     size_t nElements() const;
@@ -392,11 +392,11 @@ public:
 
     //! Return a const reference to the internal vector of molecular weights.
     //! units = kg / kmol
-    const vector<double>& molecularWeights() const;
+    span<const double> molecularWeights() const;
 
     //! Return a const reference to the internal vector of molecular weights.
     //! units = kmol / kg
-    const vector<double>& inverseMolecularWeights() const;
+    span<const double> inverseMolecularWeights() const;
 
     //! Copy the vector of species charges into array charges.
     //!     @param charges Output array of species charges (elem. charge)
@@ -461,9 +461,9 @@ public:
     //!     @param[out] y Array of mass fractions, length nSpecies()
     void getMassFractions(span<double> y) const;
 
-    //! Return a const pointer to the mass fraction array
-    const double* massFractions() const {
-        return &m_y[0];
+    //! Return a view of the mass fraction array
+    span<const double> massFractions() const {
+        return m_y;
     }
 
     //! Set the mass fractions to the specified values and normalize them.

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -13,6 +13,7 @@
 #include "cantera/thermo/Elements.h"
 #include "cantera/base/ValueCache.h"
 
+
 namespace Cantera
 {
 
@@ -452,27 +453,27 @@ public:
 
     //! Get the species mole fraction vector.
     //!     @param x On return, x contains the mole fractions. Must have a
-    //!          length greater than or equal to the number of species.
-    void getMoleFractions(double* const x) const;
+    //!          size greater than or equal to the number of species.
+    void getMoleFractions(span<double> x) const;
 
     //! Set the mole fractions to the specified values.
     //! There is no restriction on the sum of the mole fraction vector.
     //! Internally, the Phase object will normalize this vector before storing
     //! its contents.
     //!     @param x Array of unnormalized mole fraction values (input). Must
-    //! have a length greater than or equal to the number of species, m_kk.
-    virtual void setMoleFractions(const double* const x);
+    //! have a size greater than or equal to the number of species, m_kk.
+    virtual void setMoleFractions(span<const double> x);
 
     //! Set the mole fractions to the specified values without normalizing.
     //! This is useful when the normalization condition is being handled by
     //! some other means, for example by a constraint equation as part of a
     //! larger set of equations.
     //!     @param x  Input vector of mole fractions. Length is m_kk.
-    virtual void setMoleFractions_NoNorm(const double* const x);
+    virtual void setMoleFractions_NoNorm(span<const double> x);
 
     //! Get the species mass fractions.
     //!     @param[out] y Array of mass fractions, length nSpecies()
-    void getMassFractions(double* const y) const;
+    void getMassFractions(span<double> y) const;
 
     //! Return a const pointer to the mass fraction array
     const double* massFractions() const {
@@ -484,14 +485,14 @@ public:
     //!                  must be greater than or equal to the number of
     //!                  species. The Phase object will normalize this vector
     //!                  before storing its contents.
-    virtual void setMassFractions(const double* const y);
+    virtual void setMassFractions(span<const double> y);
 
     //! Set the mass fractions to the specified values without normalizing.
     //! This is useful when the normalization condition is being handled by
     //! some other means, for example by a constraint equation as part of a
     //! larger set of equations.
     //!     @param y  Input vector of mass fractions. Length is m_kk.
-    virtual void setMassFractions_NoNorm(const double* const y);
+    virtual void setMassFractions_NoNorm(span<const double> y);
 
     //! Get the species concentrations (kmol/m^3).
     /*!

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -319,44 +319,30 @@ public:
     //! Save the current thermodynamic state of the phase, excluding composition.
     //! The default implementation corresponds to the default implementation of
     //! nativeState().
-    //! @param lenstate  Length of the state array. Must be >= partialStateSize().
     //! @param[out] state  Array of state variables, in the order defined by
-    //!     nativeState().
+    //!     nativeState(). Size must be >= partialStateSize().
     //! @since New in %Cantera 3.2
-    virtual void savePartialState(size_t lenstate, double* state) const;
+    virtual void savePartialState(span<double> state) const;
 
     //! Set the internal thermodynamic state of the phase, excluding composition.
     //! The default implementation corresponds to the default implementation of
     //! nativeState().
-    //! @param lenstate  Length of the state array. Must be >= partialStateSize().
     //! @param[in] state  Array of state variables, in the order defined by
-    //!     nativeState().
+    //!     nativeState(). Size must be >= partialStateSize().
     //! @since New in %Cantera 3.2
-    virtual void restorePartialState(size_t lenstate, const double* state);
+    virtual void restorePartialState(span<const double> state);
 
     //! Return size of vector defining internal state of the phase.
     //! Used by saveState() and restoreState().
     virtual size_t stateSize() const;
 
-    //! Save the current internal state of the phase.
-    //! Write to vector 'state' the current internal state.
-    //!     @param state output vector. Will be resized to stateSize().
-    void saveState(vector<double>& state) const;
-
     //! Write to array 'state' the current internal state.
-    //!     @param lenstate length of the state array. Must be >= stateSize()
-    //!     @param state    output vector. Must be of length stateSizes() or
-    //!                     greater.
-    virtual void saveState(size_t lenstate, double* state) const;
-
-    //! Restore a state saved on a previous call to saveState.
-    //!     @param state State vector containing the previously saved state.
-    void restoreState(const vector<double>& state);
+    //!     @param state output vector. Size must be >= stateSize().
+    virtual void saveState(span<double> state) const;
 
     //! Restore the state of the phase from a previously saved state vector.
-    //!     @param lenstate   Length of the state vector
-    //!     @param state      Vector of state conditions.
-    virtual void restoreState(size_t lenstate, const double* state);
+    //!     @param state Vector of state conditions.
+    virtual void restoreState(span<const double> state);
 
     //! @name Set Thermodynamic State
     //!

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -388,7 +388,7 @@ public:
 
     //! Copy the vector of molecular weights into array weights.
     //!     @param weights  Output array of molecular weights (kg/kmol)
-    void getMolecularWeights(double* weights) const;
+    void getMolecularWeights(span<double> weights) const;
 
     //! Return a const reference to the internal vector of molecular weights.
     //! units = kg / kmol
@@ -400,7 +400,7 @@ public:
 
     //! Copy the vector of species charges into array charges.
     //!     @param charges Output array of species charges (elem. charge)
-    void getCharges(double* charges) const;
+    void getCharges(span<double> charges) const;
 
     //! @name Composition
     //! @{
@@ -486,7 +486,7 @@ public:
      *                  kmol/m^3. The length of the vector must be greater than
      *                  or equal to the number of species within the phase.
      */
-    virtual void getConcentrations(double* const c) const;
+    virtual void getConcentrations(span<double> c) const;
 
     //! Concentration of species k.
     //! If k is outside the valid range, an exception will be thrown.
@@ -507,14 +507,14 @@ public:
     //!                     species in kmol/m3. For surface phases, c[k] is the
     //!                     concentration in kmol/m2. The length of the vector
     //!                     is the number of species in the phase.
-    virtual void setConcentrations(const double* const conc);
+    virtual void setConcentrations(span<const double> conc);
 
     //! Set the concentrations without ignoring negative concentrations
-    virtual void setConcentrationsNoNorm(const double* const conc);
+    virtual void setConcentrationsNoNorm(span<const double> conc);
     //! @}
 
     //! Set the state of the object with moles in [kmol]
-    virtual void setMolesNoTruncate(const double* const N);
+    virtual void setMolesNoTruncate(span<const double> N);
 
     //! Elemental mass fraction of element m
     /*!
@@ -669,10 +669,8 @@ public:
     //! Q should contain pure-species molar property values.
     //!     @param[in] Q Array of length m_kk that is to be averaged.
     //!     @return mole-fraction-weighted mean of Q
-    double mean_X(const double* const Q) const;
+    double mean_X(span<const double> Q) const;
 
-    //! @copydoc Phase::mean_X(const double* const Q) const
-    double mean_X(const vector<double>& Q) const;
 
     //!  The mean molecular weight. Units: (kg/kmol)
     double meanMolecularWeight() const {
@@ -823,12 +821,12 @@ public:
     //! Converts a mixture composition from mole fractions to mass fractions
     //!     @param[in] Y mixture composition in mass fractions (length m_kk)
     //!     @param[out] X mixture composition in mole fractions (length m_kk)
-    void massFractionsToMoleFractions(const double* Y, double* X) const;
+    void massFractionsToMoleFractions(span<const double> Y, span<double> X) const;
 
     //! Converts a mixture composition from mass fractions to mole fractions
     //!     @param[in] X mixture composition in mole fractions (length m_kk)
     //!     @param[out] Y mixture composition in mass fractions (length m_kk)
-    void moleFractionsToMassFractions(const double* X, double* Y) const;
+    void moleFractionsToMassFractions(span<const double> X, span<double> Y) const;
 
 protected:
     //! Ensure that phase is compressible.

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -52,7 +52,7 @@ class Kinetics;
  * Class Phase contains a number of utility functions that will set the state
  * of the phase in its entirety, by first setting the composition, and then
  * temperature and pressure. An example of this is the function
- * Phase::setState_TPY(double t, double p, const double* y).
+ * Phase::setState_TPY(double t, double p, span<const double> y).
  *
  * For bulk (3-dimensional) phases, the mass density has units of kg/m^3, and the molar
  * density and concentrations have units of kmol/m^3, and the units listed in the

--- a/include/cantera/thermo/PlasmaPhase.h
+++ b/include/cantera/thermo/PlasmaPhase.h
@@ -108,13 +108,12 @@ public:
     //! Set electron energy levels.
     //! @param  levels The vector of electron energy levels (eV).
     //!                Length: #m_nPoints.
-    //! @param  length The length of the @c levels.
-    void setElectronEnergyLevels(const double* levels, size_t length);
+    void setElectronEnergyLevels(span<const double> levels);
 
     //! Get electron energy levels.
     //! @param  levels The vector of electron energy levels (eV). Length: #m_nPoints
-    void getElectronEnergyLevels(double* levels) const {
-        Eigen::Map<Eigen::ArrayXd>(levels, m_nPoints) = m_electronEnergyLevels;
+    void getElectronEnergyLevels(span<double> levels) const {
+        Eigen::Map<Eigen::ArrayXd>(levels.data(), levels.size()) = m_electronEnergyLevels;
     }
 
     //! Set discretized electron energy distribution.
@@ -122,16 +121,14 @@ public:
     //!                Length: #m_nPoints.
     //! @param  distrb The vector of electron energy distribution.
     //!                Length: #m_nPoints.
-    //! @param  length The length of the vectors, which equals #m_nPoints.
-    void setDiscretizedElectronEnergyDist(const double* levels,
-                                          const double* distrb,
-                                          size_t length);
+    void setDiscretizedElectronEnergyDist(span<const double> levels,
+                                          span<const double> distrb);
 
     //! Get electron energy distribution.
     //! @param  distrb The vector of electron energy distribution.
     //!                Length: #m_nPoints.
-    void getElectronEnergyDistribution(double* distrb) const {
-        Eigen::Map<Eigen::ArrayXd>(distrb, m_nPoints) = m_electronEnergyDist;
+    void getElectronEnergyDistribution(span<double> distrb) const {
+        Eigen::Map<Eigen::ArrayXd>(distrb.data(), distrb.size()) = m_electronEnergyDist;
     }
 
     //! Set the shape factor of isotropic electron energy distribution.

--- a/include/cantera/thermo/PlasmaPhase.h
+++ b/include/cantera/thermo/PlasmaPhase.h
@@ -299,23 +299,23 @@ public:
     */
     double intEnergy_mole() const override;
 
-    void getEntropy_R(double* sr) const override;
+    void getEntropy_R(span<double> sr) const override;
 
-    void getGibbs_RT(double* grt) const override;
+    void getGibbs_RT(span<double> grt) const override;
 
-    void getGibbs_ref(double* g) const override;
+    void getGibbs_ref(span<double> g) const override;
 
-    void getStandardVolumes_ref(double* vol) const override;
+    void getStandardVolumes_ref(span<double> vol) const override;
 
-    void getChemPotentials(double* mu) const override;
+    void getChemPotentials(span<double> mu) const override;
 
-    void getStandardChemPotentials(double* muStar) const override;
+    void getStandardChemPotentials(span<double> muStar) const override;
 
-    void getPartialMolarEnthalpies(double* hbar) const override;
+    void getPartialMolarEnthalpies(span<double> hbar) const override;
 
-    void getPartialMolarEntropies(double* sbar) const override;
+    void getPartialMolarEntropies(span<double> sbar) const override;
 
-    void getPartialMolarIntEnergies(double* ubar) const override;
+    void getPartialMolarIntEnergies(span<double> ubar) const override;
 
     void getParameters(AnyMap& phaseNode) const override;
 

--- a/include/cantera/thermo/PureFluidPhase.h
+++ b/include/cantera/thermo/PureFluidPhase.h
@@ -99,21 +99,21 @@ public:
     void setTemperature(const double T) override;
     void setDensity(const double rho) override;
 
-    void getChemPotentials(double* mu) const override{
+    void getChemPotentials(span<double> mu) const override{
         mu[0] = gibbs_mole();
     }
 
-    void getPartialMolarEnthalpies(double* hbar) const override;
-    void getPartialMolarEntropies(double* sbar) const override;
-    void getPartialMolarIntEnergies(double* ubar) const override;
-    void getPartialMolarCp(double* cpbar) const override;
-    void getPartialMolarVolumes(double* vbar) const override;
+    void getPartialMolarEnthalpies(span<double> hbar) const override;
+    void getPartialMolarEntropies(span<double> sbar) const override;
+    void getPartialMolarIntEnergies(span<double> ubar) const override;
+    void getPartialMolarCp(span<double> cpbar) const override;
+    void getPartialMolarVolumes(span<double> vbar) const override;
 
     Units standardConcentrationUnits() const override;
-    void getActivityConcentrations(double* c) const override;
+    void getActivityConcentrations(span<double> c) const override;
     double standardConcentration(size_t k=0) const override;
 
-    void getActivities(double* a) const override;
+    void getActivities(span<double> a) const override;
 
     double isothermalCompressibility() const override;
     double thermalExpansionCoeff() const override;
@@ -129,10 +129,10 @@ public:
     //! activity of the fluid is always then defined to be equal to one.
     //! @{
 
-    void getStandardChemPotentials(double* mu) const override;
-    void getEnthalpy_RT(double* hrt) const override;
-    void getEntropy_R(double* sr) const override;
-    void getGibbs_RT(double* grt) const override;
+    void getStandardChemPotentials(span<double> mu) const override;
+    void getEnthalpy_RT(span<double> hrt) const override;
+    void getEntropy_R(span<double> sr) const override;
+    void getGibbs_RT(span<double> grt) const override;
 
     //! @}
     //! @name Thermodynamic Values for the Species Reference States
@@ -141,10 +141,10 @@ public:
     //! the reference pressure and current temperature of the fluid.
     //! @{
 
-    void getEnthalpy_RT_ref(double* hrt) const override;
-    void getGibbs_RT_ref(double* grt) const override;
-    void getGibbs_ref(double* g) const override;
-    void getEntropy_R_ref(double* er) const override;
+    void getEnthalpy_RT_ref(span<double> hrt) const override;
+    void getGibbs_RT_ref(span<double> grt) const override;
+    void getGibbs_ref(span<double> g) const override;
+    void getEntropy_R_ref(span<double> er) const override;
 
     //! @}
     //! @name Setting the State

--- a/include/cantera/thermo/RedlichKisterVPSSTP.h
+++ b/include/cantera/thermo/RedlichKisterVPSSTP.h
@@ -260,13 +260,13 @@ public:
     //! on temperature and pressure.
     //! @{
 
-    void getLnActivityCoefficients(double* lnac) const override;
+    void getLnActivityCoefficients(span<double> lnac) const override;
 
     //! @}
     //! @name  Partial Molar Properties of the Solution
     //! @{
 
-    void getChemPotentials(double* mu) const override;
+    void getChemPotentials(span<double> mu) const override;
 
     //! Returns an array of partial molar enthalpies for the species in the
     //! mixture.
@@ -284,7 +284,7 @@ public:
      * @param hbar  Vector of returned partial molar enthalpies
      *              (length m_kk, units = J/kmol)
      */
-    void getPartialMolarEnthalpies(double* hbar) const override;
+    void getPartialMolarEnthalpies(span<double> hbar) const override;
 
     //! Returns an array of partial molar entropies for the species in the
     //! mixture.
@@ -301,7 +301,7 @@ public:
      * @param sbar  Vector of returned partial molar entropies
      *              (length m_kk, units = J/kmol/K)
      */
-    void getPartialMolarEntropies(double* sbar) const override;
+    void getPartialMolarEntropies(span<double> sbar) const override;
 
     //! Returns an array of partial molar heat capacities for the species in the
     //! mixture.
@@ -318,9 +318,9 @@ public:
      * @param cpbar  Vector of returned partial molar heat capacities
      *              (length m_kk, units = J/kmol/K)
      */
-    void getPartialMolarCp(double* cpbar) const override;
+    void getPartialMolarCp(span<double> cpbar) const override;
 
-    void getPartialMolarVolumes(double* vbar) const override;
+    void getPartialMolarVolumes(span<double> vbar) const override;
     //! @}
 
     //! Get the array of temperature second derivatives of the log activity
@@ -333,7 +333,7 @@ public:
      */
     void getd2lnActCoeffdT2(double* d2lnActCoeffdT2) const;
 
-    void getdlnActCoeffdT(double* dlnActCoeffdT) const override;
+    void getdlnActCoeffdT(span<double> dlnActCoeffdT) const override;
 
     //! @name Initialization
     //!
@@ -361,11 +361,11 @@ public:
     //! @name  Derivatives of Thermodynamic Variables needed for Applications
     //! @{
 
-    void getdlnActCoeffds(const double dTds, const double* const dXds,
-                          double* dlnActCoeffds) const override;
-    void getdlnActCoeffdlnX_diag(double* dlnActCoeffdlnX_diag) const override;
-    void getdlnActCoeffdlnN_diag(double* dlnActCoeffdlnN_diag) const override;
-    void getdlnActCoeffdlnN(const size_t ld, double* const dlnActCoeffdlnN) override;
+    void getdlnActCoeffds(const double dTds, span<const double> dXds,
+                          span<double> dlnActCoeffds) const override;
+    void getdlnActCoeffdlnX_diag(span<double> dlnActCoeffdlnX_diag) const override;
+    void getdlnActCoeffdlnN_diag(span<double> dlnActCoeffdlnN_diag) const override;
+    void getdlnActCoeffdlnN(const size_t ld, span<double> const dlnActCoeffdlnN) override;
     //! @}
 
 private:

--- a/include/cantera/thermo/RedlichKisterVPSSTP.h
+++ b/include/cantera/thermo/RedlichKisterVPSSTP.h
@@ -331,7 +331,7 @@ public:
      * @param d2lnActCoeffdT2  Output vector of temperature 2nd derivatives of
      *                         the log Activity Coefficients. length = m_kk
      */
-    void getd2lnActCoeffdT2(double* d2lnActCoeffdT2) const;
+    void getd2lnActCoeffdT2(span<double> d2lnActCoeffdT2) const;
 
     void getdlnActCoeffdT(span<double> dlnActCoeffdT) const override;
 
@@ -350,13 +350,10 @@ public:
      * @param speciesA         name of the first species
      * @param speciesB         name of the second species
      * @param excess_enthalpy  coefficients of the excess enthalpy polynomial
-     * @param n_enthalpy       number of excess enthalpy polynomial coefficients
      * @param excess_entropy   coefficients of the excess entropy polynomial
-     * @param n_entropy        number of excess entropy polynomial coefficients
      */
     void addBinaryInteraction(const string& speciesA, const string& speciesB,
-        const double* excess_enthalpy, size_t n_enthalpy,
-        const double* excess_entropy, size_t n_entropy);
+        span<const double> excess_enthalpy, span<const double> excess_entropy);
 
     //! @name  Derivatives of Thermodynamic Variables needed for Applications
     //! @{

--- a/include/cantera/thermo/RedlichKwongMFTP.h
+++ b/include/cantera/thermo/RedlichKwongMFTP.h
@@ -81,19 +81,19 @@ public:
      *
      * @param ac Output vector of activity coefficients. Length: m_kk.
      */
-    void getActivityCoefficients(double* ac) const override;
+    void getActivityCoefficients(span<double> ac) const override;
 
     //! @name  Partial Molar Properties of the Solution
     //! @{
 
-    void getChemPotentials(double* mu) const override;
-    void getPartialMolarEnthalpies(double* hbar) const override;
-    void getPartialMolarEntropies(double* sbar) const override;
-    void getPartialMolarIntEnergies(double* ubar) const override;
-    void getPartialMolarCp(double* cpbar) const override {
+    void getChemPotentials(span<double> mu) const override;
+    void getPartialMolarEnthalpies(span<double> hbar) const override;
+    void getPartialMolarEntropies(span<double> sbar) const override;
+    void getPartialMolarIntEnergies(span<double> ubar) const override;
+    void getPartialMolarCp(span<double> cpbar) const override {
         throw NotImplementedError("RedlichKwongMFTP::getPartialMolarCp");
     }
-    void getPartialMolarVolumes(double* vbar) const override;
+    void getPartialMolarVolumes(span<double> vbar) const override;
     //! @}
 
 public:

--- a/include/cantera/thermo/ShomatePoly.h
+++ b/include/cantera/thermo/ShomatePoly.h
@@ -100,7 +100,7 @@ public:
 
     size_t temperaturePolySize() const override { return 6; }
 
-    void updateTemperaturePoly(double T, double* T_poly) const override {
+    void updateTemperaturePoly(double T, span<double> T_poly) const override {
         double tt = 1.e-3*T;
         T_poly[0] = tt;
         T_poly[1] = tt * tt;
@@ -122,8 +122,8 @@ public:
      *   - `t[4] = log(t)`
      *   - `t[5] = 1.0/t;
      */
-    void updateProperties(const double* tt, double* cp_R, double* h_RT,
-                          double* s_R) const override {
+    void updateProperties(span<const double> tt, double& cp_R, double& h_RT,
+                          double& s_R) const override {
         double A = m_coeff[0];
         double Bt = m_coeff[1]*tt[0];
         double Ct2 = m_coeff[2]*tt[1];
@@ -132,20 +132,20 @@ public:
         double Ftm1 = m_coeff[5]*tt[5];
         double G = m_coeff[6];
 
-        *cp_R = A + Bt + Ct2 + Dt3 + Etm2;
-        *h_RT = A + 0.5*Bt + 1.0/3.0*Ct2 + 0.25*Dt3 - Etm2 + Ftm1;
-        *s_R = A*tt[4] + Bt + 0.5*Ct2 + 1.0/3.0*Dt3 - 0.5*Etm2 + G;
+        cp_R = A + Bt + Ct2 + Dt3 + Etm2;
+        h_RT = A + 0.5*Bt + 1.0/3.0*Ct2 + 0.25*Dt3 - Etm2 + Ftm1;
+        s_R = A*tt[4] + Bt + 0.5*Ct2 + 1.0/3.0*Dt3 - 0.5*Etm2 + G;
     }
 
-    void updatePropertiesTemp(const double temp, double* cp_R, double* h_RT,
-                              double* s_R) const override {
+    void updatePropertiesTemp(const double temp, double& cp_R,
+                              double& h_RT, double& s_R) const override {
         double tPoly[6];
         updateTemperaturePoly(temp, tPoly);
         updateProperties(tPoly, cp_R, h_RT, s_R);
     }
 
     void reportParameters(size_t& n, int& type, double& tlow, double& thigh,
-                          double& pref, double* const coeffs) const override {
+                          double& pref, span<double> coeffs) const override {
         n = 0;
         type = SHOMATE;
         tlow = m_lowT;
@@ -166,9 +166,9 @@ public:
         thermo["data"].asVector<vector<double>>().push_back(dimensioned_coeffs);
     }
 
-    double reportHf298(double* const h298=nullptr) const override {
+    double reportHf298(span<double> h298={}) const override {
         double cp_R, h_RT, s_R;
-        updatePropertiesTemp(298.15, &cp_R, &h_RT, &s_R);
+        updatePropertiesTemp(298.15, cp_R, h_RT, s_R);
         return h_RT * GasConstant * 298.15;
     }
 
@@ -286,13 +286,13 @@ public:
 
     size_t temperaturePolySize() const override{ return 7; }
 
-    void updateTemperaturePoly(double T, double* T_poly) const override {
+    void updateTemperaturePoly(double T, span<double> T_poly) const override {
         msp_low.updateTemperaturePoly(T, T_poly);
     }
 
     //! @copydoc ShomatePoly::updateProperties
-    void updateProperties(const double* tt, double* cp_R, double* h_RT,
-                          double* s_R) const override {
+    void updateProperties(span<const double> tt, double& cp_R, double& h_RT,
+                          double& s_R) const override {
         double T = 1000 * tt[0];
         if (T <= m_midT) {
             msp_low.updateProperties(tt, cp_R, h_RT, s_R);
@@ -301,8 +301,8 @@ public:
         }
     }
 
-    void updatePropertiesTemp(const double temp, double* cp_R, double* h_RT,
-                              double* s_R) const override {
+    void updatePropertiesTemp(const double temp, double& cp_R,
+                              double& h_RT, double& s_R) const override {
         if (temp <= m_midT) {
             msp_low.updatePropertiesTemp(temp, cp_R, h_RT, s_R);
         } else {
@@ -313,9 +313,9 @@ public:
     size_t nCoeffs() const override { return 15; }
 
     void reportParameters(size_t& n, int& type, double& tlow, double& thigh,
-                          double& pref, double* const coeffs) const override {
-        msp_low.reportParameters(n, type, tlow, coeffs[0], pref, coeffs + 1);
-        msp_high.reportParameters(n, type, coeffs[0], thigh, pref, coeffs + 8);
+                          double& pref, span<double> coeffs) const override {
+        msp_low.reportParameters(n, type, tlow, coeffs[0], pref, coeffs.subspan(1));
+        msp_high.reportParameters(n, type, coeffs[0], thigh, pref, coeffs.subspan(8));
         type = SHOMATE2;
     }
 
@@ -329,26 +329,26 @@ public:
         msp_high.getParameters(thermo);
     }
 
-    double reportHf298(double* const h298=nullptr) const override {
+    double reportHf298(span<double> h298={}) const override {
         double h;
         if (298.15 <= m_midT) {
             h = msp_low.reportHf298(h298);
         } else {
             h = msp_high.reportHf298(h298);
         }
-        if (h298) {
-            *h298 = h;
+        if (!h298.empty()) {
+            h298[0] = h;
         }
         return h;
     }
 
     void modifyOneHf298(const size_t k, const double Hf298New) override {
-        double h298now = reportHf298(0);
+        double h298now = reportHf298();
         double delH = Hf298New - h298now;
-        double h = msp_low.reportHf298(0);
+        double h = msp_low.reportHf298();
         double hnew = h + delH;
         msp_low.modifyOneHf298(k, hnew);
-        h = msp_high.reportHf298(0);
+        h = msp_high.reportHf298();
         hnew = h + delH;
         msp_high.modifyOneHf298(k, hnew);
     }

--- a/include/cantera/thermo/ShomatePoly.h
+++ b/include/cantera/thermo/ShomatePoly.h
@@ -71,7 +71,7 @@ public:
      *  See the class description for the polynomial representation of the
      *  thermo functions in terms of @f$ A, \dots, G @f$.
      */
-    ShomatePoly(double tlow, double thigh, double pref, const double* coeffs) :
+    ShomatePoly(double tlow, double thigh, double pref, span<const double> coeffs) :
         SpeciesThermoInterpType(tlow, thigh, pref),
         m_coeff(7)
     {
@@ -83,7 +83,7 @@ public:
 
     //! Set array of 7 polynomial coefficients. Input values are assumed to be
     //! on a kJ/mol basis.
-    void setParameters(const vector<double>& coeffs) {
+    void setParameters(const span<const double> coeffs) {
         if (coeffs.size() != 7) {
             throw CanteraError("ShomatePoly::setParameters", "Array must "
                 "contain 7 coefficients, but {} were given.", coeffs.size());
@@ -242,11 +242,11 @@ public:
      * @param coeffs  Vector of coefficients used to set the parameters for the
      *                standard state. [Tmid, 7 low-T coeffs, 7 high-T coeffs]
      */
-    ShomatePoly2(double tlow, double thigh, double pref, const double* coeffs) :
+    ShomatePoly2(double tlow, double thigh, double pref, span<const double> coeffs) :
         SpeciesThermoInterpType(tlow, thigh, pref),
         m_midT(coeffs[0]),
-        msp_low(tlow, coeffs[0], pref, coeffs+1),
-        msp_high(coeffs[0], thigh, pref, coeffs+8)
+        msp_low(tlow, coeffs[0], pref, coeffs.subspan(1, 7)),
+        msp_high(coeffs[0], thigh, pref, coeffs.subspan(8, 7))
     {
     }
 
@@ -272,7 +272,7 @@ public:
      * @param low   Vector of 7 coefficients for the low temperature polynomial
      * @param high  Vector of 7 coefficients for the high temperature polynomial
      */
-    void setParameters(double Tmid, const vector<double>& low, const vector<double>& high) {
+    void setParameters(double Tmid, span<const double> low, span<const double> high) {
         m_midT = Tmid;
         msp_low.setMaxTemp(Tmid);
         msp_high.setMinTemp(Tmid);

--- a/include/cantera/thermo/ShomatePoly.h
+++ b/include/cantera/thermo/ShomatePoly.h
@@ -166,7 +166,7 @@ public:
         thermo["data"].asVector<vector<double>>().push_back(dimensioned_coeffs);
     }
 
-    double reportHf298(span<double> h298={}) const override {
+    double reportHf298() const override {
         double cp_R, h_RT, s_R;
         updatePropertiesTemp(298.15, cp_R, h_RT, s_R);
         return h_RT * GasConstant * 298.15;
@@ -329,17 +329,12 @@ public:
         msp_high.getParameters(thermo);
     }
 
-    double reportHf298(span<double> h298={}) const override {
-        double h;
+    double reportHf298() const override {
         if (298.15 <= m_midT) {
-            h = msp_low.reportHf298(h298);
+            return msp_low.reportHf298();
         } else {
-            h = msp_high.reportHf298(h298);
+            return msp_high.reportHf298();
         }
-        if (!h298.empty()) {
-            h298[0] = h;
-        }
-        return h;
     }
 
     void modifyOneHf298(const size_t k, const double Hf298New) override {

--- a/include/cantera/thermo/SingleSpeciesTP.h
+++ b/include/cantera/thermo/SingleSpeciesTP.h
@@ -98,11 +98,11 @@ public:
      *
      * @param a   Output vector of activities. Length: 1.
      */
-    void getActivities(double* a) const override {
+    void getActivities(span<double> a) const override {
         a[0] = 1.0;
     }
 
-    void getActivityCoefficients(double* ac) const override {
+    void getActivityCoefficients(span<double> ac) const override {
         ac[0] = 1.0;
     }
 
@@ -123,7 +123,7 @@ public:
      * @param mu   On return, Contains the chemical potential of the single
      *             species and the phase. Units are J / kmol . Length = 1
      */
-    void getChemPotentials(double* mu) const override;
+    void getChemPotentials(span<double> mu) const override;
 
     //! Get the species partial molar enthalpies. Units: J/kmol.
     /*!
@@ -132,7 +132,7 @@ public:
      * @param hbar    Output vector of species partial molar enthalpies.
      *                Length: 1. units are J/kmol.
      */
-    void getPartialMolarEnthalpies(double* hbar) const override;
+    void getPartialMolarEnthalpies(span<double> hbar) const override;
 
     //! Get the species partial molar internal energies. Units: J/kmol.
     /*!
@@ -141,7 +141,7 @@ public:
      * @param ubar On return, Contains the internal energy of the single species
      *             and the phase. Units are J / kmol . Length = 1
      */
-    void getPartialMolarIntEnergies(double* ubar) const override;
+    void getPartialMolarIntEnergies(span<double> ubar) const override;
 
     //! Get the species partial molar entropy. Units: J/kmol K.
     /*!
@@ -150,7 +150,7 @@ public:
      * @param sbar On return, Contains the entropy of the single species and the
      *             phase. Units are J / kmol / K . Length = 1
      */
-    void getPartialMolarEntropies(double* sbar) const override;
+    void getPartialMolarEntropies(span<double> sbar) const override;
 
     //! Get the species partial molar Heat Capacities. Units: J/ kmol /K.
     /*!
@@ -159,7 +159,7 @@ public:
      * @param cpbar On return, Contains the heat capacity of the single species
      *              and the phase. Units are J / kmol / K . Length = 1
      */
-    void getPartialMolarCp(double* cpbar) const override;
+    void getPartialMolarCp(span<double> cpbar) const override;
 
     //! Get the species partial molar volumes. Units: m^3/kmol.
     /*!
@@ -168,7 +168,7 @@ public:
      * @param vbar On return, Contains the molar volume of the single species
      *             and the phase. Units are m^3 / kmol. Length = 1
      */
-    void getPartialMolarVolumes(double* vbar) const override;
+    void getPartialMolarVolumes(span<double> vbar) const override;
 
     //! @}
     //! @name  Properties of the Standard State of the Species in the Solution
@@ -190,7 +190,7 @@ public:
      * @param vbar On output this contains the standard volume of the species
      *             and phase (m^3/kmol). Vector of length 1
      */
-    void getStandardVolumes(double* vbar) const override;
+    void getStandardVolumes(span<double> vbar) const override;
 
     //! @}
     //! @name Thermodynamic Values for the Species Reference State
@@ -200,11 +200,11 @@ public:
     //! involve a specification of the equation of state.
     //! @{
 
-    void getEnthalpy_RT_ref(double* hrt) const override;
-    void getGibbs_RT_ref(double* grt) const override;
-    void getGibbs_ref(double* g) const override;
-    void getEntropy_R_ref(double* er) const override;
-    void getCp_R_ref(double* cprt) const override;
+    void getEnthalpy_RT_ref(span<double> hrt) const override;
+    void getGibbs_RT_ref(span<double> grt) const override;
+    void getGibbs_ref(span<double> g) const override;
+    void getEntropy_R_ref(span<double> er) const override;
+    void getCp_R_ref(span<double> cprt) const override;
 
     //! @}
     //! @name Setting the State

--- a/include/cantera/thermo/SingleSpeciesTP.h
+++ b/include/cantera/thermo/SingleSpeciesTP.h
@@ -213,10 +213,10 @@ public:
     //! @{
 
     //! Mass fractions are fixed, with Y[0] = 1.0.
-    void setMassFractions(const double* const y) override {};
+    void setMassFractions(span<const double> y) override {};
 
     //! Mole fractions are fixed, with x[0] = 1.0.
-    void setMoleFractions(const double* const x) override {};
+    void setMoleFractions(span<const double> x) override {};
 
     //! @}
 

--- a/include/cantera/thermo/SpeciesThermoFactory.h
+++ b/include/cantera/thermo/SpeciesThermoFactory.h
@@ -28,7 +28,7 @@ class AnyMap;
  *  @returns The pointer to the newly allocated SpeciesThermoInterpType object
  */
 SpeciesThermoInterpType* newSpeciesThermoInterpType(int type, double tlow,
-    double thigh, double pref, const double* coeffs);
+    double thigh, double pref, span<const double> coeffs);
 
 //! Create a new SpeciesThermoInterpType object given a string
 /*!
@@ -40,7 +40,7 @@ SpeciesThermoInterpType* newSpeciesThermoInterpType(int type, double tlow,
  *  @returns the pointer to the newly allocated SpeciesThermoInterpType object
  */
 SpeciesThermoInterpType* newSpeciesThermoInterpType(const string& type,
-    double tlow, double thigh, double pref, const double* coeffs);
+    double tlow, double thigh, double pref, span<const double> coeffs);
 
 //! Create a new SpeciesThermoInterpType object using the specified parameters
 /*!

--- a/include/cantera/thermo/SpeciesThermoInterpType.h
+++ b/include/cantera/thermo/SpeciesThermoInterpType.h
@@ -238,13 +238,9 @@ public:
      * the standard state of the species from its constituent elements in their
      * standard states at 298 K and 1 bar.
      *
-     * @param h298 If this is nonnull, the current value of the Heat of
-     *             Formation at 298K and 1 bar for species m_speciesIndex is
-     *             returned in h298[m_speciesIndex].
-     * @return the current value of the Heat of Formation at 298K and 1 bar for
-     *               species m_speciesIndex.
+     * @since Removed redundant output argument in %Cantera 4.0.
      */
-    virtual double reportHf298(span<double> h298={}) const;
+    virtual double reportHf298() const;
 
     //! Modify the value of the 298 K Heat of Formation of one species in the
     //! phase (J kmol-1)

--- a/include/cantera/thermo/SpeciesThermoInterpType.h
+++ b/include/cantera/thermo/SpeciesThermoInterpType.h
@@ -166,27 +166,26 @@ public:
 
     //! Given the temperature *T*, compute the terms of the temperature
     //! polynomial *T_poly*.
-    virtual void updateTemperaturePoly(double T, double* T_poly) const {
+    virtual void updateTemperaturePoly(double T, span<double> T_poly) const {
         T_poly[0] = T;
     }
 
     //! Update the properties for this species, given a temperature polynomial
     /*!
-     * This method is called with a pointer to an array containing the functions
-     * of temperature needed by this parameterization, and three pointers to
-     * arrays where the computed property values should be written. This method
-     * updates only one value in each array.
+     * This method is called with an array view containing the functions of
+     * temperature needed by this parameterization, and three references where the
+     * computed property values should be written.
      *
      * The form and length of the Temperature Polynomial may vary depending on
      * the parameterization.
      *
-     * @param tt      vector of evaluated temperature functions
-     * @param cp_R    Vector of Dimensionless heat capacities. (length m_kk).
-     * @param h_RT    Vector of Dimensionless enthalpies. (length m_kk).
-     * @param s_R     Vector of Dimensionless entropies. (length m_kk).
+     * @param[in] tt     vector of evaluated temperature functions
+     * @param[out] cp_R  Dimensionless heat capacity
+     * @param[out] h_RT  Dimensionless enthalpy
+     * @param[out] s_R   Dimensionless entropy
      */
-    virtual void updateProperties(const double* tt, double* cp_R, double* h_RT,
-                                  double* s_R) const;
+    virtual void updateProperties(span<const double> tt, double& cp_R,
+                                  double& h_RT, double& s_R) const;
 
     //! Compute the reference-state property of one species
     /*!
@@ -194,15 +193,13 @@ public:
      * dimensional heat capacity at constant pressure, enthalpy, and entropy, at
      * the reference pressure, of the species.
      *
-     * @param temp    Temperature (Kelvin)
-     * @param cp_R    Vector of Dimensionless heat capacities. (length m_kk).
-     * @param h_RT    Vector of Dimensionless enthalpies. (length m_kk).
-     * @param s_R     Vector of Dimensionless entropies. (length m_kk).
+     * @param[in] temp     Temperature (Kelvin)
+     * @param[out] cp_R    Dimensionless heat capacity
+     * @param[out] h_RT    Dimensionless enthalpy
+     * @param[out] s_R     Dimensionless entropy
      */
-    virtual void updatePropertiesTemp(const double temp,
-                                      double* cp_R,
-                                      double* h_RT,
-                                      double* s_R) const;
+    virtual void updatePropertiesTemp(const double temp, double& cp_R,
+                                      double& h_RT, double& s_R) const;
 
     //! This utility function returns the number of coefficients
     //! for a given type of species parameterization
@@ -223,7 +220,7 @@ public:
      */
     virtual void reportParameters(size_t& index, int& type, double& minTemp,
                                   double& maxTemp, double& refPressure,
-                                  double* const coeffs) const;
+                                  span<double> coeffs) const;
 
     //! Return the parameters of the species thermo object such that an
     //! identical species thermo object could be reconstructed using the
@@ -247,7 +244,7 @@ public:
      * @return the current value of the Heat of Formation at 298K and 1 bar for
      *               species m_speciesIndex.
      */
-    virtual double reportHf298(double* const h298 = 0) const;
+    virtual double reportHf298(span<double> h298={}) const;
 
     //! Modify the value of the 298 K Heat of Formation of one species in the
     //! phase (J kmol-1)

--- a/include/cantera/thermo/StoichSubstance.h
+++ b/include/cantera/thermo/StoichSubstance.h
@@ -153,7 +153,7 @@ public:
      *           units depend upon the implementation of the
      *           reaction rate expressions within the phase.
      */
-    void getActivityConcentrations(double* c) const override;
+    void getActivityConcentrations(span<double> c) const override;
 
     //! Return the standard concentration for the kth species
     /*!
@@ -184,16 +184,16 @@ public:
      * @param mu0     Output vector of chemical potentials.
      *                Length: m_kk.
      */
-    void getStandardChemPotentials(double* mu0) const override;
+    void getStandardChemPotentials(span<double> mu0) const override;
 
     //! @}
     //! @name  Properties of the Standard State of the Species in the Solution
     //! @{
 
-    void getEnthalpy_RT(double* hrt) const override;
-    void getEntropy_R(double* sr) const override;
-    void getGibbs_RT(double* grt) const override;
-    void getCp_R(double* cpr) const override;
+    void getEnthalpy_RT(span<double> hrt) const override;
+    void getEntropy_R(span<double> sr) const override;
+    void getGibbs_RT(span<double> grt) const override;
+    void getCp_R(span<double> cpr) const override;
 
     //! Returns the vector of nondimensional Internal Energies of the standard
     //! state species at the current *T* and *P* of the solution
@@ -207,7 +207,7 @@ public:
      * @param urt  output vector of nondimensional standard state
      *             internal energies of the species. Length: m_kk.
      */
-    void getIntEnergy_RT(double* urt) const override;
+    void getIntEnergy_RT(span<double> urt) const override;
 
     //! @}
     //! @name Thermodynamic Values for the Species Reference States
@@ -220,7 +220,7 @@ public:
      * @param urt    Output vector of nondimensional reference state internal
      *               energies of the species. Length: m_kk
      */
-    void getIntEnergy_RT_ref(double* urt) const override;
+    void getIntEnergy_RT_ref(span<double> urt) const override;
     //! @}
 
     void initThermo() override;

--- a/include/cantera/thermo/SurfPhase.h
+++ b/include/cantera/thermo/SurfPhase.h
@@ -162,12 +162,12 @@ public:
     double cp_mole() const override;
     double cv_mole() const override;
 
-    void getChemPotentials(double* mu) const override;
-    void getPartialMolarEnthalpies(double* hbar) const override;
-    void getPartialMolarEntropies(double* sbar) const override;
-    void getPartialMolarCp(double* cpbar) const override;
-    void getPartialMolarVolumes(double* vbar) const override;
-    void getStandardChemPotentials(double* mu0) const override;
+    void getChemPotentials(span<double> mu) const override;
+    void getPartialMolarEnthalpies(span<double> hbar) const override;
+    void getPartialMolarEntropies(span<double> sbar) const override;
+    void getPartialMolarCp(span<double> cpbar) const override;
+    void getPartialMolarVolumes(span<double> vbar) const override;
+    void getStandardChemPotentials(span<double> mu0) const override;
 
     //! Return a vector of activity concentrations for each species
     /*!
@@ -193,7 +193,7 @@ public:
      *
      * @param c vector of activity concentration (kmol m-2).
      */
-    void getActivityConcentrations(double* c) const override;
+    void getActivityConcentrations(span<double> c) const override;
 
     //! Return the standard concentration for the kth species
     /*!
@@ -244,11 +244,11 @@ public:
      */
     void setSiteDensity(double n0);
 
-    void getGibbs_RT(double* grt) const override;
-    void getEnthalpy_RT(double* hrt) const override;
-    void getEntropy_R(double* sr) const override;
-    void getCp_R(double* cpr) const override;
-    void getStandardVolumes(double* vol) const override;
+    void getGibbs_RT(span<double> grt) const override;
+    void getEnthalpy_RT(span<double> hrt) const override;
+    void getEntropy_R(span<double> sr) const override;
+    void getCp_R(span<double> cpr) const override;
+    void getStandardVolumes(span<double> vol) const override;
 
     //! Return the thermodynamic pressure (Pa).
     double pressure() const override {
@@ -264,10 +264,10 @@ public:
         m_press = p;
     }
 
-    void getGibbs_RT_ref(double* grt) const override;
-    void getEnthalpy_RT_ref(double* hrt) const override;
-    void getEntropy_R_ref(double* er) const override;
-    void getCp_R_ref(double* cprt) const override;
+    void getGibbs_RT_ref(span<double> grt) const override;
+    void getEnthalpy_RT_ref(span<double> hrt) const override;
+    void getEntropy_R_ref(span<double> er) const override;
+    void getCp_R_ref(span<double> cprt) const override;
 
     //! Set the surface site fractions to a specified state.
     /*!

--- a/include/cantera/thermo/SurfPhase.h
+++ b/include/cantera/thermo/SurfPhase.h
@@ -281,7 +281,7 @@ public:
      *
      * This routine normalizes the theta's to 1, before application
      */
-    void setCoverages(const double* theta);
+    void setCoverages(span<const double> theta);
 
     //! Set the surface site fractions to a specified state.
     /*!
@@ -293,7 +293,7 @@ public:
      * @param theta    This is the surface site fraction for the kth species in
      *                 the surface phase. This is a dimensionless quantity.
      */
-    void setCoveragesNoNorm(const double* theta);
+    void setCoveragesNoNorm(span<const double> theta);
 
     //! Set the coverages from a string of colon-separated name:value pairs.
     /*!
@@ -314,7 +314,7 @@ public:
      * @param theta Array theta must be at least as long as the number of
      *              species.
      */
-    void getCoverages(double* theta) const;
+    void getCoverages(span<double> theta) const;
 
     //! @copydoc ThermoPhase::setState
     /*!

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -536,7 +536,7 @@ public:
      * @see getPartialMolarEnthalpies()
      */
     virtual double enthalpy_mole() const {
-        getPartialMolarEnthalpies(m_workS.data());
+        getPartialMolarEnthalpies(m_workS);
         return mean_X(m_workS);
     }
 
@@ -554,7 +554,7 @@ public:
      * @see getPartialMolarEnthalpies()
      */
     virtual double entropy_mole() const {
-        getPartialMolarEntropies(m_workS.data());
+        getPartialMolarEntropies(m_workS);
         return mean_X(m_workS);
     }
 
@@ -567,7 +567,7 @@ public:
      * @see getChemPotentials()
      */
     virtual double gibbs_mole() const {
-        getChemPotentials(m_workS.data());
+        getChemPotentials(m_workS);
         return mean_X(m_workS);
     }
 
@@ -579,7 +579,7 @@ public:
      * @see getPartialMolarCp()
      */
     virtual double cp_mole() const {
-        getPartialMolarCp(m_workS.data());
+        getPartialMolarCp(m_workS);
         return mean_X(m_workS);
     }
 
@@ -735,7 +735,7 @@ public:
      *           upon the implementation of the reaction rate expressions within
      *           the phase.
      */
-    virtual void getActivityConcentrations(double* c) const {
+    virtual void getActivityConcentrations(span<double> c) const {
         throw NotImplementedError("ThermoPhase::getActivityConcentrations",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -780,14 +780,14 @@ public:
      *
      * @param a   Output vector of activities. Length: m_kk.
      */
-    virtual void getActivities(double* a) const;
+    virtual void getActivities(span<double> a) const;
 
     //! Get the array of non-dimensional molar-based activity coefficients at
     //! the current solution temperature, pressure, and solution concentration.
     /*!
      * @param ac Output vector of activity coefficients. Length: m_kk.
      */
-    virtual void getActivityCoefficients(double* ac) const {
+    virtual void getActivityCoefficients(span<double> ac) const {
         if (m_kk == 1) {
             ac[0] = 1.0;
         } else {
@@ -801,7 +801,7 @@ public:
     /*!
      * @param lnac Output vector of ln activity coefficients. Length: m_kk.
      */
-    virtual void getLnActivityCoefficients(double* lnac) const;
+    virtual void getLnActivityCoefficients(span<double> lnac) const;
 
     //! @}
     //! @name  Partial Molar Properties of the Solution
@@ -816,7 +816,7 @@ public:
      * @param mu  Output vector of species chemical
      *            potentials. Length: m_kk. Units: J/kmol
      */
-    virtual void getChemPotentials(double* mu) const {
+    virtual void getChemPotentials(span<double> mu) const {
         throw NotImplementedError("ThermoPhase::getChemPotentials",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -835,7 +835,7 @@ public:
      * @param mu  Output vector of species electrochemical
      *            potentials. Length: m_kk. Units: J/kmol
      */
-    void getElectrochemPotentials(double* mu) const;
+    void getElectrochemPotentials(span<double> mu) const;
 
     //! Returns an array of partial molar enthalpies for the species
     //! in the mixture. Units (J/kmol)
@@ -843,7 +843,7 @@ public:
      * @param hbar    Output vector of species partial molar enthalpies.
      *                Length: m_kk. units are J/kmol.
      */
-    virtual void getPartialMolarEnthalpies(double* hbar) const {
+    virtual void getPartialMolarEnthalpies(span<double> hbar) const {
         throw NotImplementedError("ThermoPhase::getPartialMolarEnthalpies",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -854,7 +854,7 @@ public:
      * @param sbar    Output vector of species partial molar entropies.
      *                Length = m_kk. units are J/kmol/K.
      */
-    virtual void getPartialMolarEntropies(double* sbar) const {
+    virtual void getPartialMolarEntropies(span<double> sbar) const {
         throw NotImplementedError("ThermoPhase::getPartialMolarEntropies",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -865,7 +865,7 @@ public:
      * @param ubar    Output vector of species partial molar internal energies.
      *                Length = m_kk. units are J/kmol.
      */
-    virtual void getPartialMolarIntEnergies(double* ubar) const {
+    virtual void getPartialMolarIntEnergies(span<double> ubar) const {
         throw NotImplementedError("ThermoPhase::getPartialMolarIntEnergies",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -877,7 +877,7 @@ public:
      *                capacities at constant pressure.
      *                Length = m_kk. units are J/kmol/K.
      */
-    virtual void getPartialMolarCp(double* cpbar) const {
+    virtual void getPartialMolarCp(span<double> cpbar) const {
         throw NotImplementedError("ThermoPhase::getPartialMolarCp",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -888,7 +888,7 @@ public:
      *  @param vbar   Output vector of species partial molar volumes.
      *                Length = m_kk. units are m^3/kmol.
      */
-    virtual void getPartialMolarVolumes(double* vbar) const {
+    virtual void getPartialMolarVolumes(span<double> vbar) const {
         throw NotImplementedError("ThermoPhase::getPartialMolarVolumes",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -907,7 +907,7 @@ public:
      * @param mu      Output vector of chemical potentials.
      *                Length: m_kk.
      */
-    virtual void getStandardChemPotentials(double* mu) const {
+    virtual void getStandardChemPotentials(span<double> mu) const {
         throw NotImplementedError("ThermoPhase::getStandardChemPotentials",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -918,7 +918,7 @@ public:
      * @param hrt      Output vector of nondimensional standard state enthalpies.
      *                 Length: m_kk.
      */
-    virtual void getEnthalpy_RT(double* hrt) const {
+    virtual void getEnthalpy_RT(span<double> hrt) const {
         throw NotImplementedError("ThermoPhase::getEnthalpy_RT",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -929,7 +929,7 @@ public:
      * @param sr   Output vector of nondimensional standard state entropies.
      *             Length: m_kk.
      */
-    virtual void getEntropy_R(double* sr) const {
+    virtual void getEntropy_R(span<double> sr) const {
         throw NotImplementedError("ThermoPhase::getEntropy_R",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -940,7 +940,7 @@ public:
      * @param grt  Output vector of nondimensional standard state Gibbs free
      *             energies. Length: m_kk.
      */
-    virtual void getGibbs_RT(double* grt) const {
+    virtual void getGibbs_RT(span<double> grt) const {
         throw NotImplementedError("ThermoPhase::getGibbs_RT",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -951,7 +951,7 @@ public:
      * @param urt  output vector of nondimensional standard state internal energies
      *             of the species. Length: m_kk.
      */
-    virtual void getIntEnergy_RT(double* urt) const {
+    virtual void getIntEnergy_RT(span<double> urt) const {
         throw NotImplementedError("ThermoPhase::getIntEnergy_RT",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -963,7 +963,7 @@ public:
      * @param cpr   Output vector of nondimensional standard state heat
      *              capacities. Length: m_kk.
      */
-    virtual void getCp_R(double* cpr) const {
+    virtual void getCp_R(span<double> cpr) const {
         throw NotImplementedError("ThermoPhase::getCp_R",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -976,7 +976,7 @@ public:
      * @param vol     Output vector containing the standard state volumes.
      *                Length: m_kk.
      */
-    virtual void getStandardVolumes(double* vol) const {
+    virtual void getStandardVolumes(span<double> vol) const {
         throw NotImplementedError("ThermoPhase::getStandardVolumes",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -992,7 +992,7 @@ public:
      * @param hrt     Output vector containing the nondimensional reference
      *                state enthalpies. Length: m_kk.
      */
-    virtual void getEnthalpy_RT_ref(double* hrt) const {
+    virtual void getEnthalpy_RT_ref(span<double> hrt) const {
         throw NotImplementedError("ThermoPhase::getEnthalpy_RT_ref",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -1004,7 +1004,7 @@ public:
      * @param grt     Output vector containing the nondimensional reference state
      *                Gibbs Free energies.  Length: m_kk.
      */
-    virtual void getGibbs_RT_ref(double* grt) const {
+    virtual void getGibbs_RT_ref(span<double> grt) const {
         throw NotImplementedError("ThermoPhase::getGibbs_RT_ref",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -1016,7 +1016,7 @@ public:
      * @param g       Output vector containing the reference state
      *                Gibbs Free energies. Length: m_kk. Units: J/kmol.
      */
-    virtual void getGibbs_ref(double* g) const {
+    virtual void getGibbs_ref(span<double> g) const {
         throw NotImplementedError("ThermoPhase::getGibbs_ref",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -1028,7 +1028,7 @@ public:
      * @param er      Output vector containing the nondimensional reference
      *                state entropies. Length: m_kk.
      */
-    virtual void getEntropy_R_ref(double* er) const {
+    virtual void getEntropy_R_ref(span<double> er) const {
         throw NotImplementedError("ThermoPhase::getEntropy_R_ref",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -1040,7 +1040,7 @@ public:
      * @param urt    Output vector of nondimensional reference state internal
      *               energies of the species. Length: m_kk
      */
-    virtual void getIntEnergy_RT_ref(double* urt) const {
+    virtual void getIntEnergy_RT_ref(span<double> urt) const {
         throw NotImplementedError("ThermoPhase::getIntEnergy_RT_ref",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -1053,7 +1053,7 @@ public:
      *               heat capacities at constant pressure for the species.
      *               Length: m_kk
      */
-    virtual void getCp_R_ref(double* cprt) const {
+    virtual void getCp_R_ref(span<double> cprt) const {
         throw NotImplementedError("ThermoPhase::getCp_R_ref",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -1066,7 +1066,7 @@ public:
      * @param vol     Output vector containing the standard state volumes.
      *                Length: m_kk.
      */
-    virtual void getStandardVolumes_ref(double* vol) const {
+    virtual void getStandardVolumes_ref(span<double> vol) const {
         throw NotImplementedError("ThermoPhase::getStandardVolumes_ref",
                                   "Not implemented for phase type '{}'", type());
     }
@@ -1164,7 +1164,7 @@ public:
      * @param x    Vector of mole fractions.
      *             Length is equal to m_kk.
      */
-    virtual void setState_TPX(double t, double p, const double* x);
+    virtual void setState_TPX(double t, double p, span<const double> x);
 
     //! Set the temperature (K), pressure (Pa), and mole fractions.
     /*!
@@ -1202,7 +1202,7 @@ public:
      * @param y    Vector of mass fractions.
      *             Length is equal to m_kk.
      */
-    virtual void setState_TPY(double t, double p, const double* y);
+    virtual void setState_TPY(double t, double p, span<const double> y);
 
     //! Set the internally stored temperature (K), pressure (Pa), and mass
     //! fractions of the phase
@@ -1473,8 +1473,9 @@ public:
      *                   Fuel and oxidizer composition are interpreted
      *                   as mole or mass fractions (default: molar)
      */
-    void setMixtureFraction(double mixFrac, const double* fuelComp,
-                            const double* oxComp, ThermoBasis basis=ThermoBasis::molar);
+    void setMixtureFraction(double mixFrac, span<const double> fuelComp,
+                            span<const double> oxComp,
+                            ThermoBasis basis=ThermoBasis::molar);
     //! @copydoc ThermoPhase::setMixtureFraction
     void setMixtureFraction(double mixFrac, const string& fuelComp,
             const string& oxComp, ThermoBasis basis=ThermoBasis::molar);
@@ -1516,7 +1517,7 @@ public:
      *                   based on a single element (default: "Bilger")
      * @returns          mixture fraction (kg fuel / kg mixture)
      */
-    double mixtureFraction(const double* fuelComp, const double* oxComp,
+    double mixtureFraction(span<const double> fuelComp, span<const double> oxComp,
                            ThermoBasis basis=ThermoBasis::molar,
                            const string& element="Bilger") const;
     //! @copydoc ThermoPhase::mixtureFraction
@@ -1545,7 +1546,8 @@ public:
      *                   Fuel and oxidizer composition are interpreted
      *                   as mole or mass fractions (default: molar)
      */
-    void setEquivalenceRatio(double phi, const double* fuelComp, const double* oxComp,
+    void setEquivalenceRatio(double phi, span<const double> fuelComp,
+                             span<const double> oxComp,
                              ThermoBasis basis=ThermoBasis::molar);
     //! @copydoc ThermoPhase::setEquivalenceRatio
     void setEquivalenceRatio(double phi, const string& fuelComp,
@@ -1582,7 +1584,7 @@ public:
      * @see mixtureFraction for the definition of the Bilger mixture fraction
      * @see equivalenceRatio() for the computation of @f$ \phi @f$ without arguments
      */
-    double equivalenceRatio(const double* fuelComp, const double* oxComp,
+    double equivalenceRatio(span<const double> fuelComp, span<const double> oxComp,
                             ThermoBasis basis=ThermoBasis::molar) const;
     //! @copydoc ThermoPhase::equivalenceRatio
     double equivalenceRatio(const string& fuelComp, const string& oxComp,
@@ -1637,7 +1639,7 @@ public:
      *                   as mole or mass fractions (default: molar)
      * @returns          Stoichiometric Air to Fuel Ratio (kg oxidizer / kg fuel)
      */
-    double stoichAirFuelRatio(const double* fuelComp, const double* oxComp,
+    double stoichAirFuelRatio(span<const double> fuelComp, span<const double> oxComp,
                               ThermoBasis basis=ThermoBasis::molar) const;
     //! @copydoc ThermoPhase::stoichAirFuelRatio
     double stoichAirFuelRatio(const string& fuelComp, const string& oxComp,
@@ -1689,7 +1691,7 @@ private:
      * @param y       array of (possibly non-normalized) mass fractions (length m_kk)
      * @returns       amount of required oxygen in kmol O / kg mixture
      */
-    double o2Required(const double* y) const;
+    double o2Required(span<const double> y) const;
 
     //! Helper function for computing the amount of oxygen
     //! available in the current mixture.
@@ -1697,7 +1699,7 @@ private:
      * @param y       array of (possibly non-normalized) mass fractions (length m_kk)
      * @returns       amount of O in kmol O / kg mixture
      */
-    double o2Present(const double* y) const;
+    double o2Present(span<const double> y) const;
 
 public:
     //! @name Chemical Equilibrium
@@ -1752,7 +1754,7 @@ public:
      * @param mu_RT Input vector of dimensionless chemical potentials
      *                  The length is equal to nSpecies().
      */
-    virtual void setToEquilState(const double* mu_RT) {
+    virtual void setToEquilState(span<const double> mu_RT) {
         throw NotImplementedError("ThermoPhase::setToEquilState");
     }
 
@@ -1959,8 +1961,8 @@ public:
      *                       m_kk units are 1/units(s). if s is a physical
      *                       coordinate then the units are 1/m.
      */
-    virtual void getdlnActCoeffds(const double dTds, const double* const dXds,
-                                  double* dlnActCoeffds) const {
+    virtual void getdlnActCoeffds(const double dTds, span<const double> dXds,
+                                  span<double> dlnActCoeffds) const {
         throw NotImplementedError("ThermoPhase::getdlnActCoeffds");
     }
 
@@ -1979,7 +1981,7 @@ public:
      * @param dlnActCoeffdlnX_diag    Output vector of derivatives of the log
      *     Activity Coefficients wrt the mole fractions. length = m_kk
      */
-    virtual void getdlnActCoeffdlnX_diag(double* dlnActCoeffdlnX_diag) const {
+    virtual void getdlnActCoeffdlnX_diag(span<double> dlnActCoeffdlnX_diag) const {
         throw NotImplementedError("ThermoPhase::getdlnActCoeffdlnX_diag");
     }
 
@@ -1999,7 +2001,7 @@ public:
      * @param dlnActCoeffdlnN_diag    Output vector of derivatives of the
      *                                log Activity Coefficients. length = m_kk
      */
-    virtual void getdlnActCoeffdlnN_diag(double* dlnActCoeffdlnN_diag) const {
+    virtual void getdlnActCoeffdlnN_diag(span<double> dlnActCoeffdlnN_diag) const {
         throw NotImplementedError("ThermoPhase::getdlnActCoeffdlnN_diag");
     }
 
@@ -2028,10 +2030,10 @@ public:
      * @param dlnActCoeffdlnN    Output vector of derivatives of the
      *                           log Activity Coefficients. length = m_kk * m_kk
      */
-    virtual void getdlnActCoeffdlnN(const size_t ld, double* const dlnActCoeffdlnN);
+    virtual void getdlnActCoeffdlnN(const size_t ld, span<double> dlnActCoeffdlnN);
 
     virtual void getdlnActCoeffdlnN_numderiv(const size_t ld,
-                                             double* const dlnActCoeffdlnN);
+                                             span<double> dlnActCoeffdlnN);
 
     //! @}
     //! @name Printing

--- a/include/cantera/thermo/VPStandardStateTP.h
+++ b/include/cantera/thermo/VPStandardStateTP.h
@@ -68,13 +68,13 @@ public:
     //! recalculated unless the temperature or pressure changes.
     //! @{
 
-    void getStandardChemPotentials(double* mu) const override;
-    void getEnthalpy_RT(double* hrt) const override;
-    void getEntropy_R(double* sr) const override;
-    void getGibbs_RT(double* grt) const override;
-    void getIntEnergy_RT(double* urt) const override;
-    void getCp_R(double* cpr) const override;
-    void getStandardVolumes(double* vol) const override;
+    void getStandardChemPotentials(span<double> mu) const override;
+    void getEnthalpy_RT(span<double> hrt) const override;
+    void getEntropy_R(span<double> sr) const override;
+    void getGibbs_RT(span<double> grt) const override;
+    void getIntEnergy_RT(span<double> urt) const override;
+    void getCp_R(span<double> cpr) const override;
+    void getStandardVolumes(span<double> vol) const override;
     virtual const vector<double>& getStandardVolumes() const;
     //! @}
 
@@ -188,12 +188,12 @@ public:
     //! routine _updateRefStateThermo().
     //! @{
 
-    void getEnthalpy_RT_ref(double* hrt) const override;
-    void getGibbs_RT_ref(double* grt) const override;
-    void getGibbs_ref(double* g) const override;
-    void getEntropy_R_ref(double* er) const override;
-    void getCp_R_ref(double* cprt) const override;
-    void getStandardVolumes_ref(double* vol) const override;
+    void getEnthalpy_RT_ref(span<double> hrt) const override;
+    void getGibbs_RT_ref(span<double> grt) const override;
+    void getGibbs_ref(span<double> g) const override;
+    void getEntropy_R_ref(span<double> er) const override;
+    void getCp_R_ref(span<double> cprt) const override;
+    void getStandardVolumes_ref(span<double> vol) const override;
 
     //! @}
     //! @name Initialization Methods - For Internal use

--- a/include/cantera/thermo/VPStandardStateTP.h
+++ b/include/cantera/thermo/VPStandardStateTP.h
@@ -75,7 +75,7 @@ public:
     void getIntEnergy_RT(span<double> urt) const override;
     void getCp_R(span<double> cpr) const override;
     void getStandardVolumes(span<double> vol) const override;
-    virtual const vector<double>& getStandardVolumes() const;
+    virtual span<const double> getStandardVolumes() const;
     //! @}
 
     //! Set the temperature of the phase

--- a/include/cantera/thermo/WaterSSTP.h
+++ b/include/cantera/thermo/WaterSSTP.h
@@ -103,12 +103,12 @@ public:
     //! @name Properties of the Standard State of the Species in the Solution
     //! @{
 
-    void getStandardChemPotentials(double* gss) const override;
-    void getGibbs_RT(double* grt) const override;
-    void getEnthalpy_RT(double* hrt) const override;
-    void getEntropy_R(double* sr) const override;
-    void getCp_R(double* cpr) const override;
-    void getIntEnergy_RT(double* urt) const override;
+    void getStandardChemPotentials(span<double> gss) const override;
+    void getGibbs_RT(span<double> grt) const override;
+    void getEnthalpy_RT(span<double> hrt) const override;
+    void getEntropy_R(span<double> sr) const override;
+    void getCp_R(span<double> cpr) const override;
+    void getIntEnergy_RT(span<double> urt) const override;
 
     //! @}
     //! @name Thermodynamic Values for the Species Reference State
@@ -118,12 +118,12 @@ public:
     //! equation of state.
     //! @{
 
-    void getEnthalpy_RT_ref(double* hrt) const override;
-    void getGibbs_RT_ref(double* grt) const override;
-    void getGibbs_ref(double* g) const override;
-    void getEntropy_R_ref(double* er) const override;
-    void getCp_R_ref(double* cprt) const override;
-    void getStandardVolumes_ref(double* vol) const override;
+    void getEnthalpy_RT_ref(span<double> hrt) const override;
+    void getGibbs_RT_ref(span<double> grt) const override;
+    void getGibbs_ref(span<double> g) const override;
+    void getEntropy_R_ref(span<double> er) const override;
+    void getCp_R_ref(span<double> cprt) const override;
+    void getStandardVolumes_ref(span<double> vol) const override;
     //! @}
 
     double critTemperature() const override;

--- a/interfaces/cython/cantera/mixture.pxd
+++ b/interfaces/cython/cantera/mixture.pxd
@@ -42,7 +42,7 @@ cdef extern from "cantera/equil/MultiPhase.h" namespace "Cantera":
         double maxTemp() except +translate_exception
         double charge() except +translate_exception
         double phaseCharge(size_t) except +translate_exception
-        void getChemPotentials(double*) except +translate_exception
+        void getChemPotentials(span[double]) except +translate_exception
         double enthalpy() except +translate_exception
         double entropy() except +translate_exception
         double gibbs() except +translate_exception

--- a/interfaces/cython/cantera/mixture.pyx
+++ b/interfaces/cython/cantera/mixture.pyx
@@ -4,6 +4,7 @@
 import numpy as np
 
 from .solutionbase cimport *
+from .ctcxx cimport span
 from .thermo cimport *
 from ._utils cimport *
 
@@ -284,7 +285,8 @@ cdef class Mixture:
         """The chemical potentials of all species [J/kmol]."""
         def __get__(self):
             cdef np.ndarray[np.double_t, ndim=1] data = np.empty(self.n_species)
-            self.mix.getChemPotentials(&data[0])
+            cdef span[double] view = span[double](&data[0], <size_t>self.n_species)
+            self.mix.getChemPotentials(view)
             return data
 
     def equilibrate(self, XY, solver='auto', rtol=1e-9, max_steps=1000,

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -74,7 +74,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         double area()
         void setArea(double)
         void setKinetics(CxxKinetics*) except +translate_exception
-        void setCoverages(double*)
+        void setCoverages(double*) except +translate_exception
         void setCoverages(Composition&) except +translate_exception
 
     cdef cppclass CxxFlowReactorSurface "Cantera::FlowReactorSurface" (CxxReactorSurface):

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -5,6 +5,7 @@ import warnings
 import numbers as _numbers
 from cython.operator cimport dereference as deref
 import numpy as np
+cimport numpy as np
 
 from ._utils cimport pystr, stringify, comp_map, py_to_anymap, anymap_to_py
 from .delegator cimport *

--- a/interfaces/cython/cantera/speciesthermo.pxd
+++ b/interfaces/cython/cantera/speciesthermo.pxd
@@ -10,11 +10,11 @@ cdef extern from "cantera/thermo/SpeciesThermoInterpType.h":
     cdef cppclass CxxSpeciesThermo "Cantera::SpeciesThermoInterpType":
         CxxSpeciesThermo()
         int reportType()
-        void updatePropertiesTemp(double, double*, double*, double*) except +translate_exception
+        void updatePropertiesTemp(double, double&, double&, double&) except +translate_exception
         double minTemp()
         double maxTemp()
         double refPressure()
-        void reportParameters(size_t&, int&, double&, double&, double&, double* const) except +translate_exception
+        void reportParameters(size_t&, int&, double&, double&, double&, span[double]) except +translate_exception
         int nCoeffs() except +translate_exception
         CxxAnyMap parameters(cbool) except +translate_exception
         CxxAnyMap& input()
@@ -22,7 +22,7 @@ cdef extern from "cantera/thermo/SpeciesThermoInterpType.h":
 
 cdef extern from "cantera/thermo/SpeciesThermoFactory.h":
     cdef CxxSpeciesThermo* CxxNewSpeciesThermo "Cantera::newSpeciesThermoInterpType"\
-        (int, double, double, double, double*) except +translate_exception
+        (int, double, double, double, span[double]) except +translate_exception
 
 
 cdef class SpeciesThermo:

--- a/interfaces/cython/cantera/thermo.pxd
+++ b/interfaces/cython/cantera/thermo.pxd
@@ -179,10 +179,10 @@ cdef extern from "cantera/thermo/SurfPhase.h":
         CxxSurfPhase()
         double siteDensity()
         void setSiteDensity(double) except +translate_exception
-        void setCoverages(double*) except +translate_exception
+        void setCoverages(span[double]) except +translate_exception
         void setCoveragesByName(Composition&) except +translate_exception
-        void setCoveragesNoNorm(double*) except +translate_exception
-        void getCoverages(double*) except +translate_exception
+        void setCoveragesNoNorm(span[double]) except +translate_exception
+        void getCoverages(span[double]) except +translate_exception
 
 
 cdef extern from "cantera/thermo/PlasmaPhase.h":
@@ -191,10 +191,10 @@ cdef extern from "cantera/thermo/PlasmaPhase.h":
         void setElectronTemperature(double) except +translate_exception
         void setReducedElectricField(double) except +translate_exception
         void setElectricField(double) except +translate_exception
-        void setElectronEnergyLevels(double*, size_t) except +translate_exception
-        void getElectronEnergyLevels(double*)
-        void setDiscretizedElectronEnergyDist(double*, double*, size_t) except +translate_exception
-        void getElectronEnergyDistribution(double*)
+        void setElectronEnergyLevels(span[double]) except +translate_exception
+        void getElectronEnergyLevels(span[double])
+        void setDiscretizedElectronEnergyDist(span[double], span[double]) except +translate_exception
+        void getElectronEnergyDistribution(span[double])
         void setIsotropicShapeFactor(double) except +translate_exception
         void setElectronEnergyDistributionType(const string&) except +translate_exception
         string electronEnergyDistributionType()

--- a/interfaces/cython/cantera/thermo.pxd
+++ b/interfaces/cython/cantera/thermo.pxd
@@ -54,8 +54,8 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
         double refPressure() except +translate_exception
         void equilibrate(string, string, double, int, int, int, int) except +translate_exception
         size_t stateSize()
-        void saveState(size_t, double*) except +translate_exception
-        void restoreState(size_t, double*) except +translate_exception
+        void saveState(span[double]) except +translate_exception
+        void restoreState(span[double]) except +translate_exception
         CxxUnits standardConcentrationUnits() except +translate_exception
 
         # initialization

--- a/interfaces/cython/cantera/thermo.pxd
+++ b/interfaces/cython/cantera/thermo.pxd
@@ -7,8 +7,6 @@
 from .ctcxx cimport *
 from .solutionbase cimport *
 
-ctypedef const double const_double
-
 cdef extern from "cantera/thermo/Species.h" namespace "Cantera":
     cdef cppclass CxxSpeciesThermo "Cantera::SpeciesThermoInterpType"
     cdef cppclass CxxTransportData "Cantera::TransportData"
@@ -166,12 +164,12 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
         void setState_Psat(double P, double x) except +translate_exception
         void setState_TPQ(double T, double P, double Q) except +translate_exception
 
-        void setMixtureFraction(double mixFrac, const double* fuelComp, const double* oxComp, ThermoBasis basis) except +translate_exception
-        double mixtureFraction(const double* fuelComp, const double* oxComp, ThermoBasis basis, string element) except +translate_exception
-        void setEquivalenceRatio(double phi, const double* fuelComp, const double* oxComp, ThermoBasis basis) except +translate_exception
-        double equivalenceRatio(const double* fuelComp, const double* oxComp, ThermoBasis basis) except +translate_exception
+        void setMixtureFraction(double mixFrac, span[double] fuelComp, span[double] oxComp, ThermoBasis basis) except +translate_exception
+        double mixtureFraction(span[double] fuelComp, span[double] oxComp, ThermoBasis basis, string element) except +translate_exception
+        void setEquivalenceRatio(double phi, span[double] fuelComp, span[double] oxComp, ThermoBasis basis) except +translate_exception
+        double equivalenceRatio(span[double] fuelComp, span[double] oxComp, ThermoBasis basis) except +translate_exception
         double equivalenceRatio() except +translate_exception
-        double stoichAirFuelRatio(const double* fuelComp, const double* oxComp, ThermoBasis basis) except +translate_exception
+        double stoichAirFuelRatio(span[double] fuelComp, span[double] oxComp, ThermoBasis basis) except +translate_exception
 
         CxxAnyMap getAuxiliaryData() except +translate_exception
 
@@ -219,11 +217,11 @@ cdef extern from "cantera/thermo/PlasmaPhase.h":
 cdef extern from "cantera/cython/thermo_utils.h":
     # ThermoPhase composition
     cdef void thermo_getMassFractions(CxxThermoPhase*, span[double]) except +translate_exception
-    cdef void thermo_setMassFractions(CxxThermoPhase*, span[const_double]) except +translate_exception
+    cdef void thermo_setMassFractions(CxxThermoPhase*, span[double]) except +translate_exception
     cdef void thermo_getMoleFractions(CxxThermoPhase*, span[double]) except +translate_exception
-    cdef void thermo_setMoleFractions(CxxThermoPhase*, span[const_double]) except +translate_exception
+    cdef void thermo_setMoleFractions(CxxThermoPhase*, span[double]) except +translate_exception
     cdef void thermo_getConcentrations(CxxThermoPhase*, span[double]) except +translate_exception
-    cdef void thermo_setConcentrations(CxxThermoPhase*, span[const_double]) except +translate_exception
+    cdef void thermo_setConcentrations(CxxThermoPhase*, span[double]) except +translate_exception
 
     # ThermoPhase partial molar properties
     cdef void thermo_getChemPotentials(CxxThermoPhase*, span[double]) except +translate_exception
@@ -249,7 +247,6 @@ cdef extern from "cantera/cython/thermo_utils.h":
 
 
 ctypedef void (*thermoMethod1d)(CxxThermoPhase*, span[double]) except +translate_exception
-ctypedef void (*thermoMethod1d_const)(CxxThermoPhase*, span[const_double]) except +translate_exception
 
 cdef extern from "cantera/thermo/Elements.h" namespace "Cantera":
     vector[string] elementSymbols()
@@ -277,7 +274,7 @@ cdef class ThermoPhase(_SolutionBase):
     cpdef int element_index(self, element) except *
     cpdef int species_index(self, species) except *
     cdef np.ndarray _getArray1(self, thermoMethod1d method)
-    cdef void _setArray1(self, thermoMethod1d_const method, values) except *
+    cdef void _setArray1(self, thermoMethod1d method, values) except *
     cdef CxxPlasmaPhase* plasma
     cdef public object _enable_plasma
 

--- a/interfaces/cython/cantera/thermo.pxd
+++ b/interfaces/cython/cantera/thermo.pxd
@@ -105,14 +105,14 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
         # composition
         void setMassFractionsByName(string) except +translate_exception
         void setMassFractionsByName(Composition&) except +translate_exception
-        void setMassFractions_NoNorm(double*) except +translate_exception
+        void setMassFractions_NoNorm(span[double]) except +translate_exception
         Composition getMassFractionsByName(double)
         double massFraction(size_t) except +translate_exception
         double massFraction(string) except +translate_exception
 
         void setMoleFractionsByName(string) except +translate_exception
         void setMoleFractionsByName(Composition&) except +translate_exception
-        void setMoleFractions_NoNorm(double*) except +translate_exception
+        void setMoleFractions_NoNorm(span[double]) except +translate_exception
         Composition getMoleFractionsByName(double)
 
         double concentration(size_t) except +translate_exception

--- a/interfaces/cython/cantera/thermo.pxd
+++ b/interfaces/cython/cantera/thermo.pxd
@@ -7,6 +7,8 @@
 from .ctcxx cimport *
 from .solutionbase cimport *
 
+ctypedef const double const_double
+
 cdef extern from "cantera/thermo/Species.h" namespace "Cantera":
     cdef cppclass CxxSpeciesThermo "Cantera::SpeciesThermoInterpType"
     cdef cppclass CxxTransportData "Cantera::TransportData"
@@ -216,37 +218,38 @@ cdef extern from "cantera/thermo/PlasmaPhase.h":
 
 cdef extern from "cantera/cython/thermo_utils.h":
     # ThermoPhase composition
-    cdef void thermo_getMassFractions(CxxThermoPhase*, double*) except +translate_exception
-    cdef void thermo_setMassFractions(CxxThermoPhase*, double*) except +translate_exception
-    cdef void thermo_getMoleFractions(CxxThermoPhase*, double*) except +translate_exception
-    cdef void thermo_setMoleFractions(CxxThermoPhase*, double*) except +translate_exception
-    cdef void thermo_getConcentrations(CxxThermoPhase*, double*) except +translate_exception
-    cdef void thermo_setConcentrations(CxxThermoPhase*, double*) except +translate_exception
+    cdef void thermo_getMassFractions(CxxThermoPhase*, span[double]) except +translate_exception
+    cdef void thermo_setMassFractions(CxxThermoPhase*, span[const_double]) except +translate_exception
+    cdef void thermo_getMoleFractions(CxxThermoPhase*, span[double]) except +translate_exception
+    cdef void thermo_setMoleFractions(CxxThermoPhase*, span[const_double]) except +translate_exception
+    cdef void thermo_getConcentrations(CxxThermoPhase*, span[double]) except +translate_exception
+    cdef void thermo_setConcentrations(CxxThermoPhase*, span[const_double]) except +translate_exception
 
     # ThermoPhase partial molar properties
-    cdef void thermo_getChemPotentials(CxxThermoPhase*, double*) except +translate_exception
-    cdef void thermo_getElectrochemPotentials(CxxThermoPhase*, double*) except +translate_exception
-    cdef void thermo_getPartialMolarEnthalpies(CxxThermoPhase*, double*) except +translate_exception
-    cdef void thermo_getPartialMolarEntropies(CxxThermoPhase*, double*) except +translate_exception
-    cdef void thermo_getPartialMolarIntEnergies(CxxThermoPhase*, double*) except +translate_exception
-    cdef void thermo_getPartialMolarCp(CxxThermoPhase*, double*) except +translate_exception
-    cdef void thermo_getPartialMolarVolumes(CxxThermoPhase*, double*) except +translate_exception
+    cdef void thermo_getChemPotentials(CxxThermoPhase*, span[double]) except +translate_exception
+    cdef void thermo_getElectrochemPotentials(CxxThermoPhase*, span[double]) except +translate_exception
+    cdef void thermo_getPartialMolarEnthalpies(CxxThermoPhase*, span[double]) except +translate_exception
+    cdef void thermo_getPartialMolarEntropies(CxxThermoPhase*, span[double]) except +translate_exception
+    cdef void thermo_getPartialMolarIntEnergies(CxxThermoPhase*, span[double]) except +translate_exception
+    cdef void thermo_getPartialMolarCp(CxxThermoPhase*, span[double]) except +translate_exception
+    cdef void thermo_getPartialMolarVolumes(CxxThermoPhase*, span[double]) except +translate_exception
 
     # ThermoPhase partial non-dimensional properties
-    void thermo_getEnthalpy_RT(CxxThermoPhase*, double*) except +translate_exception
-    void thermo_getEntropy_R(CxxThermoPhase*, double*) except +translate_exception
-    void thermo_getIntEnergy_RT(CxxThermoPhase*, double*) except +translate_exception
-    void thermo_getGibbs_RT(CxxThermoPhase*, double*) except +translate_exception
-    void thermo_getCp_R(CxxThermoPhase*, double*) except +translate_exception
-    void thermo_getActivities(CxxThermoPhase*, double*) except +translate_exception
-    void thermo_getActivityCoefficients(CxxThermoPhase*, double*) except +translate_exception
+    void thermo_getEnthalpy_RT(CxxThermoPhase*, span[double]) except +translate_exception
+    void thermo_getEntropy_R(CxxThermoPhase*, span[double]) except +translate_exception
+    void thermo_getIntEnergy_RT(CxxThermoPhase*, span[double]) except +translate_exception
+    void thermo_getGibbs_RT(CxxThermoPhase*, span[double]) except +translate_exception
+    void thermo_getCp_R(CxxThermoPhase*, span[double]) except +translate_exception
+    void thermo_getActivities(CxxThermoPhase*, span[double]) except +translate_exception
+    void thermo_getActivityCoefficients(CxxThermoPhase*, span[double]) except +translate_exception
 
     # other ThermoPhase methods
-    cdef void thermo_getMolecularWeights(CxxThermoPhase*, double*) except +translate_exception
-    cdef void thermo_getCharges(CxxThermoPhase*, double*) except +translate_exception
+    cdef void thermo_getMolecularWeights(CxxThermoPhase*, span[double]) except +translate_exception
+    cdef void thermo_getCharges(CxxThermoPhase*, span[double]) except +translate_exception
 
 
-ctypedef void (*thermoMethod1d)(CxxThermoPhase*, double*) except +translate_exception
+ctypedef void (*thermoMethod1d)(CxxThermoPhase*, span[double]) except +translate_exception
+ctypedef void (*thermoMethod1d_const)(CxxThermoPhase*, span[const_double]) except +translate_exception
 
 cdef extern from "cantera/thermo/Elements.h" namespace "Cantera":
     vector[string] elementSymbols()
@@ -274,7 +277,7 @@ cdef class ThermoPhase(_SolutionBase):
     cpdef int element_index(self, element) except *
     cpdef int species_index(self, species) except *
     cdef np.ndarray _getArray1(self, thermoMethod1d method)
-    cdef void _setArray1(self, thermoMethod1d method, values) except *
+    cdef void _setArray1(self, thermoMethod1d_const method, values) except *
     cdef CxxPlasmaPhase* plasma
     cdef public object _enable_plasma
 

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1840,10 +1840,9 @@ cdef class ThermoPhase(_SolutionBase):
             np.ascontiguousarray(levels, dtype=np.double)
         cdef np.ndarray[np.double_t, ndim=1] data_dist = \
             np.ascontiguousarray(distribution, dtype=np.double)
-
-        self.plasma.setDiscretizedElectronEnergyDist(&data_levels[0],
-                                                     &data_dist[0],
-                                                     len(levels))
+        self.plasma.setDiscretizedElectronEnergyDist(
+            span[double](&data_levels[0], data_levels.size),
+            span[double](&data_dist[0], data_dist.size))
 
     def update_electron_energy_distribution(self):
         """
@@ -1871,14 +1870,14 @@ cdef class ThermoPhase(_SolutionBase):
                 raise ThermoModelMethodError(self.thermo_model)
             cdef np.ndarray[np.double_t, ndim=1] data = np.empty(
                 self.n_electron_energy_levels)
-            self.plasma.getElectronEnergyLevels(&data[0])
+            self.plasma.getElectronEnergyLevels(span[double](&data[0], data.size))
             return data
         def __set__(self, levels):
             if not self._enable_plasma:
                 raise ThermoModelMethodError(self.thermo_model)
             cdef np.ndarray[np.double_t, ndim=1] data = \
                 np.ascontiguousarray(levels, dtype=np.double)
-            self.plasma.setElectronEnergyLevels(&data[0], len(levels))
+            self.plasma.setElectronEnergyLevels(span[double](&data[0], data.size))
 
     property electron_energy_distribution:
         """ Electron energy distribution """
@@ -1887,7 +1886,7 @@ cdef class ThermoPhase(_SolutionBase):
                 raise ThermoModelMethodError(self.thermo_model)
             cdef np.ndarray[np.double_t, ndim=1] data = np.empty(
                 self.n_electron_energy_levels)
-            self.plasma.getElectronEnergyDistribution(&data[0])
+            self.plasma.getElectronEnergyDistribution(span[double](&data[0], data.size))
             return data
 
     property isotropic_shape_factor:
@@ -1994,7 +1993,7 @@ cdef class InterfacePhase(ThermoPhase):
         """Get/Set the fraction of sites covered by each species."""
         def __get__(self):
             cdef np.ndarray[np.double_t, ndim=1] data = np.empty(self.n_species)
-            self.surf.getCoverages(&data[0])
+            self.surf.getCoverages(span[double](&data[0], data.size))
             if self._selected_species.size:
                 return data[self._selected_species]
             else:
@@ -2010,7 +2009,7 @@ cdef class InterfacePhase(ThermoPhase):
                     " Got {}, expected {}".format(len(theta), self.n_species))
             cdef np.ndarray[np.double_t, ndim=1] data = \
                 np.ascontiguousarray(theta, dtype=np.double)
-            self.surf.setCoverages(&data[0])
+            self.surf.setCoverages(span[double](&data[0], data.size))
 
     def set_unnormalized_coverages(self, cov):
         """
@@ -2024,7 +2023,7 @@ cdef class InterfacePhase(ThermoPhase):
         else:
             raise ValueError("Array has incorrect length."
                  " Got {}, expected {}.".format(len(cov), self.n_species))
-        self.surf.setCoveragesNoNorm(&data[0])
+        self.surf.setCoveragesNoNorm(span[double](&data[0], data.size))
 
 
 cdef class PureFluid(ThermoPhase):

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -8,6 +8,7 @@ import numpy as np
 cimport numpy as np
 
 from .speciesthermo cimport *
+from .ctcxx cimport span
 from .kinetics cimport CxxKinetics
 from .transport cimport *
 from ._utils cimport *
@@ -1124,7 +1125,7 @@ cdef class ThermoPhase(_SolutionBase):
         else:
             raise ValueError("Array has incorrect length."
                  " Got {}, expected {}.".format(len(Y), self.n_species))
-        self.thermo.setMassFractions_NoNorm(&data[0])
+        self.thermo.setMassFractions_NoNorm(span[double](&data[0], data.size))
 
     def set_unnormalized_mole_fractions(self, X):
         """
@@ -1138,7 +1139,7 @@ cdef class ThermoPhase(_SolutionBase):
         else:
             raise ValueError("Array has incorrect length."
                 " Got {}, expected {}.".format(len(X), self.n_species))
-        self.thermo.setMoleFractions_NoNorm(&data[0])
+        self.thermo.setMoleFractions_NoNorm(span[double](&data[0], data.size))
 
     def mass_fraction_dict(self, double threshold=0.0):
         """

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1350,12 +1350,12 @@ cdef class ThermoPhase(_SolutionBase):
         """
         def __get__(self):
             cdef np.ndarray[np.double_t, ndim=1] state = np.empty(self.state_size)
-            self.thermo.saveState(len(state), &state[0])
+            self.thermo.saveState(span[double](&state[0], len(state)))
             return state
 
         def __set__(self, state):
             cdef np.ndarray[np.double_t, ndim=1] cstate = np.asarray(state)
-            self.thermo.restoreState(len(state), &cstate[0])
+            self.thermo.restoreState(span[double](&cstate[0], len(cstate)))
 
     property TD:
         """Get/Set temperature [K] and density [kg/m³ or kmol/m³]."""

--- a/interfaces/sourcegen/src/sourcegen/clib/config.yaml
+++ b/interfaces/sourcegen/src/sourcegen/clib/config.yaml
@@ -22,6 +22,8 @@ ret_type_crosswalk:
   double*: double*
   const double: double*
   vector<double>: double*
+  span<double>: double*
+  span<const double>: const double*
   string: char*
 
 # Parameter type crosswalks

--- a/interfaces/sourcegen/src/sourcegen/clib/config.yaml
+++ b/interfaces/sourcegen/src/sourcegen/clib/config.yaml
@@ -36,6 +36,8 @@ par_type_crosswalk:
   double: double
   double*: double*
   vector<double>: double*
+  span<double>: double*
+  span<const double>: const double*
   string: char*
 
 # Cabinets with associated preambles (headers)

--- a/interfaces/sourcegen/src/sourcegen/clib/generator.py
+++ b/interfaces/sourcegen/src/sourcegen/clib/generator.py
@@ -161,7 +161,7 @@ class CLibSourceGenerator(SourceGenerator):
             after = f"copyString(out, {c_args[-1].name}, {c_args[-2].name});"
         elif "shared_ptr" in cxx_type:
             cxx_rbase = self._shared_object(cxx_type)
-        elif "vector" in cxx_type:
+        elif "vector" in cxx_type or "span" in cxx_type:
             buffer = [
                 f"{cxx_type} out",
                 "int(out.size())",
@@ -396,6 +396,8 @@ class CLibSourceGenerator(SourceGenerator):
         elif recipe.what == "getter":
             ret_type = c_func.wraps.ret_type
             if "void" in ret_type or "vector" in ret_type:
+                template = loader.from_string(self._templates["clib-array-getter"])
+            elif "span" in ret_type:
                 template = loader.from_string(self._templates["clib-array-getter"])
             elif "size_t" in ret_type:
                 template = loader.from_string(self._templates["clib-size-getter"])

--- a/interfaces/sourcegen/src/sourcegen/clib/generator.py
+++ b/interfaces/sourcegen/src/sourcegen/clib/generator.py
@@ -253,6 +253,10 @@ class CLibSourceGenerator(SourceGenerator):
                         after.append(
                             f"std::copy({c_name}_.begin(), {c_name}_.end(), {c_name});")
                     args.append(f"{c_name}_")
+                elif "span<" in cxx_type:
+                    # Example: span<double> par_(par, par + parLen);
+                    before.append(f"{cxx_type} {c_name}_({c_name}, {c_prev});")
+                    args.append(f"{c_name}_")
                 elif "*" in cxx_type:
                     # Can be passed directly; example: double *const
                     args.append(c_name)

--- a/interfaces/sourcegen/src/sourcegen/clib/templates.yaml
+++ b/interfaces/sourcegen/src/sourcegen/clib/templates.yaml
@@ -213,6 +213,7 @@ clib-array-getter: |-
       {{ render_lines(after) | indent(4) }}
       return {{ buffer[1] }};
       {% else %}
+      {{ render_lines(before) | indent(4) }}
       obj->{{ cxx_name }}({{ cxx_args[0] }});
       return 0;
       {% endif %}

--- a/interfaces/sourcegen/src/sourcegen/headers/config.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/config.yaml
@@ -38,3 +38,5 @@ par_type_crosswalk:
   double*: double*
   vector<double>: double*
   string: char*
+  span<double>: double*
+  span<const double>: const double*

--- a/interfaces/sourcegen/src/sourcegen/headers/config.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/config.yaml
@@ -24,6 +24,8 @@ ret_type_crosswalk:
   double*: double*
   const double*: double*
   vector<double>: double*
+  span<double>: double*
+  span<const double>: const double*
 
 # Parameter type crosswalks
 par_type_crosswalk:

--- a/interfaces/sourcegen/src/sourcegen/headers/ctthermo.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctthermo.yaml
@@ -100,11 +100,11 @@ recipes:
 - name: getPartialMolarCp
 - name: getPartialMolarVolumes
 - name: setState_TPX  # New in Cantera 3.2
-  wraps: setState_TPX(double, double, const double*)
+  wraps: setState_TPX(double, double, span<const double>)
 - name: setState_TPX_byName  # New in Cantera 3.2
   wraps: setState_TPX(double, double, const string&)
 - name: setState_TPY  # New in Cantera 3.2
-  wraps: setState_TPY(double, double, const double*)
+  wraps: setState_TPY(double, double, span<const double>)
 - name: setState_TPY_byName  # New in Cantera 3.2
   wraps: setState_TPY(double, double, const string&)
 - name: setState_TP  # Renamed in Cantera 3.2 (previously set_TP)

--- a/interfaces/sourcegen/src/sourcegen/headers/generator.py
+++ b/interfaces/sourcegen/src/sourcegen/headers/generator.py
@@ -82,7 +82,7 @@ class HeaderGenerator:
                 return obj_handle + cxx_member.arglist.params, cxx_member
 
             # Signature may skip C++ default parameters
-            args_short = Func.from_str(wraps).arglist
+            args_short = Func.from_str(wraps, has_names=False).arglist
             if len(args_short) < len(cxx_member.arglist):
                 cxx_arglist = ArgList(cxx_member.arglist[:len(args_short)])
                 cxx_member = Func(cxx_member.ret_type, cxx_member.name,
@@ -252,6 +252,7 @@ class HeaderGenerator:
     def _ret_crosswalk(
             self, what: str, derived: list[str]) -> tuple[Param, list[Param]]:
         """Crosswalk for return type."""
+        orig_what = what
         what = what.removeprefix("virtual ")
         ret_key = what.removeprefix("const ").removesuffix(" const").rstrip("&")
         if ret_key in self._config.ret_type_crosswalk:
@@ -299,7 +300,8 @@ class HeaderGenerator:
                 f"Handle to stored {handle} object or -1 for exception handling.")
             return returns, []
 
-        msg = f"Failed crosswalk for return type {what!r}."
+        msg = f"Failed crosswalk for return type {orig_what!r}."
+        msg += "\nKnown types: " + ", ".join(self._config.ret_type_crosswalk.keys())
         _LOGGER.critical(msg)
         sys.exit(1)
 

--- a/interfaces/sourcegen/src/sourcegen/headers/generator.py
+++ b/interfaces/sourcegen/src/sourcegen/headers/generator.py
@@ -312,7 +312,7 @@ class HeaderGenerator:
             what = par.p_type
             par_key = what.removeprefix("const ").removesuffix(" const").rstrip("&")
             if par_key in self._config.par_type_crosswalk:
-                if "vector<" in par_key:
+                if "vector<" in par_key or "span<" in par_key:
                     params.append(
                         Param("int32_t", f"{par.name}Len",
                               f"Length of vector reserved for {par.name}.", "in"))
@@ -348,6 +348,7 @@ class HeaderGenerator:
                         Param(ret_type, par.name, description.strip(), par.direction))
             else:
                 msg = f"Failed crosswalk for argument type {par_key!r}."
+                msg += " Known types: " + ", ".join(self._config.par_type_crosswalk.keys())
                 _LOGGER.critical(msg)
                 sys.exit(1)
         return params

--- a/interfaces/sourcegen/src/sourcegen/headers/tagfiles.py
+++ b/interfaces/sourcegen/src/sourcegen/headers/tagfiles.py
@@ -238,7 +238,7 @@ class TagFileParser:
     def cxx_member(self, func_string: str, setter: bool = False) -> Func | Param:
         """Generate annotated C++ function/variable specification."""
         details = tag_lookup(self._xml_path, self.tag_info(func_string))
-        ret_param = Param.from_xml(details.type)
+        ret_param = Param.from_xml(details.type, has_name=False)
 
         if details.kind == "variable":
             direction = "in" if setter else "out"

--- a/samples/cxx/LiC6_electrode/LiC6_electrode.cpp
+++ b/samples/cxx/LiC6_electrode/LiC6_electrode.cpp
@@ -59,7 +59,7 @@ void calc_potentials()
             }
         }
 
-        electrodebulk->setMoleFractions(&xv[0]);
+        electrodebulk->setMoleFractions(xv);
         electrodebulk->setTemperature(Tk);
         electrodebulk->getChemPotentials(spvals.data());
 

--- a/samples/cxx/LiC6_electrode/LiC6_electrode.cpp
+++ b/samples/cxx/LiC6_electrode/LiC6_electrode.cpp
@@ -61,13 +61,13 @@ void calc_potentials()
 
         electrodebulk->setMoleFractions(xv);
         electrodebulk->setTemperature(Tk);
-        electrodebulk->getChemPotentials(spvals.data());
+        electrodebulk->getChemPotentials(spvals);
 
         // Calculate the open circuit potential
         double Uref = (spvals[1] - spvals[0])/Faraday;
 
-        electrodebulk->getdlnActCoeffdlnX_diag(dlnActCoeffdlnX_diag.data());
-        electrodebulk->getActivityCoefficients(actCoeff.data());
+        electrodebulk->getdlnActCoeffdlnX_diag(dlnActCoeffdlnX_diag);
+        electrodebulk->getActivityCoefficients(actCoeff);
 
         fout << fmt::format("{}, {}, {}, {}, {}, {}, {}, {}\n",
             xv[0], spvals[0], spvals[1], Uref, actCoeff[0],

--- a/samples/cxx/custom/custom.cpp
+++ b/samples/cxx/custom/custom.cpp
@@ -89,7 +89,7 @@ public:
         /* ----------------------- GET REQ'D PROPERTIES ----------------------- */
         double rho = m_gas->density();
         double cp = m_gas->cp_mass();
-        m_gas->getPartialMolarEnthalpies(&m_hbar[0]);
+        m_gas->getPartialMolarEnthalpies(m_hbar);
         m_kinetics->getNetProductionRates(&m_wdot[0]);
 
         /* -------------------------- ENERGY EQUATION ------------------------- */

--- a/samples/cxx/custom/custom.cpp
+++ b/samples/cxx/custom/custom.cpp
@@ -76,7 +76,7 @@ public:
         // the following variables are defined for clear and convenient access
         // to these vectors:
         double temperature = y[0];
-        double *massFracs = &y[1];
+        span<double> massFracs(y + 1, m_nSpecies);
         double *dTdt = &ydot[0];
         double *dYdt = &ydot[1];
 
@@ -132,7 +132,7 @@ public:
         // the solution vector *y* is [T, Y_1, Y_2, ... Y_K], where T is the
         // system temperature, and Y_k is the mass fraction of species k.
         y[0] = m_gas->temperature();
-        m_gas->getMassFractions(&y[1]);
+        m_gas->getMassFractions(span<double>(y + 1, m_nSpecies));
     }
 
 private:

--- a/samples/cxx/flamespeed/flamespeed.cpp
+++ b/samples/cxx/flamespeed/flamespeed.cpp
@@ -38,16 +38,16 @@ int flamespeed(double phi, bool refine_grid, int loglevel)
 
         gas->setEquivalenceRatio(phi, "CH4", "O2:0.21,N2:0.79");
         gas->setState_TP(temp, pressure);
-        gas->getMoleFractions(x.data());
+        gas->getMoleFractions(x);
 
         double rho_in = gas->density();
 
         vector<double> yin(nsp);
-        gas->getMassFractions(&yin[0]);
+        gas->getMassFractions(yin);
 
         gas->equilibrate("HP");
         vector<double> yout(nsp);
-        gas->getMassFractions(&yout[0]);
+        gas->getMassFractions(yout);
         double rho_out = gas->density();
         double Tad = gas->temperature();
         print("phi = {}, Tad = {}\n", phi, Tad);

--- a/samples/cxx/kinetics1/example_utils.h
+++ b/samples/cxx/kinetics1/example_utils.h
@@ -21,7 +21,7 @@ void saveSoln(int i, double time, const G& gas, A& soln)
     soln(1,i) = gas.temperature();
     soln(2,i) = gas.density();
     soln(3,i) = gas.pressure();
-    gas.getMoleFractions(&soln(4,i));
+    gas.getMoleFractions(std::span<double>(&soln(4,i), gas.nSpecies()));
 }
 
 template<class G, class A>

--- a/samples/f77/demo_ftnlib.cpp
+++ b/samples/f77/demo_ftnlib.cpp
@@ -253,12 +253,12 @@ extern "C" {
 
     void gotmolefractions_(double* x)
     {
-        _gas->getMoleFractions(x);
+        _gas->getMoleFractions(span<double>(x, _gas->nSpecies()));
     }
 
     void gotmassfractions_(double* y)
     {
-        _gas->getMassFractions(y);
+        _gas->getMassFractions(span<double>(y, _gas->nSpecies()));
     }
 
     void equilibrate_(char* opt, ftnlen lenopt)

--- a/samples/f77/demo_ftnlib.cpp
+++ b/samples/f77/demo_ftnlib.cpp
@@ -130,7 +130,7 @@ extern "C" {
     void setstate_tpx_(double* T, double* P, double* X)
     {
         try {
-            _gas->setState_TPX(*T, *P, X);
+            _gas->setState_TPX(*T, *P, span<const double>(X, _gas->nSpecies()));
         } catch (CanteraError& err) {
             handleError(err);
         }
@@ -150,7 +150,7 @@ extern "C" {
     void setstate_tpy_(double* T, double* p, double* Y)
     {
         try {
-            _gas->setState_TPY(*T, *p, Y);
+            _gas->setState_TPY(*T, *p, span<const double>(Y, _gas->nSpecies()));
         } catch (CanteraError& err) {
             handleError(err);
         }

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -863,7 +863,8 @@ void SolutionArray::normalize() {
         size_t offset = nativeState["Y"];
         for (int loc = 0; loc < static_cast<int>(m_size); loc++) {
             setLoc(loc, true); // set location and restore state
-            phase->setMassFractions(m_data->data() + m_loc * m_stride + offset);
+            auto* data = m_data->data() + m_loc * m_stride + offset;
+            phase->setMassFractions(span<const double>(data, phase->nSpecies()));
             m_sol->thermo()->saveState(out);
             setState(loc, out);
         }
@@ -871,7 +872,8 @@ void SolutionArray::normalize() {
         size_t offset = nativeState["X"];
         for (int loc = 0; loc < static_cast<int>(m_size); loc++) {
             setLoc(loc, true); // set location and restore state
-            phase->setMoleFractions(m_data->data() + m_loc * m_stride + offset);
+            auto* data = m_data->data() + m_loc * m_stride + offset;
+            phase->setMoleFractions(span<const double>(data, phase->nSpecies()));
             m_sol->thermo()->saveState(out);
             setState(loc, out);
         }
@@ -1115,9 +1117,9 @@ void SolutionArray::writeEntry(const string& fname, bool overwrite, const string
         }
         setLoc(row);
         if (mole) {
-            m_sol->thermo()->getMoleFractions(buf.data());
+            m_sol->thermo()->getMoleFractions(buf);
         } else {
-            m_sol->thermo()->getMassFractions(buf.data());
+            m_sol->thermo()->getMassFractions(buf);
         }
 
         size_t idx = 0;
@@ -1285,7 +1287,7 @@ void SolutionArray::writeEntry(AnyMap& root, const string& name, const string& s
         if (surf) {
             surf->getCoverages(&values[0]);
         } else {
-            phase->getMassFractions(&values[0]);
+            phase->getMassFractions(values);
         }
         AnyMap items;
         for (size_t k = 0; k < nSpecies; k++) {
@@ -1773,7 +1775,7 @@ void SolutionArray::readEntry(const string& fname, const string& name,
         data = file.readData(path, "X", m_dataSize, nSpecies);
         vector<vector<double>> X = std::move(data.asVector<vector<double>>());
         for (size_t i = 0; i < m_dataSize; i++) {
-            m_sol->thermo()->setMoleFractions_NoNorm(X[i].data());
+            m_sol->thermo()->setMoleFractions_NoNorm(X[i]);
             m_sol->thermo()->setState_TP(T[i], P[i]);
             m_sol->thermo()->saveState(nState, m_data->data() + i * m_stride);
         }
@@ -1786,7 +1788,7 @@ void SolutionArray::readEntry(const string& fname, const string& name,
         data = file.readData(path, "X", m_dataSize, nSpecies);
         vector<vector<double>> X = std::move(data.asVector<vector<double>>());
         for (size_t i = 0; i < m_dataSize; i++) {
-            m_sol->thermo()->setMoleFractions_NoNorm(X[i].data());
+            m_sol->thermo()->setMoleFractions_NoNorm(X[i]);
             m_sol->thermo()->setState_TD(T[i], D[i]);
             m_sol->thermo()->saveState(nState, m_data->data() + i * m_stride);
         }
@@ -1799,7 +1801,7 @@ void SolutionArray::readEntry(const string& fname, const string& name,
         data = file.readData(path, "Y", m_dataSize, nSpecies);
         vector<vector<double>> Y = std::move(data.asVector<vector<double>>());
         for (size_t i = 0; i < m_dataSize; i++) {
-            m_sol->thermo()->setMassFractions_NoNorm(Y[i].data());
+            m_sol->thermo()->setMassFractions_NoNorm(Y[i]);
             m_sol->thermo()->setState_TP(T[i], P[i]);
             m_sol->thermo()->saveState(nState, m_data->data() + i * m_stride);
         }
@@ -1811,7 +1813,7 @@ void SolutionArray::readEntry(const string& fname, const string& name,
         data = file.readData(path, "X", m_dataSize, nSpecies);
         vector<vector<double>> X = std::move(data.asVector<vector<double>>());
         for (size_t i = 0; i < m_dataSize; i++) {
-            m_sol->thermo()->setMoleFractions_NoNorm(X[i].data());
+            m_sol->thermo()->setMoleFractions_NoNorm(X[i]);
             m_sol->thermo()->setTemperature(T[i]);
             m_sol->thermo()->saveState(nState, m_data->data() + i * m_stride);
         }

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -818,7 +818,8 @@ void SolutionArray::setLoc(int loc, bool restore)
     m_loc = static_cast<size_t>(m_active[loc_]);
     if (restore) {
         size_t nState = m_sol->thermo()->stateSize();
-        m_sol->thermo()->restoreState(nState, m_data->data() + m_loc * m_stride);
+        m_sol->thermo()->restoreState(
+            span<const double>(m_data->data() + m_loc * m_stride, nState));
     }
 }
 
@@ -826,7 +827,8 @@ void SolutionArray::updateState(int loc)
 {
     setLoc(loc, false);
     size_t nState = m_sol->thermo()->stateSize();
-    m_sol->thermo()->saveState(nState, m_data->data() + m_loc * m_stride);
+    m_sol->thermo()->saveState(
+        span<double>(m_data->data() + m_loc * m_stride, nState));
 }
 
 vector<double> SolutionArray::getState(int loc)
@@ -848,7 +850,8 @@ void SolutionArray::setState(int loc, const vector<double>& state)
     }
     setLoc(loc, false);
     m_sol->thermo()->restoreState(state);
-    m_sol->thermo()->saveState(nState, m_data->data() + m_loc * m_stride);
+    m_sol->thermo()->saveState(
+        span<double>(m_data->data() + m_loc * m_stride, nState));
 }
 
 void SolutionArray::normalize() {
@@ -1777,7 +1780,8 @@ void SolutionArray::readEntry(const string& fname, const string& name,
         for (size_t i = 0; i < m_dataSize; i++) {
             m_sol->thermo()->setMoleFractions_NoNorm(X[i]);
             m_sol->thermo()->setState_TP(T[i], P[i]);
-            m_sol->thermo()->saveState(nState, m_data->data() + i * m_stride);
+    m_sol->thermo()->saveState(
+        span<double>(m_data->data() + i * m_stride, nState));
         }
     } else if (mode == "TDX") {
         AnyValue data;
@@ -1790,7 +1794,8 @@ void SolutionArray::readEntry(const string& fname, const string& name,
         for (size_t i = 0; i < m_dataSize; i++) {
             m_sol->thermo()->setMoleFractions_NoNorm(X[i]);
             m_sol->thermo()->setState_TD(T[i], D[i]);
-            m_sol->thermo()->saveState(nState, m_data->data() + i * m_stride);
+            m_sol->thermo()->saveState(
+                span<double>(m_data->data() + i * m_stride, nState));
         }
     } else if (mode == "TPY") {
         AnyValue data;
@@ -1803,7 +1808,8 @@ void SolutionArray::readEntry(const string& fname, const string& name,
         for (size_t i = 0; i < m_dataSize; i++) {
             m_sol->thermo()->setMassFractions_NoNorm(Y[i]);
             m_sol->thermo()->setState_TP(T[i], P[i]);
-            m_sol->thermo()->saveState(nState, m_data->data() + i * m_stride);
+            m_sol->thermo()->saveState(
+                span<double>(m_data->data() + i * m_stride, nState));
         }
     } else if (mode == "legacySurf") {
         // erroneous TDX mode (should be TPX or TPY) - Sim1D (Cantera 2.5)
@@ -1815,7 +1821,8 @@ void SolutionArray::readEntry(const string& fname, const string& name,
         for (size_t i = 0; i < m_dataSize; i++) {
             m_sol->thermo()->setMoleFractions_NoNorm(X[i]);
             m_sol->thermo()->setTemperature(T[i]);
-            m_sol->thermo()->saveState(nState, m_data->data() + i * m_stride);
+            m_sol->thermo()->saveState(
+                span<double>(m_data->data() + i * m_stride, nState));
         }
         warn_user("SolutionArray::readEntry",
             "Detected legacy HDF format with incomplete state information\nfor name "
@@ -1941,7 +1948,7 @@ void SolutionArray::readEntry(const AnyMap& root, const string& name, const stri
             throw NotImplementedError("SolutionArray::readEntry",
                 "Import of '{}' data is not supported.", mode);
         }
-        m_sol->thermo()->saveState(nState, m_data->data());
+        m_sol->thermo()->saveState(span<double>(m_data->data(), nState));
         auto props = _stateProperties(mode, true);
         exclude.insert(props.begin(), props.end());
     } else {

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -1780,8 +1780,8 @@ void SolutionArray::readEntry(const string& fname, const string& name,
         for (size_t i = 0; i < m_dataSize; i++) {
             m_sol->thermo()->setMoleFractions_NoNorm(X[i]);
             m_sol->thermo()->setState_TP(T[i], P[i]);
-    m_sol->thermo()->saveState(
-        span<double>(m_data->data() + i * m_stride, nState));
+            m_sol->thermo()->saveState(
+                span<double>(m_data->data() + i * m_stride, nState));
         }
     } else if (mode == "TDX") {
         AnyValue data;
@@ -2010,8 +2010,9 @@ void SolutionArray::readEntry(const AnyMap& root, const string& name, const stri
             const size_t offset_Y = nativeState.find("Y")->second;
             for (size_t i = 0; i < m_dataSize; i++) {
                 double T = (*m_data)[offset_T + i * m_stride];
-                m_sol->thermo()->setState_TPY(
-                    T, P, m_data->data() + offset_Y + i * m_stride);
+                span<double> Y(m_data->data() + offset_Y + i * m_stride,
+                               m_sol->thermo()->nSpecies());
+                m_sol->thermo()->setState_TPY(T, P, Y);
                 (*m_data)[offset_D + i * m_stride] = m_sol->thermo()->density();
             }
         } else if (missingProps.size()) {

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -1288,7 +1288,7 @@ void SolutionArray::writeEntry(AnyMap& root, const string& name, const string& s
         auto nSpecies = phase->nSpecies();
         vector<double> values(nSpecies);
         if (surf) {
-            surf->getCoverages(&values[0]);
+            surf->getCoverages(values);
         } else {
             phase->getMassFractions(values);
         }

--- a/src/equil/ChemEquil.cpp
+++ b/src/equil/ChemEquil.cpp
@@ -137,7 +137,7 @@ void ChemEquil::setToEquilState(ThermoPhase& s,
 void ChemEquil::update(const ThermoPhase& s)
 {
     // get the mole fractions, temperature, and density
-    s.getMoleFractions(m_molefractions.data());
+    s.getMoleFractions(m_molefractions);
     m_temp = s.temperature();
     m_dens = s.density();
 
@@ -205,12 +205,12 @@ int ChemEquil::estimateElementPotentials(ThermoPhase& s, vector<double>& lambda_
     vector<double> mu_RT(m_kk, 0.0);
     vector<double> xMF_est(m_kk, 0.0);
 
-    s.getMoleFractions(xMF_est.data());
+    s.getMoleFractions(xMF_est);
     for (size_t n = 0; n < s.nSpecies(); n++) {
         xMF_est[n] = std::max(xMF_est[n], 1e-20);
     }
-    s.setMoleFractions(xMF_est.data());
-    s.getMoleFractions(xMF_est.data());
+    s.setMoleFractions(xMF_est);
+    s.getMoleFractions(xMF_est);
 
     MultiPhase mp;
     mp.addPhase(&s, 1.0);
@@ -226,8 +226,8 @@ int ChemEquil::estimateElementPotentials(ThermoPhase& s, vector<double>& lambda_
         m_component[m] = k;
         xMF_est[k] = std::max(xMF_est[k], 1e-8);
     }
-    s.setMoleFractions(xMF_est.data());
-    s.getMoleFractions(xMF_est.data());
+    s.setMoleFractions(xMF_est);
+    s.getMoleFractions(xMF_est);
 
     ElemRearrange(m_nComponents, elMolesGoal, &mp,
                   m_orderVectorSpecies, m_orderVectorElements);
@@ -401,7 +401,7 @@ int ChemEquil::equilibrate(ThermoPhase& s, const char* XYstr,
     for (size_t k = 0; k < m_kk; k++) {
         xmm[k] = s.moleFraction(k) + 1.0E-32;
     }
-    s.setMoleFractions(xmm.data());
+    s.setMoleFractions(xmm);
 
     // Update the internally stored values of m_temp, m_dens, and the element
     // mole fractions.
@@ -799,7 +799,7 @@ double ChemEquil::calcEmoles(ThermoPhase& s, vector<double>& x, const double& n_
     // Calculate the activity coefficients of the solution, at the previous
     // solution state.
     vector<double> actCoeff(m_kk, 1.0);
-    s.setMoleFractions(Xmol_i_calc.data());
+    s.setMoleFractions(Xmol_i_calc);
     s.setPressure(pressureConst);
     s.getActivityCoefficients(actCoeff.data());
 
@@ -842,7 +842,7 @@ int ChemEquil::estimateEP_Brinkley(ThermoPhase& s, vector<double>& x,
     vector<double> actCoeff(m_kk, 1.0);
     double beta = 1.0;
 
-    s.getMoleFractions(n_i.data());
+    s.getMoleFractions(n_i);
     double pressureConst = s.pressure();
     vector<double> Xmol_i_calc = n_i;
 
@@ -874,7 +874,7 @@ int ChemEquil::estimateEP_Brinkley(ThermoPhase& s, vector<double>& x,
 
     double n_t = 0.0;
     double nAtomsMax = 1.0;
-    s.setMoleFractions(Xmol_i_calc.data());
+    s.setMoleFractions(Xmol_i_calc);
     s.setPressure(pressureConst);
     s.getActivityCoefficients(actCoeff.data());
     for (size_t k = 0; k < m_kk; k++) {
@@ -1302,7 +1302,7 @@ void ChemEquil::adjustEloc(ThermoPhase& s, vector<double>& elMolesGoal)
     if (fabs(elMolesGoal[m_eloc]) > 1.0E-20) {
         return;
     }
-    s.getMoleFractions(m_molefractions.data());
+    s.getMoleFractions(m_molefractions);
     size_t maxPosEloc = npos;
     size_t maxNegEloc = npos;
     double maxPosVal = -1.0;
@@ -1361,8 +1361,8 @@ void ChemEquil::adjustEloc(ThermoPhase& s, vector<double>& elMolesGoal)
         }
     }
 
-    s.setMoleFractions(m_molefractions.data());
-    s.getMoleFractions(m_molefractions.data());
+    s.setMoleFractions(m_molefractions);
+    s.getMoleFractions(m_molefractions);
 }
 
 } // namespace

--- a/src/equil/ChemEquil.cpp
+++ b/src/equil/ChemEquil.cpp
@@ -304,7 +304,7 @@ int ChemEquil::equilibrate(ThermoPhase& s, const char* XYstr,
     int fail = 0;
     bool tempFixed = true;
     int XY = _equilflag(XYstr);
-    vector<double> state;
+    vector<double> state(s.stateSize());
     s.saveState(state);
     m_loglevel = loglevel;
 
@@ -830,7 +830,7 @@ int ChemEquil::estimateEP_Brinkley(ThermoPhase& s, vector<double>& x,
 {
     // Before we do anything, we will save the state of the solution. Then, if
     // things go drastically wrong, we will restore the saved state.
-    vector<double> state;
+    vector<double> state(s.stateSize());
     s.saveState(state);
     bool modifiedMatrix = false;
     size_t neq = m_mm+1;

--- a/src/equil/ChemEquil.cpp
+++ b/src/equil/ChemEquil.cpp
@@ -130,7 +130,7 @@ void ChemEquil::setToEquilState(ThermoPhase& s,
     // Call the phase-specific method to set the phase to the
     // equilibrium state with the specified species chemical
     // potentials.
-    s.setToEquilState(m_mu_RT.data());
+    s.setToEquilState(m_mu_RT);
     update(s);
 }
 
@@ -232,7 +232,7 @@ int ChemEquil::estimateElementPotentials(ThermoPhase& s, vector<double>& lambda_
     ElemRearrange(m_nComponents, elMolesGoal, &mp,
                   m_orderVectorSpecies, m_orderVectorElements);
 
-    s.getChemPotentials(mu_RT.data());
+    s.getChemPotentials(mu_RT);
     scale(mu_RT.begin(), mu_RT.end(), mu_RT.begin(),
           1.0/(GasConstant* s.temperature()));
 
@@ -801,7 +801,7 @@ double ChemEquil::calcEmoles(ThermoPhase& s, vector<double>& x, const double& n_
     vector<double> actCoeff(m_kk, 1.0);
     s.setMoleFractions(Xmol_i_calc);
     s.setPressure(pressureConst);
-    s.getActivityCoefficients(actCoeff.data());
+    s.getActivityCoefficients(actCoeff);
 
     for (size_t k = 0; k < m_kk; k++) {
         double tmp = - (m_muSS_RT[k] + log(actCoeff[k]));
@@ -852,7 +852,7 @@ int ChemEquil::estimateEP_Brinkley(ThermoPhase& s, vector<double>& x,
 
     // Get the nondimensional Gibbs functions for the species at their standard
     // states of solution at the current T and P of the solution.
-    s.getGibbs_RT(m_muSS_RT.data());
+    s.getGibbs_RT(m_muSS_RT);
 
     vector<double> eMolesCalc(m_mm, 0.0);
     vector<double> eMolesFix(m_mm, 0.0);
@@ -876,7 +876,7 @@ int ChemEquil::estimateEP_Brinkley(ThermoPhase& s, vector<double>& x,
     double nAtomsMax = 1.0;
     s.setMoleFractions(Xmol_i_calc);
     s.setPressure(pressureConst);
-    s.getActivityCoefficients(actCoeff.data());
+    s.getActivityCoefficients(actCoeff);
     for (size_t k = 0; k < m_kk; k++) {
         double tmp = - (m_muSS_RT[k] + log(actCoeff[k]));
         double sum2 = 0.0;

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -169,7 +169,8 @@ ThermoPhase& MultiPhase::phase(size_t n)
         init();
     }
     m_phase[n]->setTemperature(m_temp);
-    m_phase[n]->setMoleFractions_NoNorm(&m_moleFractions[m_spstart[n]]);
+    m_phase[n]->setMoleFractions_NoNorm(
+        span<const double>(&m_moleFractions[m_spstart[n]], m_phase[n]->nSpecies()));
     m_phase[n]->setPressure(m_press);
     return *m_phase[n];
 }
@@ -395,9 +396,9 @@ void MultiPhase::setMoles(const double* n)
         if (nsp > 1) {
             if (phasemoles > 0.0) {
                 p->setState_TPX(m_temp, m_press, n + loc);
-                p->getMoleFractions(&m_moleFractions[loc]);
+                p->getMoleFractions(span<double>(&m_moleFractions[loc], nsp));
             } else {
-                p->getMoleFractions(&m_moleFractions[loc]);
+                p->getMoleFractions(span<double>(&m_moleFractions[loc], nsp));
             }
         } else {
             m_moleFractions[loc] = 1.0;
@@ -836,7 +837,7 @@ void MultiPhase::uploadMoleFractionsFromPhases()
     size_t loc = 0;
     for (size_t ip = 0; ip < nPhases(); ip++) {
         ThermoPhase* p = m_phase[ip];
-        p->getMoleFractions(m_moleFractions.data() + loc);
+        p->getMoleFractions(span<double>(m_moleFractions.data() + loc, p->nSpecies()));
         loc += p->nSpecies();
     }
     calcElemAbundances();

--- a/src/equil/MultiPhaseEquil.cpp
+++ b/src/equil/MultiPhaseEquil.cpp
@@ -676,7 +676,7 @@ void MultiPhaseEquil::reportCSV(const string& reportFile)
         ThermoPhase& tref = m_mix->phase(iphase);
         size_t nSpecies = tref.nSpecies();
         VolPM.resize(nSpecies, 0.0);
-        tref.getMoleFractions(&mf[istart]);
+        tref.getMoleFractions(span<double>(&mf[istart], tref.nSpecies()));
         tref.getPartialMolarVolumes(VolPM.data());
 
         double TMolesPhase = phaseMoles(iphase);
@@ -697,7 +697,7 @@ void MultiPhaseEquil::reportCSV(const string& reportFile)
         size_t istart = m_mix->speciesIndex(0, iphase);
         ThermoPhase& tref = m_mix->phase(iphase);
         ThermoPhase* tp = &tref;
-        tp->getMoleFractions(&mf[istart]);
+        tp->getMoleFractions(span<double>(&mf[istart], tp->nSpecies()));
         string phaseName = tref.name();
         double TMolesPhase = phaseMoles(iphase);
         size_t nSpecies = tref.nSpecies();

--- a/src/equil/MultiPhaseEquil.cpp
+++ b/src/equil/MultiPhaseEquil.cpp
@@ -677,7 +677,7 @@ void MultiPhaseEquil::reportCSV(const string& reportFile)
         size_t nSpecies = tref.nSpecies();
         VolPM.resize(nSpecies, 0.0);
         tref.getMoleFractions(span<double>(&mf[istart], tref.nSpecies()));
-        tref.getPartialMolarVolumes(VolPM.data());
+        tref.getPartialMolarVolumes(VolPM);
 
         double TMolesPhase = phaseMoles(iphase);
         double VolPhaseVolumes = 0.0;
@@ -708,11 +708,11 @@ void MultiPhaseEquil::reportCSV(const string& reportFile)
         VolPM.resize(nSpecies, 0.0);
         molalities.resize(nSpecies, 0.0);
         int actConvention = tp->activityConvention();
-        tp->getActivities(activity.data());
-        tp->getActivityCoefficients(ac.data());
-        tp->getStandardChemPotentials(mu0.data());
-        tp->getPartialMolarVolumes(VolPM.data());
-        tp->getChemPotentials(mu.data());
+        tp->getActivities(activity);
+        tp->getActivityCoefficients(ac);
+        tp->getStandardChemPotentials(mu0);
+        tp->getPartialMolarVolumes(VolPM);
+        tp->getChemPotentials(mu);
         double VolPhaseVolumes = 0.0;
         for (size_t k = 0; k < nSpecies; k++) {
             VolPhaseVolumes += VolPM[k] * mf[istart + k];
@@ -721,8 +721,8 @@ void MultiPhaseEquil::reportCSV(const string& reportFile)
         vol += VolPhaseVolumes;
         if (actConvention == 1) {
             MolalityVPSSTP* mTP = static_cast<MolalityVPSSTP*>(tp);
-            mTP->getMolalities(molalities.data());
-            tp->getChemPotentials(mu.data());
+            mTP->getMolalities(molalities);
+            tp->getChemPotentials(mu);
 
             if (iphase == 0) {
                 fprintf(FP,"        Name,      Phase,  PhaseMoles,  Mole_Fract, "

--- a/src/equil/vcs_MultiPhaseEquil.cpp
+++ b/src/equil/vcs_MultiPhaseEquil.cpp
@@ -430,7 +430,7 @@ int vcs_MultiPhaseEquil::equilibrate_TP(int estimateEquil, int printLvl, double 
 
     if (printLvl > 0) {
         vector<double> mu(m_mix->nSpecies());
-        m_mix->getChemPotentials(mu.data());
+        m_mix->getChemPotentials(mu);
         plogf("\n Results from vcs:\n");
         if (iSuccess != 0) {
             plogf("\nVCS FAILED TO CONVERGE!\n");

--- a/src/equil/vcs_VolPhase.cpp
+++ b/src/equil/vcs_VolPhase.cpp
@@ -89,7 +89,7 @@ vcs_VolPhase::vcs_VolPhase(VCS_SOLVE* owningSolverObject,
     }
 
     setState_TP(Temp_, Pres_);
-    TP_ptr->getMoleFractions(&Xmol_[0]);
+    TP_ptr->getMoleFractions(Xmol_);
     creationMoleNumbers_ = Xmol_;
     _updateMoleFractionDependencies();
 
@@ -165,7 +165,8 @@ void vcs_VolPhase::setMoleFractions(const double* const xmol)
 void vcs_VolPhase::_updateMoleFractionDependencies()
 {
     if (TP_ptr) {
-        TP_ptr->setMoleFractions(&Xmol_[m_MFStartIndex]);
+        TP_ptr->setMoleFractions(span<const double>(
+            &Xmol_[m_MFStartIndex], m_numSpecies));
         TP_ptr->setPressure(Pres_);
     }
     if (!m_isIdealSoln) {

--- a/src/equil/vcs_VolPhase.cpp
+++ b/src/equil/vcs_VolPhase.cpp
@@ -113,13 +113,13 @@ void vcs_VolPhase::_updateActCoeff() const
         m_UpToDate_AC = true;
         return;
     }
-    TP_ptr->getActivityCoefficients(&ActCoeff[0]);
+    TP_ptr->getActivityCoefficients(ActCoeff);
     m_UpToDate_AC = true;
 }
 
 void vcs_VolPhase::_updateG0() const
 {
-    TP_ptr->getGibbs_ref(&SS0ChemicalPotential[0]);
+    TP_ptr->getGibbs_ref(SS0ChemicalPotential);
     m_UpToDate_G0 = true;
 }
 
@@ -133,7 +133,7 @@ double vcs_VolPhase::G0_calc_one(size_t kspec) const
 
 void vcs_VolPhase::_updateGStar() const
 {
-    TP_ptr->getStandardChemPotentials(&StarChemicalPotential[0]);
+    TP_ptr->getStandardChemPotentials(StarChemicalPotential);
     m_UpToDate_GStar = true;
 }
 
@@ -389,13 +389,13 @@ void vcs_VolPhase::setState_TP(const double temp, const double pres)
 
 void vcs_VolPhase::_updateVolStar() const
 {
-    TP_ptr->getStandardVolumes(&StarMolarVol[0]);
+    TP_ptr->getStandardVolumes(StarMolarVol);
     m_UpToDate_VolStar = true;
 }
 
 double vcs_VolPhase::_updateVolPM() const
 {
-    TP_ptr->getPartialMolarVolumes(&PartialMolarVol[0]);
+    TP_ptr->getPartialMolarVolumes(PartialMolarVol);
     m_totalVol = 0.0;
     for (size_t k = 0; k < m_numSpecies; k++) {
         m_totalVol += PartialMolarVol[k] * Xmol_[k];
@@ -419,7 +419,8 @@ void vcs_VolPhase::_updateLnActCoeffJac()
     if (!TP_ptr) {
         return;
     }
-    TP_ptr->getdlnActCoeffdlnN(m_numSpecies, &np_dLnActCoeffdMolNumber(0,0));
+    TP_ptr->getdlnActCoeffdlnN(m_numSpecies,
+        span<double>(&np_dLnActCoeffdMolNumber(0, 0), m_numSpecies * m_numSpecies));
     for (size_t j = 0; j < m_numSpecies; j++) {
         double moles_j_base = phaseTotalMoles * Xmol_[j];
         double* const np_lnActCoeffCol = np_dLnActCoeffdMolNumber.ptrColumn(j);

--- a/src/fortran/fct.cpp
+++ b/src/fortran/fct.cpp
@@ -306,7 +306,7 @@ extern "C" {
     {
         try {
             ThermoPhase* p = _fph(n);
-            const vector<double>& wt = p->atomicWeights();
+            auto wt = p->atomicWeights();
             copy(wt.begin(), wt.end(), atw);
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -318,7 +318,7 @@ extern "C" {
     {
         try {
             ThermoPhase* p = _fph(n);
-            const vector<double>& wt = p->molecularWeights();
+            auto wt = p->molecularWeights();
             copy(wt.begin(), wt.end(), mw);
         } catch (...) {
             return handleAllExceptions(-1, ERR);

--- a/src/fortran/fct.cpp
+++ b/src/fortran/fct.cpp
@@ -212,7 +212,8 @@ extern "C" {
     status_t phase_getmolefractions_(const integer* n, double* x)
     {
         try {
-            _fph(n)->getMoleFractions(x);
+            auto* phase = _fph(n);
+            phase->getMoleFractions(span<double>(x, phase->nSpecies()));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -233,7 +234,7 @@ extern "C" {
     {
         try {
             ThermoPhase* p = _fph(n);
-            p->getMassFractions(y);
+            p->getMassFractions(span<double>(y, p->nSpecies()));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -254,9 +255,9 @@ extern "C" {
         try {
             ThermoPhase* p = _fph(n);
             if (*norm) {
-                p->setMoleFractions(x);
+                p->setMoleFractions(span<const double>(x, p->nSpecies()));
             } else {
-                p->setMoleFractions_NoNorm(x);
+                p->setMoleFractions_NoNorm(span<const double>(x, p->nSpecies()));
             }
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -280,9 +281,9 @@ extern "C" {
         try {
             ThermoPhase* p = _fph(n);
             if (*norm) {
-                p->setMassFractions(y);
+                p->setMassFractions(span<const double>(y, p->nSpecies()));
             } else {
-                p->setMassFractions_NoNorm(y);
+                p->setMassFractions_NoNorm(span<const double>(y, p->nSpecies()));
             }
         } catch (...) {
             return handleAllExceptions(-1, ERR);

--- a/src/fortran/fct.cpp
+++ b/src/fortran/fct.cpp
@@ -508,7 +508,7 @@ extern "C" {
     {
         try {
             ThermoPhase* thrm = _fth(n);
-            thrm->getChemPotentials(murt);
+            thrm->getChemPotentials(span<double>(murt, thrm->nSpecies()));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -606,7 +606,7 @@ extern "C" {
     {
         try {
             ThermoPhase* thrm = _fth(n);
-            thrm->getEnthalpy_RT(h_rt);
+            thrm->getEnthalpy_RT(span<double>(h_rt, thrm->nSpecies()));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -616,7 +616,7 @@ extern "C" {
     status_t th_getgibbs_rt_(const integer* n, double* g_rt) {
       try {
         ThermoPhase* thrm = _fth(n);
-        thrm->getGibbs_RT(g_rt);
+        thrm->getGibbs_RT(span<double>(g_rt, thrm->nSpecies()));
       } catch(...) {
         return handleAllExceptions(-1, ERR);
       }
@@ -627,7 +627,7 @@ extern "C" {
     {
         try {
             ThermoPhase* thrm = _fth(n);
-            thrm->getEntropy_R(s_r);
+            thrm->getEntropy_R(span<double>(s_r, thrm->nSpecies()));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -638,7 +638,7 @@ extern "C" {
     {
         try {
             ThermoPhase* thrm = _fth(n);
-            thrm->getCp_R(cp_r);
+            thrm->getCp_R(span<double>(cp_r, thrm->nSpecies()));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -649,7 +649,7 @@ extern "C" {
     {
         try {
             ThermoPhase* thrm = _fth(n);
-            thrm->getPartialMolarIntEnergies(ie);
+            thrm->getPartialMolarIntEnergies(span<double>(ie, thrm->nSpecies()));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -659,7 +659,7 @@ extern "C" {
     status_t th_getpartialmolarenthalpies_(const integer* n, double* hbar) {
       try {
         ThermoPhase* thrm = _fth(n);
-        thrm->getPartialMolarEnthalpies(hbar);
+        thrm->getPartialMolarEnthalpies(span<double>(hbar, thrm->nSpecies()));
       } catch(...) {
         return handleAllExceptions(-1, ERR);
       }
@@ -669,7 +669,7 @@ extern "C" {
     status_t th_getpartialmolarcp_(const integer* n, double* cpbar) {
       try {
         ThermoPhase* thrm = _fth(n);
-        thrm->getPartialMolarCp(cpbar);
+        thrm->getPartialMolarCp(span<double>(cpbar, thrm->nSpecies()));
       } catch(...) {
         return handleAllExceptions(-1, ERR);
       }

--- a/src/kinetics/BlowersMaselRate.cpp
+++ b/src/kinetics/BlowersMaselRate.cpp
@@ -36,6 +36,11 @@ bool BlowersMaselData::update(const ThermoPhase& phase, const Kinetics& kin)
     return changed;
 }
 
+void BlowersMaselData::resize(Kinetics& kin) {
+    partialMolarEnthalpies.resize(kin.nTotalSpecies(), 0.);
+    ready = true;
+}
+
 BlowersMaselRate::BlowersMaselRate()
 {
     m_Ea_str = "Ea0";

--- a/src/kinetics/BlowersMaselRate.cpp
+++ b/src/kinetics/BlowersMaselRate.cpp
@@ -30,7 +30,7 @@ bool BlowersMaselData::update(const ThermoPhase& phase, const Kinetics& kin)
     if (changed || rho != density || mf != m_state_mf_number) {
         density = rho;
         m_state_mf_number = mf;
-        phase.getPartialMolarEnthalpies(partialMolarEnthalpies.data());
+        phase.getPartialMolarEnthalpies(partialMolarEnthalpies);
         changed = true;
     }
     return changed;

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -196,7 +196,7 @@ void BulkKinetics::getRevRateConstants(double* krev, bool doIrreversible)
 void BulkKinetics::getDeltaGibbs(double* deltaG)
 {
     // Get the chemical potentials for each species
-    thermo().getChemPotentials(m_sbuf0.data());
+    thermo().getChemPotentials(m_sbuf0);
     // Use the stoichiometric manager to find deltaG for each reaction.
     getReactionDelta(m_sbuf0.data(), deltaG);
 }
@@ -204,7 +204,7 @@ void BulkKinetics::getDeltaGibbs(double* deltaG)
 void BulkKinetics::getDeltaEnthalpy(double* deltaH)
 {
     // Get the partial molar enthalpy for each species
-    thermo().getPartialMolarEnthalpies(m_sbuf0.data());
+    thermo().getPartialMolarEnthalpies(m_sbuf0);
     // Use the stoichiometric manager to find deltaH for each reaction.
     getReactionDelta(m_sbuf0.data(), deltaH);
 }
@@ -212,7 +212,7 @@ void BulkKinetics::getDeltaEnthalpy(double* deltaH)
 void BulkKinetics::getDeltaEntropy(double* deltaS)
 {
     // Get the partial molar entropy for each species
-    thermo().getPartialMolarEntropies(m_sbuf0.data());
+    thermo().getPartialMolarEntropies(m_sbuf0);
     // Use the stoichiometric manager to find deltaS for each reaction.
     getReactionDelta(m_sbuf0.data(), deltaS);
 }
@@ -223,7 +223,7 @@ void BulkKinetics::getDeltaSSGibbs(double* deltaG)
     // array of chemical potentials at unit activity. We define these here as
     // the chemical potentials of the pure species at the temperature and
     // pressure of the solution.
-    thermo().getStandardChemPotentials(m_sbuf0.data());
+    thermo().getStandardChemPotentials(m_sbuf0);
     // Use the stoichiometric manager to find deltaG for each reaction.
     getReactionDelta(m_sbuf0.data(), deltaG);
 }
@@ -231,7 +231,7 @@ void BulkKinetics::getDeltaSSGibbs(double* deltaG)
 void BulkKinetics::getDeltaSSEnthalpy(double* deltaH)
 {
     // Get the standard state enthalpies of the species.
-    thermo().getEnthalpy_RT(m_sbuf0.data());
+    thermo().getEnthalpy_RT(m_sbuf0);
     for (size_t k = 0; k < m_kk; k++) {
         m_sbuf0[k] *= thermo().RT();
     }
@@ -244,7 +244,7 @@ void BulkKinetics::getDeltaSSEntropy(double* deltaS)
     // Get the standard state entropy of the species. We define these here as
     // the entropies of the pure species at the temperature and pressure of the
     // solution.
-    thermo().getEntropy_R(m_sbuf0.data());
+    thermo().getEntropy_R(m_sbuf0);
     for (size_t k = 0; k < m_kk; k++) {
         m_sbuf0[k] *= GasConstant;
     }
@@ -456,7 +456,7 @@ void BulkKinetics::updateROP()
 
     if (last.state1 != T || last.state2 != rho) {
         // Update properties that are independent of the composition
-        thermo().getStandardChemPotentials(m_grt.data());
+        thermo().getStandardChemPotentials(m_grt);
         fill(m_delta_gibbs0.begin(), m_delta_gibbs0.end(), 0.0);
         double logStandConc = log(thermo().standardConcentration());
 
@@ -477,7 +477,7 @@ void BulkKinetics::updateROP()
 
     if (!last.validate(T, rho, statenum)) {
         // Update terms dependent on species concentrations and temperature
-        thermo().getActivityConcentrations(m_act_conc.data());
+        thermo().getActivityConcentrations(m_act_conc);
         thermo().getConcentrations(m_phys_conc);
         double ctot = thermo().molarDensity();
 
@@ -572,7 +572,7 @@ void BulkKinetics::applyEquilibriumConstants_ddT(double* drkcn)
     // compute perturbed Delta G^0 for all reversible reactions
     thermo().saveState(m_state);
     thermo().setState_TP(T * (1. + m_jac_rtol_delta), P);
-    thermo().getStandardChemPotentials(grt.data());
+    thermo().getStandardChemPotentials(grt);
     getRevReactionDelta(grt.data(), delta_gibbs0.data());
 
     // apply scaling for derivative of inverse equilibrium constant

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -478,7 +478,7 @@ void BulkKinetics::updateROP()
     if (!last.validate(T, rho, statenum)) {
         // Update terms dependent on species concentrations and temperature
         thermo().getActivityConcentrations(m_act_conc.data());
-        thermo().getConcentrations(m_phys_conc.data());
+        thermo().getConcentrations(m_phys_conc);
         double ctot = thermo().molarDensity();
 
         // Third-body objects interacting with MultiRate evaluator

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -43,7 +43,7 @@ bool BulkKinetics::addReaction(shared_ptr<Reaction> r, bool resize)
     if (m_rateTypes.find(rtype) == m_rateTypes.end()) {
         m_rateTypes[rtype] = m_rateHandlers.size();
         m_rateHandlers.push_back(rate->newMultiRate());
-        m_rateHandlers.back()->resize(m_kk, nReactions(), nPhases());
+        m_rateHandlers.back()->resize(*this);
     }
 
     // Set index of rate to number of reaction within kinetics
@@ -114,7 +114,7 @@ void BulkKinetics::resizeSpecies()
     m_phys_conc.resize(m_kk);
     m_grt.resize(m_kk);
     for (auto& rates : m_rateHandlers) {
-        rates->resize(m_kk, nReactions(), nPhases());
+        rates->resize(*this);
     }
 }
 
@@ -129,7 +129,7 @@ void BulkKinetics::resizeReactions()
     m_state.resize(thermo().stateSize());
     m_multi_concm.resizeCoeffs(nTotalSpecies(), nReactions());
     for (auto& rates : m_rateHandlers) {
-        rates->resize(nTotalSpecies(), nReactions(), nPhases());
+        rates->resize(*this);
         // @todo ensure that ReactionData are updated; calling rates->update
         //      blocks correct behavior in update_rates_T
         //      and running updateROP() is premature

--- a/src/kinetics/ElectronCollisionPlasmaRate.cpp
+++ b/src/kinetics/ElectronCollisionPlasmaRate.cpp
@@ -34,13 +34,13 @@ bool ElectronCollisionPlasmaData::update(const ThermoPhase& phase, const Kinetic
     // Update distribution
     m_dist_number = pp.distributionNumber();
     distribution.resize(pp.nElectronEnergyLevels());
-    pp.getElectronEnergyDistribution(distribution.data());
+    pp.getElectronEnergyDistribution(distribution);
 
     // Update energy levels
     if (pp.levelNumber() != levelNumber || energyLevels.empty()) {
         levelNumber = pp.levelNumber();
         energyLevels.resize(pp.nElectronEnergyLevels());
-        pp.getElectronEnergyLevels(energyLevels.data());
+        pp.getElectronEnergyLevels(energyLevels);
     }
     return true;
 }

--- a/src/kinetics/Falloff.cpp
+++ b/src/kinetics/Falloff.cpp
@@ -78,6 +78,12 @@ void FalloffData::restore()
     m_perturbed = false;
 }
 
+void FalloffData::resize(Kinetics& kin) {
+    conc_3b.resize(kin.nReactions(), NAN);
+    m_conc_3b_buf.resize(kin.nReactions(), NAN);
+    ready = true;
+}
+
 FalloffRate::FalloffRate(const AnyMap& node, const UnitStack& rate_units)
     : FalloffRate()
 {

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -57,7 +57,8 @@ void InterfaceKinetics::_update_rates_T()
     if (T != m_temp || m_redo_rates) {
         //  Calculate the forward rate constant by calling m_rates and store it in m_rfn[]
         for (size_t n = 0; n < nPhases(); n++) {
-            thermo(n).getPartialMolarEnthalpies(m_grt.data() + m_start[n]);
+            thermo(n).getPartialMolarEnthalpies(
+                span<double>(m_grt).subspan(m_start[n], thermo(n).nSpecies()));
         }
 
         // Use the stoichiometric manager to find deltaH for each reaction.
@@ -105,10 +106,11 @@ void InterfaceKinetics::_update_rates_C()
          * the vector m_conc. m_start[] are integer indices for that vector
          * denoting the start of the species for each phase.
          */
-        tp.getActivityConcentrations(m_actConc.data() + m_start[n]);
+        tp.getActivityConcentrations(
+            span<double>(m_actConc).subspan(m_start[n], tp.nSpecies()));
 
         // Get regular concentrations too
-        tp.getConcentrations(span<double>(m_conc.data() + m_start[n], tp.nSpecies()));
+        tp.getConcentrations(span<double>(m_conc).subspan(m_start[n], tp.nSpecies()));
     }
     m_ROP_ok = false;
 }
@@ -153,7 +155,8 @@ void InterfaceKinetics::updateMu0()
     //      once the old framework is removed
     size_t ik = 0;
     for (size_t n = 0; n < nPhases(); n++) {
-        thermo(n).getStandardChemPotentials(m_mu0.data() + m_start[n]);
+        thermo(n).getStandardChemPotentials(
+            span<double>(m_mu0).subspan(m_start[n], thermo(n).nSpecies()));
         for (size_t k = 0; k < thermo(n).nSpecies(); k++) {
             m_mu0_Kc[ik] = m_mu0[ik] + Faraday * m_phi[n] * thermo(n).charge(k);
             m_mu0_Kc[ik] -= thermo(0).RT() * thermo(n).logStandardConc(k);
@@ -288,7 +291,8 @@ void InterfaceKinetics::getDeltaGibbs(double* deltaG)
     // Get the chemical potentials of the species in the all of the phases used
     // in the kinetics mechanism
     for (size_t n = 0; n < nPhases(); n++) {
-        m_thermo[n]->getChemPotentials(m_mu.data() + m_start[n]);
+        m_thermo[n]->getChemPotentials(
+            span<double>(m_mu).subspan(m_start[n], thermo(n).nSpecies()));
     }
 
     // Use the stoichiometric manager to find deltaG for each reaction.
@@ -304,7 +308,8 @@ void InterfaceKinetics::getDeltaElectrochemPotentials(double* deltaM)
 {
     // Get the chemical potentials of the species
     for (size_t n = 0; n < nPhases(); n++) {
-        thermo(n).getElectrochemPotentials(m_grt.data() + m_start[n]);
+        thermo(n).getElectrochemPotentials(
+            span<double>(m_grt).subspan(m_start[n], thermo(n).nSpecies()));
     }
 
     // Use the stoichiometric manager to find deltaG for each reaction.
@@ -315,7 +320,8 @@ void InterfaceKinetics::getDeltaEnthalpy(double* deltaH)
 {
     // Get the partial molar enthalpy of all species
     for (size_t n = 0; n < nPhases(); n++) {
-        thermo(n).getPartialMolarEnthalpies(m_grt.data() + m_start[n]);
+        thermo(n).getPartialMolarEnthalpies(
+            span<double>(m_grt).subspan(m_start[n], thermo(n).nSpecies()));
     }
 
     // Use the stoichiometric manager to find deltaH for each reaction.
@@ -326,7 +332,8 @@ void InterfaceKinetics::getDeltaEntropy(double* deltaS)
 {
     // Get the partial molar entropy of all species in all of the phases
     for (size_t n = 0; n < nPhases(); n++) {
-        thermo(n).getPartialMolarEntropies(m_grt.data() + m_start[n]);
+        thermo(n).getPartialMolarEntropies(
+            span<double>(m_grt).subspan(m_start[n], thermo(n).nSpecies()));
     }
 
     // Use the stoichiometric manager to find deltaS for each reaction.
@@ -340,7 +347,8 @@ void InterfaceKinetics::getDeltaSSGibbs(double* deltaGSS)
     // chemical potentials of the pure species at the temperature and pressure
     // of the solution.
     for (size_t n = 0; n < nPhases(); n++) {
-        thermo(n).getStandardChemPotentials(m_mu0.data() + m_start[n]);
+        thermo(n).getStandardChemPotentials(
+            span<double>(m_mu0).subspan(m_start[n], thermo(n).nSpecies()));
     }
 
     // Use the stoichiometric manager to find deltaG for each reaction.
@@ -354,7 +362,8 @@ void InterfaceKinetics::getDeltaSSEnthalpy(double* deltaH)
     // enthalpies of the pure species at the temperature and pressure of the
     // solution.
     for (size_t n = 0; n < nPhases(); n++) {
-        thermo(n).getEnthalpy_RT(m_grt.data() + m_start[n]);
+        thermo(n).getEnthalpy_RT(
+            span<double>(m_grt).subspan(m_start[n], thermo(n).nSpecies()));
     }
     for (size_t k = 0; k < m_kk; k++) {
         m_grt[k] *= thermo(0).RT();
@@ -370,7 +379,8 @@ void InterfaceKinetics::getDeltaSSEntropy(double* deltaS)
     // the entropies of the pure species at the temperature and pressure of the
     // solution.
     for (size_t n = 0; n < nPhases(); n++) {
-        thermo(n).getEntropy_R(m_grt.data() + m_start[n]);
+        thermo(n).getEntropy_R(
+            span<double>(m_grt).subspan(m_start[n], thermo(n).nSpecies()));
     }
     for (size_t k = 0; k < m_kk; k++) {
         m_grt[k] *= GasConstant;

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -33,7 +33,7 @@ void InterfaceKinetics::resizeReactions()
     m_rbuf1.resize(nReactions());
 
     for (auto& rates : m_rateHandlers) {
-        rates->resize(nTotalSpecies(), nReactions(), nPhases());
+        rates->resize(*this);
         // @todo ensure that ReactionData are updated; calling rates->update
         //      blocks correct behavior in InterfaceKinetics::_update_rates_T
         //      and running updateROP() is premature
@@ -433,7 +433,7 @@ bool InterfaceKinetics::addReaction(shared_ptr<Reaction> r_base, bool resize)
     if (m_rateTypes.find(rtype) == m_rateTypes.end()) {
         m_rateTypes[rtype] = m_rateHandlers.size();
         m_rateHandlers.push_back(rate->newMultiRate());
-        m_rateHandlers.back()->resize(m_kk, nReactions(), nPhases());
+        m_rateHandlers.back()->resize(*this);
     }
 
     // Add reaction rate to evaluator

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -531,7 +531,7 @@ void InterfaceKinetics::advanceCoverages(double tstep, double rtol, double atol,
     vector<vector<double>> savedStates(nPhases());
     for (size_t i = 1; i < nPhases(); i++) {
         savedStates[i].resize(thermo(i).partialStateSize());
-        thermo(i).savePartialState(savedStates[i].size(), savedStates[i].data());
+        thermo(i).savePartialState(savedStates[i]);
         thermo(i).setState_TP(thermo(0).temperature(), thermo(0).pressure());
     }
 
@@ -548,7 +548,7 @@ void InterfaceKinetics::advanceCoverages(double tstep, double rtol, double atol,
 
     // Restore adjacent phases to their original states
     for (size_t i = 1; i < nPhases(); i++) {
-        thermo(i).restorePartialState(savedStates[i].size(), savedStates[i].data());
+        thermo(i).restorePartialState(savedStates[i]);
     }
 }
 
@@ -558,7 +558,7 @@ void InterfaceKinetics::solvePseudoSteadyStateProblem(int loglevel)
     vector<vector<double>> savedStates(nPhases());
     for (size_t i = 1; i < nPhases(); i++) {
         savedStates[i].resize(thermo(i).partialStateSize());
-        thermo(i).savePartialState(savedStates[i].size(), savedStates[i].data());
+        thermo(i).savePartialState(savedStates[i]);
         thermo(i).setState_TP(thermo(0).temperature(), thermo(0).pressure());
     }
 
@@ -571,7 +571,7 @@ void InterfaceKinetics::solvePseudoSteadyStateProblem(int loglevel)
 
     // Restore adjacent phases to their original states
     for (size_t i = 1; i < nPhases(); i++) {
-        thermo(i).restorePartialState(savedStates[i].size(), savedStates[i].data());
+        thermo(i).restorePartialState(savedStates[i]);
     }
 }
 

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -108,7 +108,7 @@ void InterfaceKinetics::_update_rates_C()
         tp.getActivityConcentrations(m_actConc.data() + m_start[n]);
 
         // Get regular concentrations too
-        tp.getConcentrations(m_conc.data() + m_start[n]);
+        tp.getConcentrations(span<double>(m_conc.data() + m_start[n], tp.nSpecies()));
     }
     m_ROP_ok = false;
 }
@@ -622,7 +622,7 @@ double InterfaceKinetics::interfaceCurrent(const size_t iphase)
     vector<double> netProdRates(m_kk, 0.0);
     double dotProduct = 0.0;
 
-    thermo(iphase).getCharges(charges.data());
+    thermo(iphase).getCharges(charges);
     getNetProductionRates(netProdRates.data());
 
     for (size_t k = 0; k < thermo(iphase).nSpecies(); k++)

--- a/src/kinetics/InterfaceRate.cpp
+++ b/src/kinetics/InterfaceRate.cpp
@@ -91,6 +91,16 @@ void InterfaceData::perturbTemperature(double deltaT)
     throw NotImplementedError("InterfaceData::perturbTemperature");
 }
 
+void InterfaceData::resize(Kinetics& kin) {
+    coverages.resize(kin.thermo().nSpecies(), 0.);
+    logCoverages.resize(kin.thermo().nSpecies(), 0.);
+    partialMolarEnthalpies.resize(kin.nTotalSpecies(), 0.);
+    electricPotentials.resize(kin.nPhases(), 0.);
+    standardChemPotentials.resize(kin.nTotalSpecies(), 0.);
+    standardConcentrations.resize(kin.nTotalSpecies(), 0.);
+    ready = true;
+}
+
 InterfaceRateBase::InterfaceRateBase()
     : m_siteDensity(NAN)
     , m_acov(0.)

--- a/src/kinetics/InterfaceRate.cpp
+++ b/src/kinetics/InterfaceRate.cpp
@@ -62,7 +62,7 @@ bool InterfaceData::update(const ThermoPhase& phase, const Kinetics& kin)
         changed = true;
     }
     if (changed || mf != m_state_mf_number) {
-        surf.getCoverages(coverages.data());
+        surf.getCoverages(coverages);
         for (size_t n = 0; n < coverages.size(); n++) {
             logCoverages[n] = std::log(std::max(coverages[n], Tiny));
         }

--- a/src/kinetics/InterfaceRate.cpp
+++ b/src/kinetics/InterfaceRate.cpp
@@ -70,8 +70,10 @@ bool InterfaceData::update(const ThermoPhase& phase, const Kinetics& kin)
             size_t start = kin.kineticsSpeciesIndex(0, n);
             const auto& ph = kin.thermo(n);
             electricPotentials[n] = ph.electricPotential();
-            ph.getPartialMolarEnthalpies(partialMolarEnthalpies.data() + start);
-            ph.getStandardChemPotentials(standardChemPotentials.data() + start);
+            ph.getPartialMolarEnthalpies(
+                span<double>(partialMolarEnthalpies).subspan(start, ph.nSpecies()));
+            ph.getStandardChemPotentials(
+                span<double>(standardChemPotentials).subspan(start, ph.nSpecies()));
             size_t nsp = ph.nSpecies();
             for (size_t k = 0; k < nsp; k++) {
                 // only used for exchange current density formulation

--- a/src/kinetics/LinearBurkeRate.cpp
+++ b/src/kinetics/LinearBurkeRate.cpp
@@ -29,7 +29,7 @@ bool LinearBurkeData::update(const ThermoPhase& phase, const Kinetics& kin)
         pressure = P;
         logP = std::log(P);
         mf_number = X;
-        phase.getMoleFractions(moleFractions.data());
+        phase.getMoleFractions(moleFractions);
         return true;
     }
     return false;

--- a/src/kinetics/LinearBurkeRate.cpp
+++ b/src/kinetics/LinearBurkeRate.cpp
@@ -55,6 +55,13 @@ void LinearBurkeData::restore()
     m_pressure_buf = -1.;
 }
 
+void LinearBurkeData::resize(Kinetics& kin)
+{
+    moleFractions.resize(kin.nTotalSpecies(), NAN);
+    ready = true;
+}
+
+
 LinearBurkeRate::LinearBurkeRate(const AnyMap& node, const UnitStack& rate_units)
 {
     setParameters(node, rate_units);

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -157,7 +157,7 @@ void Inlet1D::updateState(size_t loc)
     if (m_flow) {
         m_press = m_flow->pressure();
     }
-    m_solution->thermo()->setState_TPY(m_temp, m_press, m_yin.data());
+    m_solution->thermo()->setState_TPY(m_temp, m_press, m_yin);
 }
 
 void Inlet1D::init()
@@ -294,7 +294,7 @@ shared_ptr<SolutionArray> Inlet1D::toArray(bool normalize)
     // set gas state (using pressure from adjacent domain)
     double pressure = m_flow->phase().pressure();
     auto thermo = m_solution->thermo();
-    thermo->setState_TPY(m_temp, pressure, m_yin.data());
+    thermo->setState_TPY(m_temp, pressure, m_yin);
     vector<double> data(thermo->stateSize());
     thermo->saveState(data);
 
@@ -545,7 +545,7 @@ shared_ptr<SolutionArray> OutletRes1D::toArray(bool normalize)
     // set gas state (using pressure from adjacent domain)
     double pressure = m_flow->phase().pressure();
     auto thermo = m_solution->thermo();
-    thermo->setState_TPY(m_temp, pressure, &m_yres[0]);
+    thermo->setState_TPY(m_temp, pressure, m_yres);
     vector<double> data(thermo->stateSize());
     thermo->saveState(data);
 

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -563,7 +563,7 @@ void OutletRes1D::fromArray(const shared_ptr<SolutionArray>& arr)
     auto thermo = arr->thermo();
     m_temp = thermo->temperature();
     auto Y = thermo->massFractions();
-    std::copy(Y, Y + m_nsp, &m_yres[0]);
+    m_yres.assign(Y.begin(), Y.end());
 }
 
 // -------- Surf1D --------
@@ -743,7 +743,7 @@ void ReactingSurf1D::eval(size_t jg, double* xg, double* rg,
     }
     if (m_flow_left) {
         size_t nc = m_flow_left->nComponents();
-        const vector<double>& mwleft = m_phase_left->molecularWeights();
+        auto mwleft = m_phase_left->molecularWeights();
         double* rb = r - nc;
         double* xb = x - nc;
         rb[c_offset_T] = xb[c_offset_T] - m_temp; // specified T

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -792,7 +792,7 @@ shared_ptr<SolutionArray> ReactingSurf1D::toArray(bool normalize)
     m_sphase->setState_TP(m_temp, m_sphase->pressure());
     m_sphase->setCoverages(soln);
     vector<double> data(m_sphase->stateSize());
-    m_sphase->saveState(data.size(), &data[0]);
+    m_sphase->saveState(data);
 
     auto arr = SolutionArray::create(m_solution, 1, meta);
     arr->setState(0, data);

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -677,8 +677,8 @@ void ReactingSurf1D::init()
 
 void ReactingSurf1D::resetBadValues(double* xg) {
     double* x = xg + loc();
-    m_sphase->setCoverages(x);
-    m_sphase->getCoverages(x);
+    m_sphase->setCoverages(span<const double>(x, m_nsp));
+    m_sphase->getCoverages(span<double>(x, m_nsp));
 }
 
 void ReactingSurf1D::eval(size_t jg, double* xg, double* rg,
@@ -700,7 +700,7 @@ void ReactingSurf1D::eval(size_t jg, double* xg, double* rg,
         sum += x[k];
     }
     m_sphase->setTemperature(m_temp);
-    m_sphase->setCoveragesNoNorm(m_work.data());
+    m_sphase->setCoveragesNoNorm(m_work);
 
     // set the left gas state to the adjacent point
 
@@ -790,7 +790,7 @@ shared_ptr<SolutionArray> ReactingSurf1D::toArray(bool normalize)
 
     // set state of surface phase
     m_sphase->setState_TP(m_temp, m_sphase->pressure());
-    m_sphase->setCoverages(soln);
+    m_sphase->setCoverages(span<const double>(soln, m_nsp));
     vector<double> data(m_sphase->stateSize());
     m_sphase->saveState(data);
 
@@ -820,7 +820,7 @@ void ReactingSurf1D::fromArray(const shared_ptr<SolutionArray>& arr)
             "Restoring of coverages requires surface phase");
     }
     m_temp = surf->temperature();
-    surf->getCoverages(soln);
+    surf->getCoverages(span<double>(soln, m_nsp));
     _finalize(soln);
 }
 

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -95,7 +95,7 @@ Inlet1D::Inlet1D(shared_ptr<Solution> phase, const string& id)
     m_press = thermo->pressure();
     m_nsp = thermo->nSpecies();
     m_yin.resize(m_nsp);
-    thermo->getMassFractions(m_yin.data());
+    thermo->getMassFractions(m_yin);
 }
 
 //! set spreading rate
@@ -135,7 +135,7 @@ void Inlet1D::setMoleFractions(const string& xin)
     if (m_solution) {
         auto thermo = m_solution->thermo();
         thermo->setMoleFractionsByName(xin);
-        thermo->getMassFractions(m_yin.data());
+        thermo->getMassFractions(m_yin);
         needJacUpdate();
     } else {
         m_xstr = xin;
@@ -146,8 +146,8 @@ void Inlet1D::setMoleFractions(const double* xin)
 {
     if (m_solution) {
         auto thermo = m_solution->thermo();
-        thermo->setMoleFractions(xin);
-        thermo->getMassFractions(m_yin.data());
+        thermo->setMoleFractions(span<const double>(xin, m_nsp));
+        thermo->getMassFractions(m_yin);
         needJacUpdate();
     }
 }
@@ -319,7 +319,7 @@ void Inlet1D::fromArray(const shared_ptr<SolutionArray>& arr)
         auto aux = arr->getAuxiliary(0);
         m_mdot = thermo->density() * aux.at("velocity").as<double>();
     }
-    thermo->getMassFractions(m_yin.data());
+    thermo->getMassFractions(m_yin);
 }
 
 // ------------- Empty1D -------------
@@ -467,7 +467,7 @@ void OutletRes1D::setMoleFractions(const string& xres)
     m_xstr = xres;
     if (m_flow) {
         m_flow->phase().setMoleFractionsByName(xres);
-        m_flow->phase().getMassFractions(m_yres.data());
+        m_flow->phase().getMassFractions(m_yres);
         needJacUpdate();
     }
 }
@@ -475,8 +475,8 @@ void OutletRes1D::setMoleFractions(const string& xres)
 void OutletRes1D::setMoleFractions(const double* xres)
 {
     if (m_flow) {
-        m_flow->phase().setMoleFractions(xres);
-        m_flow->phase().getMassFractions(m_yres.data());
+        m_flow->phase().setMoleFractions(span<const double>(xres, m_nsp));
+        m_flow->phase().getMassFractions(m_yres);
         needJacUpdate();
     }
 }

--- a/src/oneD/Flow1D.cpp
+++ b/src/oneD/Flow1D.cpp
@@ -35,7 +35,8 @@ Flow1D::Flow1D(shared_ptr<Solution> phase, const string& id, size_t points)
     , m_thermo(phase->thermo().get())
 {
     // make a local copy of the species molecular weight vector
-    m_wt = m_thermo->molecularWeights();
+    m_wt.assign(m_thermo->molecularWeights().begin(),
+                m_thermo->molecularWeights().end());
 
     // set pressure based on associated thermo object
     setPressure(m_thermo->pressure());

--- a/src/thermo/BinarySolutionTabulatedThermo.cpp
+++ b/src/thermo/BinarySolutionTabulatedThermo.cpp
@@ -196,9 +196,9 @@ void BinarySolutionTabulatedThermo::diff(const vector<double>& inputData,
     }
 }
 
-void BinarySolutionTabulatedThermo::getPartialMolarVolumes(double* vbar) const
+void BinarySolutionTabulatedThermo::getPartialMolarVolumes(span<double> vbar) const
 {
-    std::copy(m_speciesMolarVolume.begin(), m_speciesMolarVolume.end(), vbar);
+    std::copy(m_speciesMolarVolume.begin(), m_speciesMolarVolume.end(), vbar.begin());
 }
 
 void BinarySolutionTabulatedThermo::calcDensity()

--- a/src/thermo/BinarySolutionTabulatedThermo.cpp
+++ b/src/thermo/BinarySolutionTabulatedThermo.cpp
@@ -198,6 +198,8 @@ void BinarySolutionTabulatedThermo::diff(span<const double> inputData,
 
 void BinarySolutionTabulatedThermo::getPartialMolarVolumes(span<double> vbar) const
 {
+    checkArraySize("BinarySolutionTabulatedThermo::getPartialMolarVolumes",
+                   vbar.size(), m_kk);
     std::copy(m_speciesMolarVolume.begin(), m_speciesMolarVolume.end(), vbar.begin());
 }
 

--- a/src/thermo/BinarySolutionTabulatedThermo.cpp
+++ b/src/thermo/BinarySolutionTabulatedThermo.cpp
@@ -157,7 +157,7 @@ void BinarySolutionTabulatedThermo::getParameters(AnyMap& phaseNode) const
 }
 
 double BinarySolutionTabulatedThermo::interpolate(const double x,
-                                                  const vector<double>& inputData) const
+                                                  span<const double> inputData) const
 {
     double c;
     // Check if x is out of bound
@@ -176,8 +176,8 @@ double BinarySolutionTabulatedThermo::interpolate(const double x,
     return c;
 }
 
-void BinarySolutionTabulatedThermo::diff(const vector<double>& inputData,
-                                         vector<double>& derivedData) const
+void BinarySolutionTabulatedThermo::diff(span<const double> inputData,
+                                         span<double> derivedData) const
 {
     if (inputData.size() > 1) {
         derivedData[0] = (inputData[1] - inputData[0]) /

--- a/src/thermo/BinarySolutionTabulatedThermo.cpp
+++ b/src/thermo/BinarySolutionTabulatedThermo.cpp
@@ -56,7 +56,7 @@ void BinarySolutionTabulatedThermo::_updateThermo() const
     double tnow = temperature();
     if (x_changed || m_tlast != tnow) {
         // Update the thermodynamic functions of the reference state.
-        m_spthermo.update(tnow, m_cp0_R.data(), m_h0_RT.data(), m_s0_R.data());
+        m_spthermo.update(tnow, m_cp0_R, m_h0_RT, m_s0_R);
         double rrt = 1.0 / RT();
         m_h0_RT[m_kk_tab] += m_h0_tab * rrt;
         m_s0_R[m_kk_tab] += m_s0_tab / GasConstant;

--- a/src/thermo/ConstCpPoly.cpp
+++ b/src/thermo/ConstCpPoly.cpp
@@ -20,7 +20,7 @@ ConstCpPoly::ConstCpPoly()
 }
 
 ConstCpPoly::ConstCpPoly(double tlow, double thigh, double pref,
-                         const double* coeffs) :
+                         span<const double> coeffs) :
     SpeciesThermoInterpType(tlow, thigh, pref)
 {
     setParameters(coeffs[0], coeffs[1], coeffs[2], coeffs[3]);
@@ -35,33 +35,29 @@ void ConstCpPoly::setParameters(double t0, double h0, double s0, double cp0)
     m_s0_R = s0 / GasConstant;
 }
 
-void ConstCpPoly::updateProperties(const double* tt,
-                                   double* cp_R,
-                                   double* h_RT,
-                                   double* s_R) const
+void ConstCpPoly::updateProperties(span<const double> tt, double& cp_R,
+                                   double& h_RT, double& s_R) const
 {
-    double t = *tt;
+    double t = tt[0];
     double logt = log(t);
     double rt = 1.0/t;
-    *cp_R = m_cp0_R;
-    *h_RT = rt*(m_h0_R + (t - m_t0) * m_cp0_R);
-    *s_R = m_s0_R + m_cp0_R * (logt - m_logt0);
+    cp_R = m_cp0_R;
+    h_RT = rt*(m_h0_R + (t - m_t0) * m_cp0_R);
+    s_R = m_s0_R + m_cp0_R * (logt - m_logt0);
 }
 
-void ConstCpPoly::updatePropertiesTemp(const double temp,
-                                       double* cp_R,
-                                       double* h_RT,
-                                       double* s_R) const
+void ConstCpPoly::updatePropertiesTemp(const double temp, double& cp_R,
+                                       double& h_RT, double& s_R) const
 {
     double logt = log(temp);
     double rt = 1.0/temp;
-    *cp_R = m_cp0_R;
-    *h_RT = rt*(m_h0_R + (temp - m_t0) * m_cp0_R);
-    *s_R = m_s0_R + m_cp0_R * (logt - m_logt0);
+    cp_R = m_cp0_R;
+    h_RT = rt*(m_h0_R + (temp - m_t0) * m_cp0_R);
+    s_R = m_s0_R + m_cp0_R * (logt - m_logt0);
 }
 
 void ConstCpPoly::reportParameters(size_t& n, int& type, double& tlow, double& thigh,
-                                   double& pref, double* const coeffs) const
+                                   double& pref, span<double> coeffs) const
 {
     n = 0;
     type = CONSTANT_CP;
@@ -84,12 +80,12 @@ void ConstCpPoly::getParameters(AnyMap& thermo) const
     thermo["cp0"].setQuantity(m_cp0_R * GasConstant, "J/kmol/K");
 }
 
-double ConstCpPoly::reportHf298(double* const h298) const
+double ConstCpPoly::reportHf298(span<double> h298) const
 {
     double temp = 298.15;
     double h = GasConstant * (m_h0_R + (temp - m_t0) * m_cp0_R);
-    if (h298) {
-        *h298 = h;
+    if (!h298.empty()) {
+        h298[0] = h;
     }
     return h;
 }

--- a/src/thermo/ConstCpPoly.cpp
+++ b/src/thermo/ConstCpPoly.cpp
@@ -80,14 +80,10 @@ void ConstCpPoly::getParameters(AnyMap& thermo) const
     thermo["cp0"].setQuantity(m_cp0_R * GasConstant, "J/kmol/K");
 }
 
-double ConstCpPoly::reportHf298(span<double> h298) const
+double ConstCpPoly::reportHf298() const
 {
     double temp = 298.15;
-    double h = GasConstant * (m_h0_R + (temp - m_t0) * m_cp0_R);
-    if (!h298.empty()) {
-        h298[0] = h;
-    }
-    return h;
+    return GasConstant * (m_h0_R + (temp - m_t0) * m_cp0_R);
 }
 
 void ConstCpPoly::modifyOneHf298(const size_t k, const double Hf298New)

--- a/src/thermo/ConstCpPoly.cpp
+++ b/src/thermo/ConstCpPoly.cpp
@@ -23,6 +23,7 @@ ConstCpPoly::ConstCpPoly(double tlow, double thigh, double pref,
                          span<const double> coeffs) :
     SpeciesThermoInterpType(tlow, thigh, pref)
 {
+    checkArraySize("ConstCpPoly::ConstCpPoly", coeffs.size(), 4);
     setParameters(coeffs[0], coeffs[1], coeffs[2], coeffs[3]);
 }
 
@@ -59,6 +60,7 @@ void ConstCpPoly::updatePropertiesTemp(const double temp, double& cp_R,
 void ConstCpPoly::reportParameters(size_t& n, int& type, double& tlow, double& thigh,
                                    double& pref, span<double> coeffs) const
 {
+    checkArraySize("ConstCpPoly::reportParameters", coeffs.size(), 4);
     n = 0;
     type = CONSTANT_CP;
     tlow = m_lowT;

--- a/src/thermo/CoverageDependentSurfPhase.cpp
+++ b/src/thermo/CoverageDependentSurfPhase.cpp
@@ -322,36 +322,42 @@ void CoverageDependentSurfPhase::getSpeciesParameters(const string& name,
 
 void CoverageDependentSurfPhase::getGibbs_RT_ref(span<double> grt) const
 {
+    checkArraySize("CoverageDependentSurfPhase::getGibbs_RT_ref", grt.size(), m_kk);
     SurfPhase::_updateThermo();
     scale(m_mu0.begin(), m_mu0.end(), grt.begin(), 1.0/RT());
 }
 
 void CoverageDependentSurfPhase::getEnthalpy_RT_ref(span<double> hrt) const
 {
+    checkArraySize("CoverageDependentSurfPhase::getEnthalpy_RT_ref", hrt.size(), m_kk);
     SurfPhase::_updateThermo();
     scale(m_h0.begin(), m_h0.end(), hrt.begin(), 1.0/RT());
 }
 
 void CoverageDependentSurfPhase::getEntropy_R_ref(span<double> sr) const
 {
+    checkArraySize("CoverageDependentSurfPhase::getEntropy_R_ref", sr.size(), m_kk);
     SurfPhase::_updateThermo();
     scale(m_s0.begin(), m_s0.end(), sr.begin(), 1.0/GasConstant);
 }
 
 void CoverageDependentSurfPhase::getCp_R_ref(span<double> cpr) const
 {
+    checkArraySize("CoverageDependentSurfPhase::getCp_R_ref", cpr.size(), m_kk);
     SurfPhase::_updateThermo();
     scale(m_cp0.begin(), m_cp0.end(), cpr.begin(), 1.0/GasConstant);
 }
 
 void CoverageDependentSurfPhase::getEnthalpy_RT(span<double> hrt) const
 {
+    checkArraySize("CoverageDependentSurfPhase::getEnthalpy_RT", hrt.size(), m_kk);
     _updateTotalThermo();
     scale(m_enthalpy.begin(), m_enthalpy.end(), hrt.begin(), 1.0/RT());
 }
 
 void CoverageDependentSurfPhase::getEntropy_R(span<double> sr) const
 {
+    checkArraySize("CoverageDependentSurfPhase::getEntropy_R", sr.size(), m_kk);
     _updateTotalThermo();
     scale(m_entropy.begin(), m_entropy.end(), sr.begin(), 1.0/GasConstant);
     if (m_theta_ref != 1.0) {
@@ -364,12 +370,14 @@ void CoverageDependentSurfPhase::getEntropy_R(span<double> sr) const
 
 void CoverageDependentSurfPhase::getCp_R(span<double> cpr) const
 {
+    checkArraySize("CoverageDependentSurfPhase::getCp_R", cpr.size(), m_kk);
     _updateTotalThermo();
     scale(m_heatcapacity.begin(), m_heatcapacity.end(), cpr.begin(), 1.0/GasConstant);
 }
 
 void CoverageDependentSurfPhase::getGibbs_RT(span<double> grt) const
 {
+    checkArraySize("CoverageDependentSurfPhase::getGibbs_RT", grt.size(), m_kk);
     _updateTotalThermo();
     scale(m_chempot.begin(), m_chempot.end(), grt.begin(), 1.0/RT());
     if (m_theta_ref != 1.0) {
@@ -382,6 +390,8 @@ void CoverageDependentSurfPhase::getGibbs_RT(span<double> grt) const
 
 void CoverageDependentSurfPhase::getStandardChemPotentials(span<double> mu0) const
 {
+    checkArraySize("CoverageDependentSurfPhase::getStandardChemPotentials",
+                   mu0.size(), m_kk);
     _updateTotalThermo();
     copy(m_chempot.begin(), m_chempot.end(), mu0.begin());
     if (m_theta_ref != 1.0) {
@@ -394,12 +404,16 @@ void CoverageDependentSurfPhase::getStandardChemPotentials(span<double> mu0) con
 
 void CoverageDependentSurfPhase::getPartialMolarEnthalpies(span<double> hbar) const
 {
+    checkArraySize("CoverageDependentSurfPhase::getPartialMolarEnthalpies",
+                   hbar.size(), m_kk);
     _updateTotalThermo();
     copy(m_enthalpy.begin(), m_enthalpy.end(), hbar.begin());
 }
 
 void CoverageDependentSurfPhase::getPartialMolarEntropies(span<double> sbar) const
 {
+    checkArraySize("CoverageDependentSurfPhase::getPartialMolarEntropies",
+                   sbar.size(), m_kk);
     _updateTotalThermo();
     copy(m_entropy.begin(), m_entropy.end(), sbar.begin());
     for (size_t k = 0; k < m_kk; k++) {
@@ -409,12 +423,14 @@ void CoverageDependentSurfPhase::getPartialMolarEntropies(span<double> sbar) con
 
 void CoverageDependentSurfPhase::getPartialMolarCp(span<double> cpbar) const
 {
+    checkArraySize("CoverageDependentSurfPhase::getPartialMolarCp", cpbar.size(), m_kk);
     _updateTotalThermo();
     copy(m_heatcapacity.begin(), m_heatcapacity.end(), cpbar.begin());
 }
 
 void CoverageDependentSurfPhase::getChemPotentials(span<double> mu) const
 {
+    checkArraySize("CoverageDependentSurfPhase::getChemPotentials", mu.size(), m_kk);
     _updateTotalThermo();
     copy(m_chempot.begin(), m_chempot.end(), mu.begin());
     for (size_t k = 0; k < m_kk; k++) {

--- a/src/thermo/CoverageDependentSurfPhase.cpp
+++ b/src/thermo/CoverageDependentSurfPhase.cpp
@@ -455,7 +455,7 @@ void CoverageDependentSurfPhase::_updateCovDepThermo() const
             m_s_cov[k] = 0.0;
             m_cp_cov[k] = 0.0;
         }
-        getCoverages(m_cov.data());
+        getCoverages(m_cov);
 
         // For linear and polynomial model
         for (auto& item : m_PolynomialDependency) {

--- a/src/thermo/CoverageDependentSurfPhase.cpp
+++ b/src/thermo/CoverageDependentSurfPhase.cpp
@@ -320,40 +320,40 @@ void CoverageDependentSurfPhase::getSpeciesParameters(const string& name,
     }
 }
 
-void CoverageDependentSurfPhase::getGibbs_RT_ref(double* grt) const
+void CoverageDependentSurfPhase::getGibbs_RT_ref(span<double> grt) const
 {
     SurfPhase::_updateThermo();
-    scale(m_mu0.begin(), m_mu0.end(), grt, 1.0/RT());
+    scale(m_mu0.begin(), m_mu0.end(), grt.begin(), 1.0/RT());
 }
 
-void CoverageDependentSurfPhase::getEnthalpy_RT_ref(double* hrt) const
+void CoverageDependentSurfPhase::getEnthalpy_RT_ref(span<double> hrt) const
 {
     SurfPhase::_updateThermo();
-    scale(m_h0.begin(), m_h0.end(), hrt, 1.0/RT());
+    scale(m_h0.begin(), m_h0.end(), hrt.begin(), 1.0/RT());
 }
 
-void CoverageDependentSurfPhase::getEntropy_R_ref(double* sr) const
+void CoverageDependentSurfPhase::getEntropy_R_ref(span<double> sr) const
 {
     SurfPhase::_updateThermo();
-    scale(m_s0.begin(), m_s0.end(), sr, 1.0/GasConstant);
+    scale(m_s0.begin(), m_s0.end(), sr.begin(), 1.0/GasConstant);
 }
 
-void CoverageDependentSurfPhase::getCp_R_ref(double* cpr) const
+void CoverageDependentSurfPhase::getCp_R_ref(span<double> cpr) const
 {
     SurfPhase::_updateThermo();
-    scale(m_cp0.begin(), m_cp0.end(), cpr, 1.0/GasConstant);
+    scale(m_cp0.begin(), m_cp0.end(), cpr.begin(), 1.0/GasConstant);
 }
 
-void CoverageDependentSurfPhase::getEnthalpy_RT(double* hrt) const
+void CoverageDependentSurfPhase::getEnthalpy_RT(span<double> hrt) const
 {
     _updateTotalThermo();
-    scale(m_enthalpy.begin(), m_enthalpy.end(), hrt, 1.0/RT());
+    scale(m_enthalpy.begin(), m_enthalpy.end(), hrt.begin(), 1.0/RT());
 }
 
-void CoverageDependentSurfPhase::getEntropy_R(double* sr) const
+void CoverageDependentSurfPhase::getEntropy_R(span<double> sr) const
 {
     _updateTotalThermo();
-    scale(m_entropy.begin(), m_entropy.end(), sr, 1.0/GasConstant);
+    scale(m_entropy.begin(), m_entropy.end(), sr.begin(), 1.0/GasConstant);
     if (m_theta_ref != 1.0) {
         double tmp = -log(m_theta_ref);
         for (size_t k = 0; k < m_kk; k++) {
@@ -362,16 +362,16 @@ void CoverageDependentSurfPhase::getEntropy_R(double* sr) const
     }
 }
 
-void CoverageDependentSurfPhase::getCp_R(double* cpr) const
+void CoverageDependentSurfPhase::getCp_R(span<double> cpr) const
 {
     _updateTotalThermo();
-    scale(m_heatcapacity.begin(), m_heatcapacity.end(), cpr, 1.0/GasConstant);
+    scale(m_heatcapacity.begin(), m_heatcapacity.end(), cpr.begin(), 1.0/GasConstant);
 }
 
-void CoverageDependentSurfPhase::getGibbs_RT(double* grt) const
+void CoverageDependentSurfPhase::getGibbs_RT(span<double> grt) const
 {
     _updateTotalThermo();
-    scale(m_chempot.begin(), m_chempot.end(), grt, 1.0/RT());
+    scale(m_chempot.begin(), m_chempot.end(), grt.begin(), 1.0/RT());
     if (m_theta_ref != 1.0) {
         double tmp = -log(m_theta_ref);
         for (size_t k = 0; k < m_kk; k++) {
@@ -380,10 +380,10 @@ void CoverageDependentSurfPhase::getGibbs_RT(double* grt) const
     }
 }
 
-void CoverageDependentSurfPhase::getStandardChemPotentials(double* mu0) const
+void CoverageDependentSurfPhase::getStandardChemPotentials(span<double> mu0) const
 {
     _updateTotalThermo();
-    copy(m_chempot.begin(), m_chempot.end(), mu0);
+    copy(m_chempot.begin(), m_chempot.end(), mu0.begin());
     if (m_theta_ref != 1.0) {
         double tmp = RT() * -log(m_theta_ref);
         for (size_t k = 0; k < m_kk; k++) {
@@ -392,31 +392,31 @@ void CoverageDependentSurfPhase::getStandardChemPotentials(double* mu0) const
     }
 }
 
-void CoverageDependentSurfPhase::getPartialMolarEnthalpies(double* hbar) const
+void CoverageDependentSurfPhase::getPartialMolarEnthalpies(span<double> hbar) const
 {
     _updateTotalThermo();
-    copy(m_enthalpy.begin(), m_enthalpy.end(), hbar);
+    copy(m_enthalpy.begin(), m_enthalpy.end(), hbar.begin());
 }
 
-void CoverageDependentSurfPhase::getPartialMolarEntropies(double* sbar) const
+void CoverageDependentSurfPhase::getPartialMolarEntropies(span<double> sbar) const
 {
     _updateTotalThermo();
-    copy(m_entropy.begin(), m_entropy.end(), sbar);
+    copy(m_entropy.begin(), m_entropy.end(), sbar.begin());
     for (size_t k = 0; k < m_kk; k++) {
         sbar[k] -= GasConstant * log(std::max(m_cov[k], SmallNumber) / m_theta_ref);
     }
 }
 
-void CoverageDependentSurfPhase::getPartialMolarCp(double* cpbar) const
+void CoverageDependentSurfPhase::getPartialMolarCp(span<double> cpbar) const
 {
     _updateTotalThermo();
-    copy(m_heatcapacity.begin(), m_heatcapacity.end(), cpbar);
+    copy(m_heatcapacity.begin(), m_heatcapacity.end(), cpbar.begin());
 }
 
-void CoverageDependentSurfPhase::getChemPotentials(double* mu) const
+void CoverageDependentSurfPhase::getChemPotentials(span<double> mu) const
 {
     _updateTotalThermo();
-    copy(m_chempot.begin(), m_chempot.end(), mu);
+    copy(m_chempot.begin(), m_chempot.end(), mu.begin());
     for (size_t k = 0; k < m_kk; k++) {
         mu[k] += RT() * log(std::max(m_cov[k], SmallNumber) / m_theta_ref);
     }

--- a/src/thermo/DebyeHuckel.cpp
+++ b/src/thermo/DebyeHuckel.cpp
@@ -74,6 +74,7 @@ double DebyeHuckel::standardConcentration(size_t k) const
 
 void DebyeHuckel::getActivities(span<double> ac) const
 {
+    checkArraySize("DebyeHuckel::getActivities", ac.size(), m_kk);
     _updateStandardStateThermo();
 
     // Update the molality array, m_molalities(). This requires an update due to
@@ -88,6 +89,8 @@ void DebyeHuckel::getActivities(span<double> ac) const
 
 void DebyeHuckel::getMolalityActivityCoefficients(span<double> acMolality) const
 {
+    checkArraySize("DebyeHuckel::getMolalityActivityCoefficients",
+                   acMolality.size(), m_kk);
     _updateStandardStateThermo();
     A_Debye_TP(-1.0, -1.0);
     s_update_lnMolalityActCoeff();

--- a/src/thermo/DebyeHuckel.cpp
+++ b/src/thermo/DebyeHuckel.cpp
@@ -57,7 +57,7 @@ void DebyeHuckel::calcDensity()
 
 // ------- Activities and Activity Concentrations
 
-void DebyeHuckel::getActivityConcentrations(double* c) const
+void DebyeHuckel::getActivityConcentrations(span<double> c) const
 {
     double c_solvent = standardConcentration();
     getActivities(c);
@@ -72,7 +72,7 @@ double DebyeHuckel::standardConcentration(size_t k) const
     return 1.0 / mvSolvent;
 }
 
-void DebyeHuckel::getActivities(double* ac) const
+void DebyeHuckel::getActivities(span<double> ac) const
 {
     _updateStandardStateThermo();
 
@@ -86,12 +86,12 @@ void DebyeHuckel::getActivities(double* ac) const
     ac[0] = exp(m_lnActCoeffMolal[0]) * xmolSolvent;
 }
 
-void DebyeHuckel::getMolalityActivityCoefficients(double* acMolality) const
+void DebyeHuckel::getMolalityActivityCoefficients(span<double> acMolality) const
 {
     _updateStandardStateThermo();
     A_Debye_TP(-1.0, -1.0);
     s_update_lnMolalityActCoeff();
-    copy(m_lnActCoeffMolal.begin(), m_lnActCoeffMolal.end(), acMolality);
+    copy(m_lnActCoeffMolal.begin(), m_lnActCoeffMolal.end(), acMolality.begin());
     for (size_t k = 0; k < m_kk; k++) {
         acMolality[k] = exp(acMolality[k]);
     }
@@ -99,7 +99,7 @@ void DebyeHuckel::getMolalityActivityCoefficients(double* acMolality) const
 
 // ------ Partial Molar Properties of the Solution -----------------
 
-void DebyeHuckel::getChemPotentials(double* mu) const
+void DebyeHuckel::getChemPotentials(span<double> mu) const
 {
     double xx;
 
@@ -119,7 +119,7 @@ void DebyeHuckel::getChemPotentials(double* mu) const
     mu[0] += RT() * (log(xx) + m_lnActCoeffMolal[0]);
 }
 
-void DebyeHuckel::getPartialMolarEnthalpies(double* hbar) const
+void DebyeHuckel::getPartialMolarEnthalpies(span<double> hbar) const
 {
     // Get the nondimensional standard state enthalpies
     getEnthalpy_RT(hbar);
@@ -144,7 +144,7 @@ void DebyeHuckel::getPartialMolarEnthalpies(double* hbar) const
     }
 }
 
-void DebyeHuckel::getPartialMolarEntropies(double* sbar) const
+void DebyeHuckel::getPartialMolarEntropies(span<double> sbar) const
 {
     // Get the standard state entropies at the temperature and pressure of the
     // solution.
@@ -182,7 +182,7 @@ void DebyeHuckel::getPartialMolarEntropies(double* sbar) const
     }
 }
 
-void DebyeHuckel::getPartialMolarVolumes(double* vbar) const
+void DebyeHuckel::getPartialMolarVolumes(span<double> vbar) const
 {
     getStandardVolumes(vbar);
 
@@ -194,7 +194,7 @@ void DebyeHuckel::getPartialMolarVolumes(double* vbar) const
     }
 }
 
-void DebyeHuckel::getPartialMolarCp(double* cpbar) const
+void DebyeHuckel::getPartialMolarCp(span<double> cpbar) const
 {
     getCp_R(cpbar);
     for (size_t k = 0; k < m_kk; k++) {

--- a/src/thermo/EEDFTwoTermApproximation.cpp
+++ b/src/thermo/EEDFTwoTermApproximation.cpp
@@ -223,7 +223,7 @@ vector<double> EEDFTwoTermApproximation::vector_g(const Eigen::VectorXd& f0)
     return g;
 }
 
-SparseMat EEDFTwoTermApproximation::matrix_P(const vector<double>& g, size_t k)
+SparseMat EEDFTwoTermApproximation::matrix_P(span<const double> g, size_t k)
 {
     SparseTriplets tripletList;
     for (size_t n = 0; n < m_eps[k].size(); n++) {
@@ -242,7 +242,7 @@ SparseMat EEDFTwoTermApproximation::matrix_P(const vector<double>& g, size_t k)
     return P;
 }
 
-SparseMat EEDFTwoTermApproximation::matrix_Q(const vector<double>& g, size_t k)
+SparseMat EEDFTwoTermApproximation::matrix_Q(span<const double> g, size_t k)
 {
     SparseTriplets tripletList;
     for (size_t n = 0; n < m_eps[k].size(); n++) {

--- a/src/thermo/GibbsExcessVPSSTP.cpp
+++ b/src/thermo/GibbsExcessVPSSTP.cpp
@@ -24,7 +24,7 @@ namespace Cantera
 void GibbsExcessVPSSTP::compositionChanged()
 {
     Phase::compositionChanged();
-    getMoleFractions(moleFractions_.data());
+    getMoleFractions(moleFractions_);
 }
 
 // ------------ Mechanical Properties ------------------------------
@@ -65,7 +65,7 @@ double GibbsExcessVPSSTP::logStandardConc(size_t k) const
 void GibbsExcessVPSSTP::getActivities(double* ac) const
 {
     getActivityCoefficients(ac);
-    getMoleFractions(moleFractions_.data());
+    getMoleFractions(moleFractions_);
     for (size_t k = 0; k < m_kk; k++) {
         ac[k] *= moleFractions_[k];
     }

--- a/src/thermo/GibbsExcessVPSSTP.cpp
+++ b/src/thermo/GibbsExcessVPSSTP.cpp
@@ -47,7 +47,7 @@ Units GibbsExcessVPSSTP::standardConcentrationUnits() const
     return Units(1.0); // dimensionless
 }
 
-void GibbsExcessVPSSTP::getActivityConcentrations(double* c) const
+void GibbsExcessVPSSTP::getActivityConcentrations(span<double> c) const
 {
     getActivities(c);
 }
@@ -62,7 +62,7 @@ double GibbsExcessVPSSTP::logStandardConc(size_t k) const
     return 0.0;
 }
 
-void GibbsExcessVPSSTP::getActivities(double* ac) const
+void GibbsExcessVPSSTP::getActivities(span<double> ac) const
 {
     getActivityCoefficients(ac);
     getMoleFractions(moleFractions_);
@@ -71,7 +71,7 @@ void GibbsExcessVPSSTP::getActivities(double* ac) const
     }
 }
 
-void GibbsExcessVPSSTP::getActivityCoefficients(double* const ac) const
+void GibbsExcessVPSSTP::getActivityCoefficients(span<double> const ac) const
 {
     getLnActivityCoefficients(ac);
     for (size_t k = 0; k < m_kk; k++) {
@@ -87,7 +87,7 @@ void GibbsExcessVPSSTP::getActivityCoefficients(double* const ac) const
 
 // ------------ Partial Molar Properties of the Solution ------------
 
-void GibbsExcessVPSSTP::getPartialMolarVolumes(double* vbar) const
+void GibbsExcessVPSSTP::getPartialMolarVolumes(span<double> vbar) const
 {
     // Get the standard state values in m^3 kmol-1
     getStandardVolumes(vbar);

--- a/src/thermo/GibbsExcessVPSSTP.cpp
+++ b/src/thermo/GibbsExcessVPSSTP.cpp
@@ -31,7 +31,7 @@ void GibbsExcessVPSSTP::compositionChanged()
 
 void GibbsExcessVPSSTP::calcDensity()
 {
-    const vector<double>& vbar = getStandardVolumes();
+    auto vbar = getStandardVolumes();
     double vtotal = 0.0;
     for (size_t i = 0; i < m_kk; i++) {
         vtotal += vbar[i] * moleFractions_[i];

--- a/src/thermo/HMWSoln.cpp
+++ b/src/thermo/HMWSoln.cpp
@@ -154,6 +154,7 @@ double HMWSoln::standardConcentration(size_t k) const
 
 void HMWSoln::getActivities(span<double> ac) const
 {
+    checkArraySize("HMWSoln::getActivities", ac.size(), m_kk);
     updateStandardStateThermo();
 
     // Update the molality array, m_molalities(). This requires an update due to
@@ -170,6 +171,8 @@ void HMWSoln::getActivities(span<double> ac) const
 
 void HMWSoln::getUnscaledMolalityActivityCoefficients(span<double> acMolality) const
 {
+    checkArraySize("HMWSoln::getUnscaledMolalityActivityCoefficients",
+                   acMolality.size(), m_kk);
     updateStandardStateThermo();
     A_Debye_TP(-1.0, -1.0);
     s_update_lnMolalityActCoeff();
@@ -3952,6 +3955,7 @@ void HMWSoln::printCoeffs() const
 
 void HMWSoln::applyphScale(span<double> acMolality) const
 {
+    checkArraySize("HMWSoln::applyphScale", acMolality.size(), m_kk);
     if (m_pHScalingType == PHSCALE_PITZER) {
         return;
     }

--- a/src/thermo/HMWSoln.cpp
+++ b/src/thermo/HMWSoln.cpp
@@ -66,7 +66,7 @@ double HMWSoln::relative_enthalpy() const
 double HMWSoln::relative_molal_enthalpy() const
 {
     double L = relative_enthalpy();
-    getMoleFractions(m_workS.data());
+    getMoleFractions(m_workS);
     double xanion = 0.0;
     size_t kcation = npos;
     double xcation = 0.0;
@@ -613,7 +613,7 @@ void HMWSoln::initThermo()
     // Lastly calculate the charge balance and then add stuff until the charges
     // compensate
     vector<double> mf(m_kk, 0.0);
-    getMoleFractions(mf.data());
+    getMoleFractions(mf);
     bool notDone = true;
 
     while (notDone) {
@@ -668,7 +668,7 @@ void HMWSoln::initThermo()
                     }
                 }
             }
-            setMoleFractions(mf.data());
+            setMoleFractions(mf);
         } else {
             notDone = false;
         }
@@ -1356,7 +1356,7 @@ void HMWSoln::calcMolalitiesCropped() const
 
     if (cropMethod == 1) {
         double* molF = m_gamma_tmp.data();
-        getMoleFractions(molF);
+        getMoleFractions(span<double>(molF, m_kk));
         double xmolSolvent = molF[0];
         if (xmolSolvent >= MC_X_o_cutoff_) {
             return;
@@ -3908,7 +3908,7 @@ void HMWSoln::printCoeffs() const
 
     // Update the coefficients wrt Temperature. Calculate the derivatives as well
     s_updatePitzer_CoeffWRTemp(2);
-    getMoleFractions(moleF.data());
+    getMoleFractions(moleF);
 
     writelog("Index  Name                  MoleF   MolalityCropped  Charge\n");
     for (size_t k = 0; k < m_kk; k++) {

--- a/src/thermo/HMWSoln.cpp
+++ b/src/thermo/HMWSoln.cpp
@@ -53,9 +53,9 @@ HMWSoln::HMWSoln(const string& inputFile, const string& id_) :
 
 double HMWSoln::relative_enthalpy() const
 {
-    getPartialMolarEnthalpies(m_workS.data());
+    getPartialMolarEnthalpies(m_workS);
     double hbar = mean_X(m_workS);
-    getEnthalpy_RT(m_gamma_tmp.data());
+    getEnthalpy_RT(m_gamma_tmp);
     for (size_t k = 0; k < m_kk; k++) {
         m_gamma_tmp[k] *= RT();
     }
@@ -129,7 +129,7 @@ void HMWSoln::calcDensity()
 
 // ------- Activities and Activity Concentrations
 
-void HMWSoln::getActivityConcentrations(double* c) const
+void HMWSoln::getActivityConcentrations(span<double> c) const
 {
     double cs_solvent = standardConcentration();
     getActivities(c);
@@ -144,7 +144,7 @@ void HMWSoln::getActivityConcentrations(double* c) const
 
 double HMWSoln::standardConcentration(size_t k) const
 {
-    getStandardVolumes(m_workS.data());
+    getStandardVolumes(m_workS);
     double mvSolvent = m_workS[0];
     if (k > 0) {
         return m_Mnaught / mvSolvent;
@@ -152,7 +152,7 @@ double HMWSoln::standardConcentration(size_t k) const
     return 1.0 / mvSolvent;
 }
 
-void HMWSoln::getActivities(double* ac) const
+void HMWSoln::getActivities(span<double> ac) const
 {
     updateStandardStateThermo();
 
@@ -168,12 +168,13 @@ void HMWSoln::getActivities(double* ac) const
     ac[0] = exp(m_lnActCoeffMolal_Scaled[0]) * xmolSolvent;
 }
 
-void HMWSoln::getUnscaledMolalityActivityCoefficients(double* acMolality) const
+void HMWSoln::getUnscaledMolalityActivityCoefficients(span<double> acMolality) const
 {
     updateStandardStateThermo();
     A_Debye_TP(-1.0, -1.0);
     s_update_lnMolalityActCoeff();
-    std::copy(m_lnActCoeffMolal_Unscaled.begin(), m_lnActCoeffMolal_Unscaled.end(), acMolality);
+    std::copy(m_lnActCoeffMolal_Unscaled.begin(), m_lnActCoeffMolal_Unscaled.end(),
+              acMolality.begin());
     for (size_t k = 0; k < m_kk; k++) {
         acMolality[k] = exp(acMolality[k]);
     }
@@ -181,7 +182,7 @@ void HMWSoln::getUnscaledMolalityActivityCoefficients(double* acMolality) const
 
 // ------ Partial Molar Properties of the Solution -----------------
 
-void HMWSoln::getChemPotentials(double* mu) const
+void HMWSoln::getChemPotentials(span<double> mu) const
 {
     double xx;
 
@@ -201,7 +202,7 @@ void HMWSoln::getChemPotentials(double* mu) const
     mu[0] += RT() * (log(xx) + m_lnActCoeffMolal_Scaled[0]);
 }
 
-void HMWSoln::getPartialMolarEnthalpies(double* hbar) const
+void HMWSoln::getPartialMolarEnthalpies(span<double> hbar) const
 {
     // Get the nondimensional standard state enthalpies
     getEnthalpy_RT(hbar);
@@ -220,7 +221,7 @@ void HMWSoln::getPartialMolarEnthalpies(double* hbar) const
     }
 }
 
-void HMWSoln::getPartialMolarEntropies(double* sbar) const
+void HMWSoln::getPartialMolarEntropies(span<double> sbar) const
 {
     // Get the standard state entropies at the temperature and pressure of the
     // solution.
@@ -255,7 +256,7 @@ void HMWSoln::getPartialMolarEntropies(double* sbar) const
     }
 }
 
-void HMWSoln::getPartialMolarVolumes(double* vbar) const
+void HMWSoln::getPartialMolarVolumes(span<double> vbar) const
 {
     // Get the standard state values in m^3 kmol-1
     getStandardVolumes(vbar);
@@ -268,7 +269,7 @@ void HMWSoln::getPartialMolarVolumes(double* vbar) const
     }
 }
 
-void HMWSoln::getPartialMolarCp(double* cpbar) const
+void HMWSoln::getPartialMolarCp(span<double> cpbar) const
 {
     getCp_R(cpbar);
     for (size_t k = 0; k < m_kk; k++) {
@@ -3945,7 +3946,7 @@ void HMWSoln::printCoeffs() const
     }
 }
 
-void HMWSoln::applyphScale(double* acMolality) const
+void HMWSoln::applyphScale(span<double> acMolality) const
 {
     if (m_pHScalingType == PHSCALE_PITZER) {
         return;

--- a/src/thermo/IdealGasPhase.cpp
+++ b/src/thermo/IdealGasPhase.cpp
@@ -50,6 +50,7 @@ double IdealGasPhase::standardConcentration(size_t k) const
 
 void IdealGasPhase::getActivityCoefficients(span<double> ac) const
 {
+    checkArraySize("IdealGasPhase::getActivityCoefficients", ac.size(), m_kk);
     for (size_t k = 0; k < m_kk; k++) {
         ac[k] = 1.0;
     }
@@ -77,12 +78,14 @@ void IdealGasPhase::getChemPotentials(span<double> mu) const
 
 void IdealGasPhase::getPartialMolarEnthalpies(span<double> hbar) const
 {
+    checkArraySize("IdealGasPhase::getPartialMolarEnthalpies", hbar.size(), m_kk);
     auto _h = enthalpy_RT_ref();
     scale(_h.begin(), _h.end(), hbar.begin(), RT());
 }
 
 void IdealGasPhase::getPartialMolarEntropies(span<double> sbar) const
 {
+    checkArraySize("IdealGasPhase::getPartialMolarEntropies", sbar.size(), m_kk);
     auto _s = entropy_R_ref();
     scale(_s.begin(), _s.end(), sbar.begin(), GasConstant);
     double logp = log(pressure() / refPressure());
@@ -94,6 +97,7 @@ void IdealGasPhase::getPartialMolarEntropies(span<double> sbar) const
 
 void IdealGasPhase::getPartialMolarIntEnergies(span<double> ubar) const
 {
+    checkArraySize("IdealGasPhase::getPartialMolarIntEnergies", ubar.size(), m_kk);
     auto _h = enthalpy_RT_ref();
     for (size_t k = 0; k < m_kk; k++) {
         ubar[k] = RT() * (_h[k] - 1.0);
@@ -102,12 +106,14 @@ void IdealGasPhase::getPartialMolarIntEnergies(span<double> ubar) const
 
 void IdealGasPhase::getPartialMolarCp(span<double> cpbar) const
 {
+    checkArraySize("IdealGasPhase::getPartialMolarCp", cpbar.size(), m_kk);
     auto _cp = cp_R_ref();
     scale(_cp.begin(), _cp.end(), cpbar.begin(), GasConstant);
 }
 
 void IdealGasPhase::getPartialMolarVolumes(span<double> vbar) const
 {
+    checkArraySize("IdealGasPhase::getPartialMolarVolumes", vbar.size(), m_kk);
     double vol = 1.0 / molarDensity();
     for (size_t k = 0; k < m_kk; k++) {
         vbar[k] = vol;
@@ -118,12 +124,14 @@ void IdealGasPhase::getPartialMolarVolumes(span<double> vbar) const
 
 void IdealGasPhase::getEnthalpy_RT(span<double> hrt) const
 {
+    checkArraySize("IdealGasPhase::getEnthalpy_RT", hrt.size(), m_kk);
     auto _h = enthalpy_RT_ref();
     copy(_h.begin(), _h.end(), hrt.begin());
 }
 
 void IdealGasPhase::getEntropy_R(span<double> sr) const
 {
+    checkArraySize("IdealGasPhase::getEntropy_R", sr.size(), m_kk);
     auto _s = entropy_R_ref();
     copy(_s.begin(), _s.end(), sr.begin());
     double tmp = log(pressure() / refPressure());
@@ -134,6 +142,7 @@ void IdealGasPhase::getEntropy_R(span<double> sr) const
 
 void IdealGasPhase::getGibbs_RT(span<double> grt) const
 {
+    checkArraySize("IdealGasPhase::getGibbs_RT", grt.size(), m_kk);
     auto gibbsrt = gibbs_RT_ref();
     copy(gibbsrt.begin(), gibbsrt.end(), grt.begin());
     double tmp = log(pressure() / refPressure());
@@ -149,12 +158,14 @@ void IdealGasPhase::getIntEnergy_RT(span<double> urt) const
 
 void IdealGasPhase::getCp_R(span<double> cpr) const
 {
+    checkArraySize("IdealGasPhase::getCp_R", cpr.size(), m_kk);
     auto _cpr = cp_R_ref();
     copy(_cpr.begin(), _cpr.end(), cpr.begin());
 }
 
 void IdealGasPhase::getStandardVolumes(span<double> vol) const
 {
+    checkArraySize("IdealGasPhase::getStandardVolumes", vol.size(), m_kk);
     double tmp = 1.0 / molarDensity();
     for (size_t k = 0; k < m_kk; k++) {
         vol[k] = tmp;
@@ -165,30 +176,35 @@ void IdealGasPhase::getStandardVolumes(span<double> vol) const
 
 void IdealGasPhase::getEnthalpy_RT_ref(span<double> hrt) const
 {
+    checkArraySize("IdealGasPhase::getEnthalpy_RT_ref", hrt.size(), m_kk);
     auto _h = enthalpy_RT_ref();
     copy(_h.begin(), _h.end(), hrt.begin());
 }
 
 void IdealGasPhase::getGibbs_RT_ref(span<double> grt) const
 {
+    checkArraySize("IdealGasPhase::getGibbs_RT_ref", grt.size(), m_kk);
     auto gibbsrt = gibbs_RT_ref();
     copy(gibbsrt.begin(), gibbsrt.end(), grt.begin());
 }
 
 void IdealGasPhase::getGibbs_ref(span<double> g) const
 {
+    checkArraySize("IdealGasPhase::getGibbs_ref", g.size(), m_kk);
     auto gibbsrt = gibbs_RT_ref();
     scale(gibbsrt.begin(), gibbsrt.end(), g.begin(), RT());
 }
 
 void IdealGasPhase::getEntropy_R_ref(span<double> er) const
 {
+    checkArraySize("IdealGasPhase::getEntropy_R_ref", er.size(), m_kk);
     auto _s = entropy_R_ref();
     copy(_s.begin(), _s.end(), er.begin());
 }
 
 void IdealGasPhase::getIntEnergy_RT_ref(span<double> urt) const
 {
+    checkArraySize("IdealGasPhase::getIntEnergy_RT_ref", urt.size(), m_kk);
     auto _h = enthalpy_RT_ref();
     for (size_t k = 0; k < m_kk; k++) {
         urt[k] = _h[k] - 1.0;
@@ -197,12 +213,14 @@ void IdealGasPhase::getIntEnergy_RT_ref(span<double> urt) const
 
 void IdealGasPhase::getCp_R_ref(span<double> cprt) const
 {
+    checkArraySize("IdealGasPhase::getCp_R_ref", cprt.size(), m_kk);
     auto _cpr = cp_R_ref();
     copy(_cpr.begin(), _cpr.end(), cprt.begin());
 }
 
 void IdealGasPhase::getStandardVolumes_ref(span<double> vol) const
 {
+    checkArraySize("IdealGasPhase::getStandardVolumes_ref", vol.size(), m_kk);
     double tmp = RT() / m_p0;
     for (size_t k = 0; k < m_kk; k++) {
         vol[k] = tmp;

--- a/src/thermo/IdealGasPhase.cpp
+++ b/src/thermo/IdealGasPhase.cpp
@@ -263,7 +263,7 @@ void IdealGasPhase::updateThermo() const
     // If the temperature has changed since the last time these
     // properties were computed, recompute them.
     if (cached.state1 != tnow) {
-        m_spthermo.update(tnow, &m_cp0_R[0], &m_h0_RT[0], &m_s0_R[0]);
+        m_spthermo.update(tnow, m_cp0_R, m_h0_RT, m_s0_R);
         cached.state1 = tnow;
 
         // update the species Gibbs functions

--- a/src/thermo/IdealGasPhase.cpp
+++ b/src/thermo/IdealGasPhase.cpp
@@ -48,14 +48,14 @@ double IdealGasPhase::standardConcentration(size_t k) const
     return pressure() / RT();
 }
 
-void IdealGasPhase::getActivityCoefficients(double* ac) const
+void IdealGasPhase::getActivityCoefficients(span<double> ac) const
 {
     for (size_t k = 0; k < m_kk; k++) {
         ac[k] = 1.0;
     }
 }
 
-void IdealGasPhase::getStandardChemPotentials(double* muStar) const
+void IdealGasPhase::getStandardChemPotentials(span<double> muStar) const
 {
     getGibbs_ref(muStar);
     double tmp = log(pressure() / refPressure()) * RT();
@@ -66,7 +66,7 @@ void IdealGasPhase::getStandardChemPotentials(double* muStar) const
 
 //  Partial Molar Properties of the Solution --------------
 
-void IdealGasPhase::getChemPotentials(double* mu) const
+void IdealGasPhase::getChemPotentials(span<double> mu) const
 {
     getStandardChemPotentials(mu);
     for (size_t k = 0; k < m_kk; k++) {
@@ -75,16 +75,16 @@ void IdealGasPhase::getChemPotentials(double* mu) const
     }
 }
 
-void IdealGasPhase::getPartialMolarEnthalpies(double* hbar) const
+void IdealGasPhase::getPartialMolarEnthalpies(span<double> hbar) const
 {
     const vector<double>& _h = enthalpy_RT_ref();
-    scale(_h.begin(), _h.end(), hbar, RT());
+    scale(_h.begin(), _h.end(), hbar.begin(), RT());
 }
 
-void IdealGasPhase::getPartialMolarEntropies(double* sbar) const
+void IdealGasPhase::getPartialMolarEntropies(span<double> sbar) const
 {
     const vector<double>& _s = entropy_R_ref();
-    scale(_s.begin(), _s.end(), sbar, GasConstant);
+    scale(_s.begin(), _s.end(), sbar.begin(), GasConstant);
     double logp = log(pressure() / refPressure());
     for (size_t k = 0; k < m_kk; k++) {
         double xx = std::max(SmallNumber, moleFraction(k));
@@ -92,7 +92,7 @@ void IdealGasPhase::getPartialMolarEntropies(double* sbar) const
     }
 }
 
-void IdealGasPhase::getPartialMolarIntEnergies(double* ubar) const
+void IdealGasPhase::getPartialMolarIntEnergies(span<double> ubar) const
 {
     const vector<double>& _h = enthalpy_RT_ref();
     for (size_t k = 0; k < m_kk; k++) {
@@ -100,13 +100,13 @@ void IdealGasPhase::getPartialMolarIntEnergies(double* ubar) const
     }
 }
 
-void IdealGasPhase::getPartialMolarCp(double* cpbar) const
+void IdealGasPhase::getPartialMolarCp(span<double> cpbar) const
 {
     const vector<double>& _cp = cp_R_ref();
-    scale(_cp.begin(), _cp.end(), cpbar, GasConstant);
+    scale(_cp.begin(), _cp.end(), cpbar.begin(), GasConstant);
 }
 
-void IdealGasPhase::getPartialMolarVolumes(double* vbar) const
+void IdealGasPhase::getPartialMolarVolumes(span<double> vbar) const
 {
     double vol = 1.0 / molarDensity();
     for (size_t k = 0; k < m_kk; k++) {
@@ -116,44 +116,44 @@ void IdealGasPhase::getPartialMolarVolumes(double* vbar) const
 
 // Properties of the Standard State of the Species in the Solution --
 
-void IdealGasPhase::getEnthalpy_RT(double* hrt) const
+void IdealGasPhase::getEnthalpy_RT(span<double> hrt) const
 {
     const vector<double>& _h = enthalpy_RT_ref();
-    copy(_h.begin(), _h.end(), hrt);
+    copy(_h.begin(), _h.end(), hrt.begin());
 }
 
-void IdealGasPhase::getEntropy_R(double* sr) const
+void IdealGasPhase::getEntropy_R(span<double> sr) const
 {
     const vector<double>& _s = entropy_R_ref();
-    copy(_s.begin(), _s.end(), sr);
+    copy(_s.begin(), _s.end(), sr.begin());
     double tmp = log(pressure() / refPressure());
     for (size_t k = 0; k < m_kk; k++) {
         sr[k] -= tmp;
     }
 }
 
-void IdealGasPhase::getGibbs_RT(double* grt) const
+void IdealGasPhase::getGibbs_RT(span<double> grt) const
 {
     const vector<double>& gibbsrt = gibbs_RT_ref();
-    copy(gibbsrt.begin(), gibbsrt.end(), grt);
+    copy(gibbsrt.begin(), gibbsrt.end(), grt.begin());
     double tmp = log(pressure() / refPressure());
     for (size_t k = 0; k < m_kk; k++) {
         grt[k] += tmp;
     }
 }
 
-void IdealGasPhase::getIntEnergy_RT(double* urt) const
+void IdealGasPhase::getIntEnergy_RT(span<double> urt) const
 {
     getIntEnergy_RT_ref(urt);
 }
 
-void IdealGasPhase::getCp_R(double* cpr) const
+void IdealGasPhase::getCp_R(span<double> cpr) const
 {
     const vector<double>& _cpr = cp_R_ref();
-    copy(_cpr.begin(), _cpr.end(), cpr);
+    copy(_cpr.begin(), _cpr.end(), cpr.begin());
 }
 
-void IdealGasPhase::getStandardVolumes(double* vol) const
+void IdealGasPhase::getStandardVolumes(span<double> vol) const
 {
     double tmp = 1.0 / molarDensity();
     for (size_t k = 0; k < m_kk; k++) {
@@ -163,31 +163,31 @@ void IdealGasPhase::getStandardVolumes(double* vol) const
 
 // Thermodynamic Values for the Species Reference States ---------
 
-void IdealGasPhase::getEnthalpy_RT_ref(double* hrt) const
+void IdealGasPhase::getEnthalpy_RT_ref(span<double> hrt) const
 {
     const vector<double>& _h = enthalpy_RT_ref();
-    copy(_h.begin(), _h.end(), hrt);
+    copy(_h.begin(), _h.end(), hrt.begin());
 }
 
-void IdealGasPhase::getGibbs_RT_ref(double* grt) const
+void IdealGasPhase::getGibbs_RT_ref(span<double> grt) const
 {
     const vector<double>& gibbsrt = gibbs_RT_ref();
-    copy(gibbsrt.begin(), gibbsrt.end(), grt);
+    copy(gibbsrt.begin(), gibbsrt.end(), grt.begin());
 }
 
-void IdealGasPhase::getGibbs_ref(double* g) const
+void IdealGasPhase::getGibbs_ref(span<double> g) const
 {
     const vector<double>& gibbsrt = gibbs_RT_ref();
-    scale(gibbsrt.begin(), gibbsrt.end(), g, RT());
+    scale(gibbsrt.begin(), gibbsrt.end(), g.begin(), RT());
 }
 
-void IdealGasPhase::getEntropy_R_ref(double* er) const
+void IdealGasPhase::getEntropy_R_ref(span<double> er) const
 {
     const vector<double>& _s = entropy_R_ref();
-    copy(_s.begin(), _s.end(), er);
+    copy(_s.begin(), _s.end(), er.begin());
 }
 
-void IdealGasPhase::getIntEnergy_RT_ref(double* urt) const
+void IdealGasPhase::getIntEnergy_RT_ref(span<double> urt) const
 {
     const vector<double>& _h = enthalpy_RT_ref();
     for (size_t k = 0; k < m_kk; k++) {
@@ -195,13 +195,13 @@ void IdealGasPhase::getIntEnergy_RT_ref(double* urt) const
     }
 }
 
-void IdealGasPhase::getCp_R_ref(double* cprt) const
+void IdealGasPhase::getCp_R_ref(span<double> cprt) const
 {
     const vector<double>& _cpr = cp_R_ref();
-    copy(_cpr.begin(), _cpr.end(), cprt);
+    copy(_cpr.begin(), _cpr.end(), cprt.begin());
 }
 
-void IdealGasPhase::getStandardVolumes_ref(double* vol) const
+void IdealGasPhase::getStandardVolumes_ref(span<double> vol) const
 {
     double tmp = RT() / m_p0;
     for (size_t k = 0; k < m_kk; k++) {
@@ -226,7 +226,7 @@ bool IdealGasPhase::addSpecies(shared_ptr<Species> spec)
     return added;
 }
 
-void IdealGasPhase::setToEquilState(const double* mu_RT)
+void IdealGasPhase::setToEquilState(span<const double> mu_RT)
 {
     const vector<double>& grt = gibbs_RT_ref();
 

--- a/src/thermo/IdealGasPhase.cpp
+++ b/src/thermo/IdealGasPhase.cpp
@@ -250,7 +250,7 @@ void IdealGasPhase::setToEquilState(const double* mu_RT)
         pres += m_pp[k];
     }
     // set state
-    setMoleFractions(m_pp.data());
+    setMoleFractions(m_pp);
     setPressure(pres);
 }
 

--- a/src/thermo/IdealGasPhase.cpp
+++ b/src/thermo/IdealGasPhase.cpp
@@ -77,13 +77,13 @@ void IdealGasPhase::getChemPotentials(span<double> mu) const
 
 void IdealGasPhase::getPartialMolarEnthalpies(span<double> hbar) const
 {
-    const vector<double>& _h = enthalpy_RT_ref();
+    auto _h = enthalpy_RT_ref();
     scale(_h.begin(), _h.end(), hbar.begin(), RT());
 }
 
 void IdealGasPhase::getPartialMolarEntropies(span<double> sbar) const
 {
-    const vector<double>& _s = entropy_R_ref();
+    auto _s = entropy_R_ref();
     scale(_s.begin(), _s.end(), sbar.begin(), GasConstant);
     double logp = log(pressure() / refPressure());
     for (size_t k = 0; k < m_kk; k++) {
@@ -94,7 +94,7 @@ void IdealGasPhase::getPartialMolarEntropies(span<double> sbar) const
 
 void IdealGasPhase::getPartialMolarIntEnergies(span<double> ubar) const
 {
-    const vector<double>& _h = enthalpy_RT_ref();
+    auto _h = enthalpy_RT_ref();
     for (size_t k = 0; k < m_kk; k++) {
         ubar[k] = RT() * (_h[k] - 1.0);
     }
@@ -102,7 +102,7 @@ void IdealGasPhase::getPartialMolarIntEnergies(span<double> ubar) const
 
 void IdealGasPhase::getPartialMolarCp(span<double> cpbar) const
 {
-    const vector<double>& _cp = cp_R_ref();
+    auto _cp = cp_R_ref();
     scale(_cp.begin(), _cp.end(), cpbar.begin(), GasConstant);
 }
 
@@ -118,13 +118,13 @@ void IdealGasPhase::getPartialMolarVolumes(span<double> vbar) const
 
 void IdealGasPhase::getEnthalpy_RT(span<double> hrt) const
 {
-    const vector<double>& _h = enthalpy_RT_ref();
+    auto _h = enthalpy_RT_ref();
     copy(_h.begin(), _h.end(), hrt.begin());
 }
 
 void IdealGasPhase::getEntropy_R(span<double> sr) const
 {
-    const vector<double>& _s = entropy_R_ref();
+    auto _s = entropy_R_ref();
     copy(_s.begin(), _s.end(), sr.begin());
     double tmp = log(pressure() / refPressure());
     for (size_t k = 0; k < m_kk; k++) {
@@ -134,7 +134,7 @@ void IdealGasPhase::getEntropy_R(span<double> sr) const
 
 void IdealGasPhase::getGibbs_RT(span<double> grt) const
 {
-    const vector<double>& gibbsrt = gibbs_RT_ref();
+    auto gibbsrt = gibbs_RT_ref();
     copy(gibbsrt.begin(), gibbsrt.end(), grt.begin());
     double tmp = log(pressure() / refPressure());
     for (size_t k = 0; k < m_kk; k++) {
@@ -149,7 +149,7 @@ void IdealGasPhase::getIntEnergy_RT(span<double> urt) const
 
 void IdealGasPhase::getCp_R(span<double> cpr) const
 {
-    const vector<double>& _cpr = cp_R_ref();
+    auto _cpr = cp_R_ref();
     copy(_cpr.begin(), _cpr.end(), cpr.begin());
 }
 
@@ -165,31 +165,31 @@ void IdealGasPhase::getStandardVolumes(span<double> vol) const
 
 void IdealGasPhase::getEnthalpy_RT_ref(span<double> hrt) const
 {
-    const vector<double>& _h = enthalpy_RT_ref();
+    auto _h = enthalpy_RT_ref();
     copy(_h.begin(), _h.end(), hrt.begin());
 }
 
 void IdealGasPhase::getGibbs_RT_ref(span<double> grt) const
 {
-    const vector<double>& gibbsrt = gibbs_RT_ref();
+    auto gibbsrt = gibbs_RT_ref();
     copy(gibbsrt.begin(), gibbsrt.end(), grt.begin());
 }
 
 void IdealGasPhase::getGibbs_ref(span<double> g) const
 {
-    const vector<double>& gibbsrt = gibbs_RT_ref();
+    auto gibbsrt = gibbs_RT_ref();
     scale(gibbsrt.begin(), gibbsrt.end(), g.begin(), RT());
 }
 
 void IdealGasPhase::getEntropy_R_ref(span<double> er) const
 {
-    const vector<double>& _s = entropy_R_ref();
+    auto _s = entropy_R_ref();
     copy(_s.begin(), _s.end(), er.begin());
 }
 
 void IdealGasPhase::getIntEnergy_RT_ref(span<double> urt) const
 {
-    const vector<double>& _h = enthalpy_RT_ref();
+    auto _h = enthalpy_RT_ref();
     for (size_t k = 0; k < m_kk; k++) {
         urt[k] = _h[k] - 1.0;
     }
@@ -197,7 +197,7 @@ void IdealGasPhase::getIntEnergy_RT_ref(span<double> urt) const
 
 void IdealGasPhase::getCp_R_ref(span<double> cprt) const
 {
-    const vector<double>& _cpr = cp_R_ref();
+    auto _cpr = cp_R_ref();
     copy(_cpr.begin(), _cpr.end(), cprt.begin());
 }
 
@@ -228,7 +228,7 @@ bool IdealGasPhase::addSpecies(shared_ptr<Species> spec)
 
 void IdealGasPhase::setToEquilState(span<const double> mu_RT)
 {
-    const vector<double>& grt = gibbs_RT_ref();
+    auto grt = gibbs_RT_ref();
 
     // Within the method, we protect against inf results if the exponent is too
     // high.

--- a/src/thermo/IdealMolalSoln.cpp
+++ b/src/thermo/IdealMolalSoln.cpp
@@ -110,6 +110,7 @@ double IdealMolalSoln::standardConcentration(size_t k) const
 
 void IdealMolalSoln::getActivities(span<double> ac) const
 {
+    checkArraySize("IdealMolalSoln::getActivities", ac.size(), m_kk);
     _updateStandardStateThermo();
 
     // Update the molality array, m_molalities(). This requires an update due to
@@ -139,6 +140,8 @@ void IdealMolalSoln::getActivities(span<double> ac) const
 
 void IdealMolalSoln::getMolalityActivityCoefficients(span<double> acMolality) const
 {
+    checkArraySize("IdealMolalSoln::getMolalityActivityCoefficients",
+                   acMolality.size(), m_kk);
     if (IMS_typeCutoff_ == 0) {
         for (size_t k = 0; k < m_kk; k++) {
             acMolality[k] = 1.0;

--- a/src/thermo/IdealMolalSoln.cpp
+++ b/src/thermo/IdealMolalSoln.cpp
@@ -47,7 +47,7 @@ IdealMolalSoln::IdealMolalSoln(const string& inputFile, const string& id_) :
 
 double IdealMolalSoln::intEnergy_mole() const
 {
-    getPartialMolarIntEnergies(m_workS.data());
+    getPartialMolarIntEnergies(m_workS);
     return mean_X(m_workS);
 }
 
@@ -75,7 +75,7 @@ Units IdealMolalSoln::standardConcentrationUnits() const
     }
 }
 
-void IdealMolalSoln::getActivityConcentrations(double* c) const
+void IdealMolalSoln::getActivityConcentrations(span<double> c) const
 {
     if (m_formGC != 1) {
         double c_solvent = standardConcentration();
@@ -108,7 +108,7 @@ double IdealMolalSoln::standardConcentration(size_t k) const
     }
 }
 
-void IdealMolalSoln::getActivities(double* ac) const
+void IdealMolalSoln::getActivities(span<double> ac) const
 {
     _updateStandardStateThermo();
 
@@ -137,7 +137,7 @@ void IdealMolalSoln::getActivities(double* ac) const
     }
 }
 
-void IdealMolalSoln::getMolalityActivityCoefficients(double* acMolality) const
+void IdealMolalSoln::getMolalityActivityCoefficients(span<double> acMolality) const
 {
     if (IMS_typeCutoff_ == 0) {
         for (size_t k = 0; k < m_kk; k++) {
@@ -150,7 +150,7 @@ void IdealMolalSoln::getMolalityActivityCoefficients(double* acMolality) const
         acMolality[0] = exp((xmolSolvent - 1.0)/xmolSolvent) / xmolSolvent;
     } else {
         s_updateIMS_lnMolalityActCoeff();
-        std::copy(IMS_lnActCoeffMolal_.begin(), IMS_lnActCoeffMolal_.end(), acMolality);
+        std::copy(IMS_lnActCoeffMolal_.begin(), IMS_lnActCoeffMolal_.end(), acMolality.begin());
         for (size_t k = 0; k < m_kk; k++) {
             acMolality[k] = exp(acMolality[k]);
         }
@@ -159,7 +159,7 @@ void IdealMolalSoln::getMolalityActivityCoefficients(double* acMolality) const
 
 // ------ Partial Molar Properties of the Solution -----------------
 
-void IdealMolalSoln::getChemPotentials(double* mu) const
+void IdealMolalSoln::getChemPotentials(span<double> mu) const
 {
     // First get the standard chemical potentials. This requires updates of
     // standard state as a function of T and P These are defined at unit
@@ -197,7 +197,7 @@ void IdealMolalSoln::getChemPotentials(double* mu) const
     }
 }
 
-void IdealMolalSoln::getPartialMolarEnthalpies(double* hbar) const
+void IdealMolalSoln::getPartialMolarEnthalpies(span<double> hbar) const
 {
     getEnthalpy_RT(hbar);
     for (size_t k = 0; k < m_kk; k++) {
@@ -205,7 +205,7 @@ void IdealMolalSoln::getPartialMolarEnthalpies(double* hbar) const
     }
 }
 
-void IdealMolalSoln::getPartialMolarIntEnergies(double* ubar) const
+void IdealMolalSoln::getPartialMolarIntEnergies(span<double> ubar) const
 {
     getIntEnergy_RT(ubar);
     for (size_t k = 0; k < m_kk; k++) {
@@ -213,7 +213,7 @@ void IdealMolalSoln::getPartialMolarIntEnergies(double* ubar) const
     }
 }
 
-void IdealMolalSoln::getPartialMolarEntropies(double* sbar) const
+void IdealMolalSoln::getPartialMolarEntropies(span<double> sbar) const
 {
     getEntropy_R(sbar);
     calcMolalities();
@@ -242,12 +242,12 @@ void IdealMolalSoln::getPartialMolarEntropies(double* sbar) const
     }
 }
 
-void IdealMolalSoln::getPartialMolarVolumes(double* vbar) const
+void IdealMolalSoln::getPartialMolarVolumes(span<double> vbar) const
 {
     getStandardVolumes(vbar);
 }
 
-void IdealMolalSoln::getPartialMolarCp(double* cpbar) const
+void IdealMolalSoln::getPartialMolarCp(span<double> cpbar) const
 {
     // Get the nondimensional Gibbs standard state of the species at the T and P
     // of the solution.

--- a/src/thermo/IdealSolidSolnPhase.cpp
+++ b/src/thermo/IdealSolidSolnPhase.cpp
@@ -118,7 +118,7 @@ void IdealSolidSolnPhase::getActivityCoefficients(span<double> ac) const
 void IdealSolidSolnPhase::getChemPotentials(span<double> mu) const
 {
     double delta_p = m_Pcurrent - m_Pref;
-    const vector<double>& g_RT = gibbs_RT_ref();
+    auto g_RT = gibbs_RT_ref();
     for (size_t k = 0; k < m_kk; k++) {
         double xx = std::max(SmallNumber, moleFraction(k));
         mu[k] = RT() * (g_RT[k] + log(xx))
@@ -130,7 +130,7 @@ void IdealSolidSolnPhase::getChemPotentials(span<double> mu) const
 
 void IdealSolidSolnPhase::getPartialMolarEnthalpies(span<double> hbar) const
 {
-    const vector<double>& _h = enthalpy_RT_ref();
+    auto _h = enthalpy_RT_ref();
     double delta_p = m_Pcurrent - m_Pref;
     for (size_t k = 0; k < m_kk; k++) {
         hbar[k] = _h[k]*RT() + delta_p * m_speciesMolarVolume[k];
@@ -140,7 +140,7 @@ void IdealSolidSolnPhase::getPartialMolarEnthalpies(span<double> hbar) const
 
 void IdealSolidSolnPhase::getPartialMolarEntropies(span<double> sbar) const
 {
-    const vector<double>& _s = entropy_R_ref();
+    auto _s = entropy_R_ref();
     for (size_t k = 0; k < m_kk; k++) {
         double xx = std::max(SmallNumber, moleFraction(k));
         sbar[k] = GasConstant * (_s[k] - log(xx));
@@ -164,7 +164,7 @@ void IdealSolidSolnPhase::getPartialMolarVolumes(span<double> vbar) const
 
 void IdealSolidSolnPhase::getStandardChemPotentials(span<double> g0) const
 {
-    const vector<double>& gibbsrt = gibbs_RT_ref();
+    auto gibbsrt = gibbs_RT_ref();
     double delta_p = (m_Pcurrent - m_Pref);
     for (size_t k = 0; k < m_kk; k++) {
         g0[k] = RT() * gibbsrt[k] + delta_p * m_speciesMolarVolume[k];
@@ -173,7 +173,7 @@ void IdealSolidSolnPhase::getStandardChemPotentials(span<double> g0) const
 
 void IdealSolidSolnPhase::getGibbs_RT(span<double> grt) const
 {
-    const vector<double>& gibbsrt = gibbs_RT_ref();
+    auto gibbsrt = gibbs_RT_ref();
     double delta_prt = (m_Pcurrent - m_Pref)/ RT();
     for (size_t k = 0; k < m_kk; k++) {
         grt[k] = gibbsrt[k] + delta_prt * m_speciesMolarVolume[k];
@@ -182,7 +182,7 @@ void IdealSolidSolnPhase::getGibbs_RT(span<double> grt) const
 
 void IdealSolidSolnPhase::getEnthalpy_RT(span<double> hrt) const
 {
-    const vector<double>& _h = enthalpy_RT_ref();
+    auto _h = enthalpy_RT_ref();
     double delta_prt = (m_Pcurrent - m_Pref) / RT();
     for (size_t k = 0; k < m_kk; k++) {
         hrt[k] = _h[k] + delta_prt * m_speciesMolarVolume[k];
@@ -191,13 +191,13 @@ void IdealSolidSolnPhase::getEnthalpy_RT(span<double> hrt) const
 
 void IdealSolidSolnPhase::getEntropy_R(span<double> sr) const
 {
-    const vector<double>& _s = entropy_R_ref();
+    auto _s = entropy_R_ref();
     copy(_s.begin(), _s.end(), sr.begin());
 }
 
 void IdealSolidSolnPhase::getIntEnergy_RT(span<double> urt) const
 {
-    const vector<double>& _h = enthalpy_RT_ref();
+    auto _h = enthalpy_RT_ref();
     double prefrt = m_Pref / RT();
     for (size_t k = 0; k < m_kk; k++) {
         urt[k] = _h[k] - prefrt * m_speciesMolarVolume[k];
@@ -206,7 +206,7 @@ void IdealSolidSolnPhase::getIntEnergy_RT(span<double> urt) const
 
 void IdealSolidSolnPhase::getCp_R(span<double> cpr) const
 {
-    const vector<double>& _cpr = cp_R_ref();
+    auto _cpr = cp_R_ref();
     copy(_cpr.begin(), _cpr.end(), cpr.begin());
 }
 
@@ -244,7 +244,7 @@ void IdealSolidSolnPhase::getGibbs_ref(span<double> g) const
 
 void IdealSolidSolnPhase::getIntEnergy_RT_ref(span<double> urt) const
 {
-    const vector<double>& _h = enthalpy_RT_ref();
+    auto _h = enthalpy_RT_ref();
     double prefrt = m_Pref / RT();
     for (size_t k = 0; k < m_kk; k++) {
         urt[k] = _h[k] - prefrt * m_speciesMolarVolume[k];
@@ -267,13 +267,13 @@ void IdealSolidSolnPhase::getCp_R_ref(span<double> cpr) const
     }
 }
 
-const vector<double>& IdealSolidSolnPhase::enthalpy_RT_ref() const
+span<const double> IdealSolidSolnPhase::enthalpy_RT_ref() const
 {
     _updateThermo();
     return m_h0_RT;
 }
 
-const vector<double>& IdealSolidSolnPhase::entropy_R_ref() const
+span<const double> IdealSolidSolnPhase::entropy_R_ref() const
 {
     _updateThermo();
     return m_s0_R;
@@ -372,7 +372,7 @@ void IdealSolidSolnPhase::getSpeciesParameters(const string &name,
 
 void IdealSolidSolnPhase::setToEquilState(span<const double> mu_RT)
 {
-    const vector<double>& grt = gibbs_RT_ref();
+    auto grt = gibbs_RT_ref();
 
     // Within the method, we protect against inf results if the exponent is too
     // high.

--- a/src/thermo/IdealSolidSolnPhase.cpp
+++ b/src/thermo/IdealSolidSolnPhase.cpp
@@ -432,7 +432,7 @@ void IdealSolidSolnPhase::_updateThermo() const
     if (m_tlast != tnow) {
 
         // Update the thermodynamic functions of the reference state.
-        m_spthermo.update(tnow, m_cp0_R.data(), m_h0_RT.data(), m_s0_R.data());
+        m_spthermo.update(tnow, m_cp0_R, m_h0_RT, m_s0_R);
         m_tlast = tnow;
         for (size_t k = 0; k < m_kk; k++) {
             m_g0_RT[k] = m_h0_RT[k] - m_s0_R[k];

--- a/src/thermo/IdealSolidSolnPhase.cpp
+++ b/src/thermo/IdealSolidSolnPhase.cpp
@@ -76,9 +76,9 @@ Units IdealSolidSolnPhase::standardConcentrationUnits() const
     }
 }
 
-void IdealSolidSolnPhase::getActivityConcentrations(double* c) const
+void IdealSolidSolnPhase::getActivityConcentrations(span<double> c) const
 {
-    getMoleFractions(span<double>(c, m_kk));
+    getMoleFractions(c);
     switch (m_formGC) {
     case 0:
         break;
@@ -108,14 +108,14 @@ double IdealSolidSolnPhase::standardConcentration(size_t k) const
     return 0.0;
 }
 
-void IdealSolidSolnPhase::getActivityCoefficients(double* ac) const
+void IdealSolidSolnPhase::getActivityCoefficients(span<double> ac) const
 {
     for (size_t k = 0; k < m_kk; k++) {
         ac[k] = 1.0;
     }
 }
 
-void IdealSolidSolnPhase::getChemPotentials(double* mu) const
+void IdealSolidSolnPhase::getChemPotentials(span<double> mu) const
 {
     double delta_p = m_Pcurrent - m_Pref;
     const vector<double>& g_RT = gibbs_RT_ref();
@@ -128,7 +128,7 @@ void IdealSolidSolnPhase::getChemPotentials(double* mu) const
 
 // Partial Molar Properties
 
-void IdealSolidSolnPhase::getPartialMolarEnthalpies(double* hbar) const
+void IdealSolidSolnPhase::getPartialMolarEnthalpies(span<double> hbar) const
 {
     const vector<double>& _h = enthalpy_RT_ref();
     double delta_p = m_Pcurrent - m_Pref;
@@ -138,7 +138,7 @@ void IdealSolidSolnPhase::getPartialMolarEnthalpies(double* hbar) const
     // scale(_h.begin(), _h.end(), hbar, RT());
 }
 
-void IdealSolidSolnPhase::getPartialMolarEntropies(double* sbar) const
+void IdealSolidSolnPhase::getPartialMolarEntropies(span<double> sbar) const
 {
     const vector<double>& _s = entropy_R_ref();
     for (size_t k = 0; k < m_kk; k++) {
@@ -147,7 +147,7 @@ void IdealSolidSolnPhase::getPartialMolarEntropies(double* sbar) const
     }
 }
 
-void IdealSolidSolnPhase::getPartialMolarCp(double* cpbar) const
+void IdealSolidSolnPhase::getPartialMolarCp(span<double> cpbar) const
 {
     getCp_R(cpbar);
     for (size_t k = 0; k < m_kk; k++) {
@@ -155,14 +155,14 @@ void IdealSolidSolnPhase::getPartialMolarCp(double* cpbar) const
     }
 }
 
-void IdealSolidSolnPhase::getPartialMolarVolumes(double* vbar) const
+void IdealSolidSolnPhase::getPartialMolarVolumes(span<double> vbar) const
 {
     getStandardVolumes(vbar);
 }
 
 // Properties of the Standard State of the Species in the Solution
 
-void IdealSolidSolnPhase::getStandardChemPotentials(double* g0) const
+void IdealSolidSolnPhase::getStandardChemPotentials(span<double> g0) const
 {
     const vector<double>& gibbsrt = gibbs_RT_ref();
     double delta_p = (m_Pcurrent - m_Pref);
@@ -171,7 +171,7 @@ void IdealSolidSolnPhase::getStandardChemPotentials(double* g0) const
     }
 }
 
-void IdealSolidSolnPhase::getGibbs_RT(double* grt) const
+void IdealSolidSolnPhase::getGibbs_RT(span<double> grt) const
 {
     const vector<double>& gibbsrt = gibbs_RT_ref();
     double delta_prt = (m_Pcurrent - m_Pref)/ RT();
@@ -180,7 +180,7 @@ void IdealSolidSolnPhase::getGibbs_RT(double* grt) const
     }
 }
 
-void IdealSolidSolnPhase::getEnthalpy_RT(double* hrt) const
+void IdealSolidSolnPhase::getEnthalpy_RT(span<double> hrt) const
 {
     const vector<double>& _h = enthalpy_RT_ref();
     double delta_prt = (m_Pcurrent - m_Pref) / RT();
@@ -189,13 +189,13 @@ void IdealSolidSolnPhase::getEnthalpy_RT(double* hrt) const
     }
 }
 
-void IdealSolidSolnPhase::getEntropy_R(double* sr) const
+void IdealSolidSolnPhase::getEntropy_R(span<double> sr) const
 {
     const vector<double>& _s = entropy_R_ref();
-    copy(_s.begin(), _s.end(), sr);
+    copy(_s.begin(), _s.end(), sr.begin());
 }
 
-void IdealSolidSolnPhase::getIntEnergy_RT(double* urt) const
+void IdealSolidSolnPhase::getIntEnergy_RT(span<double> urt) const
 {
     const vector<double>& _h = enthalpy_RT_ref();
     double prefrt = m_Pref / RT();
@@ -204,20 +204,20 @@ void IdealSolidSolnPhase::getIntEnergy_RT(double* urt) const
     }
 }
 
-void IdealSolidSolnPhase::getCp_R(double* cpr) const
+void IdealSolidSolnPhase::getCp_R(span<double> cpr) const
 {
     const vector<double>& _cpr = cp_R_ref();
-    copy(_cpr.begin(), _cpr.end(), cpr);
+    copy(_cpr.begin(), _cpr.end(), cpr.begin());
 }
 
-void IdealSolidSolnPhase::getStandardVolumes(double* vol) const
+void IdealSolidSolnPhase::getStandardVolumes(span<double> vol) const
 {
-    copy(m_speciesMolarVolume.begin(), m_speciesMolarVolume.end(), vol);
+    copy(m_speciesMolarVolume.begin(), m_speciesMolarVolume.end(), vol.begin());
 }
 
 // Thermodynamic Values for the Species Reference States
 
-void IdealSolidSolnPhase::getEnthalpy_RT_ref(double* hrt) const
+void IdealSolidSolnPhase::getEnthalpy_RT_ref(span<double> hrt) const
 {
     _updateThermo();
     for (size_t k = 0; k != m_kk; k++) {
@@ -225,7 +225,7 @@ void IdealSolidSolnPhase::getEnthalpy_RT_ref(double* hrt) const
     }
 }
 
-void IdealSolidSolnPhase::getGibbs_RT_ref(double* grt) const
+void IdealSolidSolnPhase::getGibbs_RT_ref(span<double> grt) const
 {
     _updateThermo();
     for (size_t k = 0; k != m_kk; k++) {
@@ -233,7 +233,7 @@ void IdealSolidSolnPhase::getGibbs_RT_ref(double* grt) const
     }
 }
 
-void IdealSolidSolnPhase::getGibbs_ref(double* g) const
+void IdealSolidSolnPhase::getGibbs_ref(span<double> g) const
 {
     _updateThermo();
     double tmp = RT();
@@ -242,7 +242,7 @@ void IdealSolidSolnPhase::getGibbs_ref(double* g) const
     }
 }
 
-void IdealSolidSolnPhase::getIntEnergy_RT_ref(double* urt) const
+void IdealSolidSolnPhase::getIntEnergy_RT_ref(span<double> urt) const
 {
     const vector<double>& _h = enthalpy_RT_ref();
     double prefrt = m_Pref / RT();
@@ -251,7 +251,7 @@ void IdealSolidSolnPhase::getIntEnergy_RT_ref(double* urt) const
     }
 }
 
-void IdealSolidSolnPhase::getEntropy_R_ref(double* er) const
+void IdealSolidSolnPhase::getEntropy_R_ref(span<double> er) const
 {
     _updateThermo();
     for (size_t k = 0; k != m_kk; k++) {
@@ -259,7 +259,7 @@ void IdealSolidSolnPhase::getEntropy_R_ref(double* er) const
     }
 }
 
-void IdealSolidSolnPhase::getCp_R_ref(double* cpr) const
+void IdealSolidSolnPhase::getCp_R_ref(span<double> cpr) const
 {
     _updateThermo();
     for (size_t k = 0; k != m_kk; k++) {
@@ -370,7 +370,7 @@ void IdealSolidSolnPhase::getSpeciesParameters(const string &name,
     }
 }
 
-void IdealSolidSolnPhase::setToEquilState(const double* mu_RT)
+void IdealSolidSolnPhase::setToEquilState(span<const double> mu_RT)
 {
     const vector<double>& grt = gibbs_RT_ref();
 
@@ -421,9 +421,9 @@ double IdealSolidSolnPhase::speciesMolarVolume(int k) const
     return m_speciesMolarVolume[k];
 }
 
-void IdealSolidSolnPhase::getSpeciesMolarVolumes(double* smv) const
+void IdealSolidSolnPhase::getSpeciesMolarVolumes(span<double> smv) const
 {
-    copy(m_speciesMolarVolume.begin(), m_speciesMolarVolume.end(), smv);
+    copy(m_speciesMolarVolume.begin(), m_speciesMolarVolume.end(), smv.begin());
 }
 
 void IdealSolidSolnPhase::_updateThermo() const

--- a/src/thermo/IdealSolidSolnPhase.cpp
+++ b/src/thermo/IdealSolidSolnPhase.cpp
@@ -110,6 +110,7 @@ double IdealSolidSolnPhase::standardConcentration(size_t k) const
 
 void IdealSolidSolnPhase::getActivityCoefficients(span<double> ac) const
 {
+    checkArraySize("IdealSolidSolnPhase::getActivityCoefficients", ac.size(), m_kk);
     for (size_t k = 0; k < m_kk; k++) {
         ac[k] = 1.0;
     }
@@ -117,6 +118,7 @@ void IdealSolidSolnPhase::getActivityCoefficients(span<double> ac) const
 
 void IdealSolidSolnPhase::getChemPotentials(span<double> mu) const
 {
+    checkArraySize("IdealSolidSolnPhase::getChemPotentials", mu.size(), m_kk);
     double delta_p = m_Pcurrent - m_Pref;
     auto g_RT = gibbs_RT_ref();
     for (size_t k = 0; k < m_kk; k++) {
@@ -130,6 +132,7 @@ void IdealSolidSolnPhase::getChemPotentials(span<double> mu) const
 
 void IdealSolidSolnPhase::getPartialMolarEnthalpies(span<double> hbar) const
 {
+    checkArraySize("IdealSolidSolnPhase::getPartialMolarEnthalpies", hbar.size(), m_kk);
     auto _h = enthalpy_RT_ref();
     double delta_p = m_Pcurrent - m_Pref;
     for (size_t k = 0; k < m_kk; k++) {
@@ -140,6 +143,7 @@ void IdealSolidSolnPhase::getPartialMolarEnthalpies(span<double> hbar) const
 
 void IdealSolidSolnPhase::getPartialMolarEntropies(span<double> sbar) const
 {
+    checkArraySize("IdealSolidSolnPhase::getPartialMolarEntropies", sbar.size(), m_kk);
     auto _s = entropy_R_ref();
     for (size_t k = 0; k < m_kk; k++) {
         double xx = std::max(SmallNumber, moleFraction(k));
@@ -164,6 +168,7 @@ void IdealSolidSolnPhase::getPartialMolarVolumes(span<double> vbar) const
 
 void IdealSolidSolnPhase::getStandardChemPotentials(span<double> g0) const
 {
+    checkArraySize("IdealSolidSolnPhase::getStandardChemPotentials", g0.size(), m_kk);
     auto gibbsrt = gibbs_RT_ref();
     double delta_p = (m_Pcurrent - m_Pref);
     for (size_t k = 0; k < m_kk; k++) {
@@ -173,6 +178,7 @@ void IdealSolidSolnPhase::getStandardChemPotentials(span<double> g0) const
 
 void IdealSolidSolnPhase::getGibbs_RT(span<double> grt) const
 {
+    checkArraySize("IdealSolidSolnPhase::getGibbs_RT", grt.size(), m_kk);
     auto gibbsrt = gibbs_RT_ref();
     double delta_prt = (m_Pcurrent - m_Pref)/ RT();
     for (size_t k = 0; k < m_kk; k++) {
@@ -182,6 +188,7 @@ void IdealSolidSolnPhase::getGibbs_RT(span<double> grt) const
 
 void IdealSolidSolnPhase::getEnthalpy_RT(span<double> hrt) const
 {
+    checkArraySize("IdealSolidSolnPhase::getEnthalpy_RT", hrt.size(), m_kk);
     auto _h = enthalpy_RT_ref();
     double delta_prt = (m_Pcurrent - m_Pref) / RT();
     for (size_t k = 0; k < m_kk; k++) {
@@ -191,12 +198,14 @@ void IdealSolidSolnPhase::getEnthalpy_RT(span<double> hrt) const
 
 void IdealSolidSolnPhase::getEntropy_R(span<double> sr) const
 {
+    checkArraySize("IdealSolidSolnPhase::getEntropy_R", sr.size(), m_kk);
     auto _s = entropy_R_ref();
     copy(_s.begin(), _s.end(), sr.begin());
 }
 
 void IdealSolidSolnPhase::getIntEnergy_RT(span<double> urt) const
 {
+    checkArraySize("IdealSolidSolnPhase::getIntEnergy_RT", urt.size(), m_kk);
     auto _h = enthalpy_RT_ref();
     double prefrt = m_Pref / RT();
     for (size_t k = 0; k < m_kk; k++) {
@@ -206,12 +215,14 @@ void IdealSolidSolnPhase::getIntEnergy_RT(span<double> urt) const
 
 void IdealSolidSolnPhase::getCp_R(span<double> cpr) const
 {
+    checkArraySize("IdealSolidSolnPhase::getCp_R", cpr.size(), m_kk);
     auto _cpr = cp_R_ref();
     copy(_cpr.begin(), _cpr.end(), cpr.begin());
 }
 
 void IdealSolidSolnPhase::getStandardVolumes(span<double> vol) const
 {
+    checkArraySize("IdealSolidSolnPhase::getStandardVolumes", vol.size(), m_kk);
     copy(m_speciesMolarVolume.begin(), m_speciesMolarVolume.end(), vol.begin());
 }
 
@@ -219,6 +230,7 @@ void IdealSolidSolnPhase::getStandardVolumes(span<double> vol) const
 
 void IdealSolidSolnPhase::getEnthalpy_RT_ref(span<double> hrt) const
 {
+    checkArraySize("IdealSolidSolnPhase::getEnthalpy_RT_ref", hrt.size(), m_kk);
     _updateThermo();
     for (size_t k = 0; k != m_kk; k++) {
         hrt[k] = m_h0_RT[k];
@@ -227,6 +239,7 @@ void IdealSolidSolnPhase::getEnthalpy_RT_ref(span<double> hrt) const
 
 void IdealSolidSolnPhase::getGibbs_RT_ref(span<double> grt) const
 {
+    checkArraySize("IdealSolidSolnPhase::getGibbs_RT_ref", grt.size(), m_kk);
     _updateThermo();
     for (size_t k = 0; k != m_kk; k++) {
         grt[k] = m_g0_RT[k];
@@ -235,6 +248,7 @@ void IdealSolidSolnPhase::getGibbs_RT_ref(span<double> grt) const
 
 void IdealSolidSolnPhase::getGibbs_ref(span<double> g) const
 {
+    checkArraySize("IdealSolidSolnPhase::getGibbs_ref", g.size(), m_kk);
     _updateThermo();
     double tmp = RT();
     for (size_t k = 0; k != m_kk; k++) {
@@ -244,6 +258,7 @@ void IdealSolidSolnPhase::getGibbs_ref(span<double> g) const
 
 void IdealSolidSolnPhase::getIntEnergy_RT_ref(span<double> urt) const
 {
+    checkArraySize("IdealSolidSolnPhase::getIntEnergy_RT_ref", urt.size(), m_kk);
     auto _h = enthalpy_RT_ref();
     double prefrt = m_Pref / RT();
     for (size_t k = 0; k < m_kk; k++) {
@@ -253,6 +268,7 @@ void IdealSolidSolnPhase::getIntEnergy_RT_ref(span<double> urt) const
 
 void IdealSolidSolnPhase::getEntropy_R_ref(span<double> er) const
 {
+    checkArraySize("IdealSolidSolnPhase::getEntropy_R_ref", er.size(), m_kk);
     _updateThermo();
     for (size_t k = 0; k != m_kk; k++) {
         er[k] = m_s0_R[k];
@@ -261,6 +277,7 @@ void IdealSolidSolnPhase::getEntropy_R_ref(span<double> er) const
 
 void IdealSolidSolnPhase::getCp_R_ref(span<double> cpr) const
 {
+    checkArraySize("IdealSolidSolnPhase::getCp_R_ref", cpr.size(), m_kk);
     _updateThermo();
     for (size_t k = 0; k != m_kk; k++) {
         cpr[k] = m_cp0_R[k];
@@ -372,6 +389,7 @@ void IdealSolidSolnPhase::getSpeciesParameters(const string &name,
 
 void IdealSolidSolnPhase::setToEquilState(span<const double> mu_RT)
 {
+    checkArraySize("IdealSolidSolnPhase::setToEquilState", mu_RT.size(), m_kk);
     auto grt = gibbs_RT_ref();
 
     // Within the method, we protect against inf results if the exponent is too
@@ -423,6 +441,7 @@ double IdealSolidSolnPhase::speciesMolarVolume(int k) const
 
 void IdealSolidSolnPhase::getSpeciesMolarVolumes(span<double> smv) const
 {
+    checkArraySize("IdealSolidSolnPhase::getSpeciesMolarVolumes", smv.size(), m_kk);
     copy(m_speciesMolarVolume.begin(), m_speciesMolarVolume.end(), smv.begin());
 }
 

--- a/src/thermo/IdealSolidSolnPhase.cpp
+++ b/src/thermo/IdealSolidSolnPhase.cpp
@@ -78,7 +78,7 @@ Units IdealSolidSolnPhase::standardConcentrationUnits() const
 
 void IdealSolidSolnPhase::getActivityConcentrations(double* c) const
 {
-    getMoleFractions(c);
+    getMoleFractions(span<double>(c, m_kk));
     switch (m_formGC) {
     case 0:
         break;
@@ -396,7 +396,7 @@ void IdealSolidSolnPhase::setToEquilState(const double* mu_RT)
         pres += m_pp[k];
     }
     // set state
-    setMoleFractions(m_pp.data());
+    setMoleFractions(m_pp);
     setPressure(pres);
 }
 

--- a/src/thermo/IdealSolnGasVPSS.cpp
+++ b/src/thermo/IdealSolnGasVPSS.cpp
@@ -89,6 +89,7 @@ Units IdealSolnGasVPSS::standardConcentrationUnits() const
 
 void IdealSolnGasVPSS::getActivityConcentrations(span<double> c) const
 {
+    checkArraySize("IdealSolnGasVPSS::getActivityConcentrations", c.size(), m_kk);
     auto vss = getStandardVolumes();
     switch (m_formGC) {
     case 0:
@@ -125,6 +126,7 @@ double IdealSolnGasVPSS::standardConcentration(size_t k) const
 
 void IdealSolnGasVPSS::getActivityCoefficients(span<double> ac) const
 {
+    checkArraySize("IdealSolnGasVPSS::getActivityCoefficients", ac.size(), m_kk);
     for (size_t k = 0; k < m_kk; k++) {
         ac[k] = 1.0;
     }
@@ -176,6 +178,7 @@ void IdealSolnGasVPSS::getPartialMolarVolumes(span<double> vbar) const
 
 void IdealSolnGasVPSS::setToEquilState(span<const double> mu_RT)
 {
+    checkArraySize("IdealSolnGasVPSS::setToEquilState", mu_RT.size(), m_kk);
     updateStandardStateThermo();
 
     // Within the method, we protect against inf results if the exponent is too

--- a/src/thermo/IdealSolnGasVPSS.cpp
+++ b/src/thermo/IdealSolnGasVPSS.cpp
@@ -199,7 +199,7 @@ void IdealSolnGasVPSS::setToEquilState(const double* mu_RT)
         pres += m_pp[k];
     }
     // set state
-    setMoleFractions(m_pp.data());
+    setMoleFractions(m_pp);
     setPressure(pres);
 }
 

--- a/src/thermo/IdealSolnGasVPSS.cpp
+++ b/src/thermo/IdealSolnGasVPSS.cpp
@@ -89,7 +89,7 @@ Units IdealSolnGasVPSS::standardConcentrationUnits() const
 
 void IdealSolnGasVPSS::getActivityConcentrations(span<double> c) const
 {
-    const vector<double>& vss = getStandardVolumes();
+    auto vss = getStandardVolumes();
     switch (m_formGC) {
     case 0:
         for (size_t k = 0; k < m_kk; k++) {
@@ -111,7 +111,7 @@ void IdealSolnGasVPSS::getActivityConcentrations(span<double> c) const
 
 double IdealSolnGasVPSS::standardConcentration(size_t k) const
 {
-    const vector<double>& vss = getStandardVolumes();
+    auto vss = getStandardVolumes();
     switch (m_formGC) {
     case 0:
         return 1.0;

--- a/src/thermo/IdealSolnGasVPSS.cpp
+++ b/src/thermo/IdealSolnGasVPSS.cpp
@@ -87,7 +87,7 @@ Units IdealSolnGasVPSS::standardConcentrationUnits() const
     }
 }
 
-void IdealSolnGasVPSS::getActivityConcentrations(double* c) const
+void IdealSolnGasVPSS::getActivityConcentrations(span<double> c) const
 {
     const vector<double>& vss = getStandardVolumes();
     switch (m_formGC) {
@@ -123,7 +123,7 @@ double IdealSolnGasVPSS::standardConcentration(size_t k) const
     return 0.0;
 }
 
-void IdealSolnGasVPSS::getActivityCoefficients(double* ac) const
+void IdealSolnGasVPSS::getActivityCoefficients(span<double> ac) const
 {
     for (size_t k = 0; k < m_kk; k++) {
         ac[k] = 1.0;
@@ -132,7 +132,7 @@ void IdealSolnGasVPSS::getActivityCoefficients(double* ac) const
 
 // ---- Partial Molar Properties of the Solution -----------------
 
-void IdealSolnGasVPSS::getChemPotentials(double* mu) const
+void IdealSolnGasVPSS::getChemPotentials(span<double> mu) const
 {
     getStandardChemPotentials(mu);
     for (size_t k = 0; k < m_kk; k++) {
@@ -141,40 +141,40 @@ void IdealSolnGasVPSS::getChemPotentials(double* mu) const
     }
 }
 
-void IdealSolnGasVPSS::getPartialMolarEnthalpies(double* hbar) const
+void IdealSolnGasVPSS::getPartialMolarEnthalpies(span<double> hbar) const
 {
     getEnthalpy_RT(hbar);
-    scale(hbar, hbar+m_kk, hbar, RT());
+    scale(hbar.begin(), hbar.end(), hbar.begin(), RT());
 }
 
-void IdealSolnGasVPSS::getPartialMolarEntropies(double* sbar) const
+void IdealSolnGasVPSS::getPartialMolarEntropies(span<double> sbar) const
 {
     getEntropy_R(sbar);
-    scale(sbar, sbar+m_kk, sbar, GasConstant);
+    scale(sbar.begin(), sbar.end(), sbar.begin(), GasConstant);
     for (size_t k = 0; k < m_kk; k++) {
         double xx = std::max(SmallNumber, moleFraction(k));
         sbar[k] += GasConstant * (- log(xx));
     }
 }
 
-void IdealSolnGasVPSS::getPartialMolarIntEnergies(double* ubar) const
+void IdealSolnGasVPSS::getPartialMolarIntEnergies(span<double> ubar) const
 {
     getIntEnergy_RT(ubar);
-    scale(ubar, ubar+m_kk, ubar, RT());
+    scale(ubar.begin(), ubar.end(), ubar.begin(), RT());
 }
 
-void IdealSolnGasVPSS::getPartialMolarCp(double* cpbar) const
+void IdealSolnGasVPSS::getPartialMolarCp(span<double> cpbar) const
 {
     getCp_R(cpbar);
-    scale(cpbar, cpbar+m_kk, cpbar, GasConstant);
+    scale(cpbar.begin(), cpbar.end(), cpbar.begin(), GasConstant);
 }
 
-void IdealSolnGasVPSS::getPartialMolarVolumes(double* vbar) const
+void IdealSolnGasVPSS::getPartialMolarVolumes(span<double> vbar) const
 {
     getStandardVolumes(vbar);
 }
 
-void IdealSolnGasVPSS::setToEquilState(const double* mu_RT)
+void IdealSolnGasVPSS::setToEquilState(span<const double> mu_RT)
 {
     updateStandardStateThermo();
 

--- a/src/thermo/MargulesVPSSTP.cpp
+++ b/src/thermo/MargulesVPSSTP.cpp
@@ -22,7 +22,7 @@ MargulesVPSSTP::MargulesVPSSTP(const string& inputFile, const string& id_)
 
 // -- Activities, Standard States, Activity Concentrations -----------
 
-void MargulesVPSSTP::getLnActivityCoefficients(double* lnac) const
+void MargulesVPSSTP::getLnActivityCoefficients(span<double> lnac) const
 {
     // Update the activity coefficients
     s_update_lnActCoeff();
@@ -35,7 +35,7 @@ void MargulesVPSSTP::getLnActivityCoefficients(double* lnac) const
 
 // ------------ Partial Molar Properties of the Solution ------------
 
-void MargulesVPSSTP::getChemPotentials(double* mu) const
+void MargulesVPSSTP::getChemPotentials(span<double> mu) const
 {
     // First get the standard chemical potentials in molar form. This requires
     // updates of standard state as a function of T and P
@@ -54,7 +54,7 @@ double MargulesVPSSTP::cv_mole() const
     return cp_mole() - GasConstant;
 }
 
-void MargulesVPSSTP::getPartialMolarEnthalpies(double* hbar) const
+void MargulesVPSSTP::getPartialMolarEnthalpies(span<double> hbar) const
 {
     // Get the nondimensional standard state enthalpies
     getEnthalpy_RT(hbar);
@@ -73,7 +73,7 @@ void MargulesVPSSTP::getPartialMolarEnthalpies(double* hbar) const
     }
 }
 
-void MargulesVPSSTP::getPartialMolarCp(double* cpbar) const
+void MargulesVPSSTP::getPartialMolarCp(span<double> cpbar) const
 {
     // Get the nondimensional standard state entropies
     getCp_R(cpbar);
@@ -93,7 +93,7 @@ void MargulesVPSSTP::getPartialMolarCp(double* cpbar) const
     }
 }
 
-void MargulesVPSSTP::getPartialMolarEntropies(double* sbar) const
+void MargulesVPSSTP::getPartialMolarEntropies(span<double> sbar) const
 {
     // Get the nondimensional standard state entropies
     getEntropy_R(sbar);
@@ -115,7 +115,7 @@ void MargulesVPSSTP::getPartialMolarEntropies(double* sbar) const
     }
 }
 
-void MargulesVPSSTP::getPartialMolarVolumes(double* vbar) const
+void MargulesVPSSTP::getPartialMolarVolumes(span<double> vbar) const
 {
     double T = temperature();
 
@@ -277,7 +277,7 @@ void MargulesVPSSTP::s_update_dlnActCoeff_dT() const
     }
 }
 
-void MargulesVPSSTP::getdlnActCoeffdT(double* dlnActCoeffdT) const
+void MargulesVPSSTP::getdlnActCoeffdT(span<double> dlnActCoeffdT) const
 {
     s_update_dlnActCoeff_dT();
     for (size_t k = 0; k < m_kk; k++) {
@@ -293,8 +293,8 @@ void MargulesVPSSTP::getd2lnActCoeffdT2(double* d2lnActCoeffdT2) const
     }
 }
 
-void MargulesVPSSTP::getdlnActCoeffds(const double dTds, const double* const dXds,
-                                       double* dlnActCoeffds) const
+void MargulesVPSSTP::getdlnActCoeffds(const double dTds, span<const double> const dXds,
+                                      span<double> dlnActCoeffds) const
 {
     double T = temperature();
     s_update_dlnActCoeff_dT();
@@ -413,7 +413,7 @@ void MargulesVPSSTP::s_update_dlnActCoeff_dlnX_diag() const
     }
 }
 
-void MargulesVPSSTP::getdlnActCoeffdlnN_diag(double* dlnActCoeffdlnN_diag) const
+void MargulesVPSSTP::getdlnActCoeffdlnN_diag(span<double> dlnActCoeffdlnN_diag) const
 {
     s_update_dlnActCoeff_dlnN_diag();
     for (size_t k = 0; k < m_kk; k++) {
@@ -421,7 +421,7 @@ void MargulesVPSSTP::getdlnActCoeffdlnN_diag(double* dlnActCoeffdlnN_diag) const
     }
 }
 
-void MargulesVPSSTP::getdlnActCoeffdlnX_diag(double* dlnActCoeffdlnX_diag) const
+void MargulesVPSSTP::getdlnActCoeffdlnX_diag(span<double> dlnActCoeffdlnX_diag) const
 {
     s_update_dlnActCoeff_dlnX_diag();
     for (size_t k = 0; k < m_kk; k++) {
@@ -429,7 +429,7 @@ void MargulesVPSSTP::getdlnActCoeffdlnX_diag(double* dlnActCoeffdlnX_diag) const
     }
 }
 
-void MargulesVPSSTP::getdlnActCoeffdlnN(const size_t ld, double* dlnActCoeffdlnN)
+void MargulesVPSSTP::getdlnActCoeffdlnN(const size_t ld, span<double> dlnActCoeffdlnN)
 {
     s_update_dlnActCoeff_dlnN();
     double* data =  & dlnActCoeffdlnN_(0,0);

--- a/src/thermo/MargulesVPSSTP.cpp
+++ b/src/thermo/MargulesVPSSTP.cpp
@@ -24,6 +24,7 @@ MargulesVPSSTP::MargulesVPSSTP(const string& inputFile, const string& id_)
 
 void MargulesVPSSTP::getLnActivityCoefficients(span<double> lnac) const
 {
+    checkArraySize("MargulesVPSSTP::getLnActivityCoefficients", lnac.size(), m_kk);
     // Update the activity coefficients
     s_update_lnActCoeff();
 
@@ -279,6 +280,7 @@ void MargulesVPSSTP::s_update_dlnActCoeff_dT() const
 
 void MargulesVPSSTP::getdlnActCoeffdT(span<double> dlnActCoeffdT) const
 {
+    checkArraySize("MargulesVPSSTP::getdlnActCoeffdT", dlnActCoeffdT.size(), m_kk);
     s_update_dlnActCoeff_dT();
     for (size_t k = 0; k < m_kk; k++) {
         dlnActCoeffdT[k] = dlnActCoeffdT_Scaled_[k];
@@ -287,6 +289,7 @@ void MargulesVPSSTP::getdlnActCoeffdT(span<double> dlnActCoeffdT) const
 
 void MargulesVPSSTP::getd2lnActCoeffdT2(span<double> d2lnActCoeffdT2) const
 {
+    checkArraySize("MargulesVPSSTP::getd2lnActCoeffdT2", d2lnActCoeffdT2.size(), m_kk);
     s_update_dlnActCoeff_dT();
     for (size_t k = 0; k < m_kk; k++) {
         d2lnActCoeffdT2[k] = d2lnActCoeffdT2_Scaled_[k];
@@ -296,6 +299,8 @@ void MargulesVPSSTP::getd2lnActCoeffdT2(span<double> d2lnActCoeffdT2) const
 void MargulesVPSSTP::getdlnActCoeffds(const double dTds, span<const double> const dXds,
                                       span<double> dlnActCoeffds) const
 {
+    checkArraySize("MargulesVPSSTP::getdlnActCoeffds", dlnActCoeffds.size(), m_kk);
+    checkArraySize("MargulesVPSSTP::getdlnActCoeffds", dXds.size(), m_kk);
     double T = temperature();
     s_update_dlnActCoeff_dT();
     for (size_t iK = 0; iK < m_kk; iK++) {

--- a/src/thermo/MargulesVPSSTP.cpp
+++ b/src/thermo/MargulesVPSSTP.cpp
@@ -285,7 +285,7 @@ void MargulesVPSSTP::getdlnActCoeffdT(span<double> dlnActCoeffdT) const
     }
 }
 
-void MargulesVPSSTP::getd2lnActCoeffdT2(double* d2lnActCoeffdT2) const
+void MargulesVPSSTP::getd2lnActCoeffdT2(span<double> d2lnActCoeffdT2) const
 {
     s_update_dlnActCoeff_dT();
     for (size_t k = 0; k < m_kk; k++) {

--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -123,13 +123,7 @@ void MixtureFugacityTP::getGibbs_RT_ref(span<double> grt) const
 
 void MixtureFugacityTP::getGibbs_ref(span<double> g) const
 {
-    const vector<double>& gibbsrt = gibbs_RT_ref();
-    scale(gibbsrt.begin(), gibbsrt.end(), g.begin(), RT());
-}
-
-const vector<double>& MixtureFugacityTP::gibbs_RT_ref() const
-{
-    return m_g0_RT;
+    scale(m_g0_RT.begin(), m_g0_RT.end(), g.begin(), RT());
 }
 
 void MixtureFugacityTP::getEntropy_R_ref(span<double> er) const

--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -57,52 +57,52 @@ double MixtureFugacityTP::entropy_mole() const
 
 // ----- Thermodynamic Values for the Species Standard States States ----
 
-void MixtureFugacityTP::getStandardChemPotentials(double* g) const
+void MixtureFugacityTP::getStandardChemPotentials(span<double> g) const
 {
-    copy(m_g0_RT.begin(), m_g0_RT.end(), g);
+    copy(m_g0_RT.begin(), m_g0_RT.end(), g.begin());
     double tmp = log(pressure() / refPressure());
     for (size_t k = 0; k < m_kk; k++) {
         g[k] = RT() * (g[k] + tmp);
     }
 }
 
-void MixtureFugacityTP::getEnthalpy_RT(double* hrt) const
+void MixtureFugacityTP::getEnthalpy_RT(span<double> hrt) const
 {
     getEnthalpy_RT_ref(hrt);
 }
 
-void MixtureFugacityTP::getEntropy_R(double* sr) const
+void MixtureFugacityTP::getEntropy_R(span<double> sr) const
 {
-    copy(m_s0_R.begin(), m_s0_R.end(), sr);
+    copy(m_s0_R.begin(), m_s0_R.end(), sr.begin());
     double tmp = log(pressure() / refPressure());
     for (size_t k = 0; k < m_kk; k++) {
         sr[k] -= tmp;
     }
 }
 
-void MixtureFugacityTP::getGibbs_RT(double* grt) const
+void MixtureFugacityTP::getGibbs_RT(span<double> grt) const
 {
-    copy(m_g0_RT.begin(), m_g0_RT.end(), grt);
+    copy(m_g0_RT.begin(), m_g0_RT.end(), grt.begin());
     double tmp = log(pressure() / refPressure());
     for (size_t k = 0; k < m_kk; k++) {
         grt[k] += tmp;
     }
 }
 
-void MixtureFugacityTP::getIntEnergy_RT(double* urt) const
+void MixtureFugacityTP::getIntEnergy_RT(span<double> urt) const
 {
-    copy(m_h0_RT.begin(), m_h0_RT.end(), urt);
+    copy(m_h0_RT.begin(), m_h0_RT.end(), urt.begin());
     for (size_t i = 0; i < m_kk; i++) {
         urt[i] -= 1.0;
     }
 }
 
-void MixtureFugacityTP::getCp_R(double* cpr) const
+void MixtureFugacityTP::getCp_R(span<double> cpr) const
 {
-    copy(m_cp0_R.begin(), m_cp0_R.end(), cpr);
+    copy(m_cp0_R.begin(), m_cp0_R.end(), cpr.begin());
 }
 
-void MixtureFugacityTP::getStandardVolumes(double* vol) const
+void MixtureFugacityTP::getStandardVolumes(span<double> vol) const
 {
     for (size_t i = 0; i < m_kk; i++) {
         vol[i] = RT() / pressure();
@@ -111,20 +111,20 @@ void MixtureFugacityTP::getStandardVolumes(double* vol) const
 
 // ----- Thermodynamic Values for the Species Reference States ----
 
-void MixtureFugacityTP::getEnthalpy_RT_ref(double* hrt) const
+void MixtureFugacityTP::getEnthalpy_RT_ref(span<double> hrt) const
 {
-    copy(m_h0_RT.begin(), m_h0_RT.end(), hrt);
+    copy(m_h0_RT.begin(), m_h0_RT.end(), hrt.begin());
 }
 
-void MixtureFugacityTP::getGibbs_RT_ref(double* grt) const
+void MixtureFugacityTP::getGibbs_RT_ref(span<double> grt) const
 {
-    copy(m_g0_RT.begin(), m_g0_RT.end(), grt);
+    copy(m_g0_RT.begin(), m_g0_RT.end(), grt.begin());
 }
 
-void MixtureFugacityTP::getGibbs_ref(double* g) const
+void MixtureFugacityTP::getGibbs_ref(span<double> g) const
 {
     const vector<double>& gibbsrt = gibbs_RT_ref();
-    scale(gibbsrt.begin(), gibbsrt.end(), g, RT());
+    scale(gibbsrt.begin(), gibbsrt.end(), g.begin(), RT());
 }
 
 const vector<double>& MixtureFugacityTP::gibbs_RT_ref() const
@@ -132,17 +132,17 @@ const vector<double>& MixtureFugacityTP::gibbs_RT_ref() const
     return m_g0_RT;
 }
 
-void MixtureFugacityTP::getEntropy_R_ref(double* er) const
+void MixtureFugacityTP::getEntropy_R_ref(span<double> er) const
 {
-    copy(m_s0_R.begin(), m_s0_R.end(), er);
+    copy(m_s0_R.begin(), m_s0_R.end(), er.begin());
 }
 
-void MixtureFugacityTP::getCp_R_ref(double* cpr) const
+void MixtureFugacityTP::getCp_R_ref(span<double> cpr) const
 {
-    copy(m_cp0_R.begin(), m_cp0_R.end(), cpr);
+    copy(m_cp0_R.begin(), m_cp0_R.end(), cpr.begin());
 }
 
-void MixtureFugacityTP::getStandardVolumes_ref(double* vol) const
+void MixtureFugacityTP::getStandardVolumes_ref(span<double> vol) const
 {
     for (size_t i = 0; i < m_kk; i++) {
         vol[i]= RT() / refPressure();
@@ -246,7 +246,7 @@ void MixtureFugacityTP::compositionChanged()
     updateMixingExpressions();
 }
 
-void MixtureFugacityTP::getActivityConcentrations(double* c) const
+void MixtureFugacityTP::getActivityConcentrations(span<double> c) const
 {
     getActivityCoefficients(c);
     double p_RT = pressure() / RT();

--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -706,7 +706,7 @@ void MixtureFugacityTP::_updateReferenceStateThermo() const
     // If the temperature has changed since the last time these
     // properties were computed, recompute them.
     if (m_tlast != Tnow) {
-        m_spthermo.update(Tnow, &m_cp0_R[0], &m_h0_RT[0], &m_s0_R[0]);
+        m_spthermo.update(Tnow, m_cp0_R, m_h0_RT, m_s0_R);
         m_tlast = Tnow;
 
         // update the species Gibbs functions

--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -242,7 +242,7 @@ void MixtureFugacityTP::setPressure(double p)
 void MixtureFugacityTP::compositionChanged()
 {
     Phase::compositionChanged();
-    getMoleFractions(moleFractions_.data());
+    getMoleFractions(moleFractions_);
     updateMixingExpressions();
 }
 

--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -59,6 +59,7 @@ double MixtureFugacityTP::entropy_mole() const
 
 void MixtureFugacityTP::getStandardChemPotentials(span<double> g) const
 {
+    checkArraySize("MixtureFugacityTP::getStandardChemPotentials", g.size(), m_kk);
     copy(m_g0_RT.begin(), m_g0_RT.end(), g.begin());
     double tmp = log(pressure() / refPressure());
     for (size_t k = 0; k < m_kk; k++) {
@@ -73,6 +74,7 @@ void MixtureFugacityTP::getEnthalpy_RT(span<double> hrt) const
 
 void MixtureFugacityTP::getEntropy_R(span<double> sr) const
 {
+    checkArraySize("MixtureFugacityTP::getEntropy_R", sr.size(), m_kk);
     copy(m_s0_R.begin(), m_s0_R.end(), sr.begin());
     double tmp = log(pressure() / refPressure());
     for (size_t k = 0; k < m_kk; k++) {
@@ -82,6 +84,7 @@ void MixtureFugacityTP::getEntropy_R(span<double> sr) const
 
 void MixtureFugacityTP::getGibbs_RT(span<double> grt) const
 {
+    checkArraySize("MixtureFugacityTP::getGibbs_RT", grt.size(), m_kk);
     copy(m_g0_RT.begin(), m_g0_RT.end(), grt.begin());
     double tmp = log(pressure() / refPressure());
     for (size_t k = 0; k < m_kk; k++) {
@@ -91,6 +94,7 @@ void MixtureFugacityTP::getGibbs_RT(span<double> grt) const
 
 void MixtureFugacityTP::getIntEnergy_RT(span<double> urt) const
 {
+    checkArraySize("MixtureFugacityTP::getIntEnergy_RT", urt.size(), m_kk);
     copy(m_h0_RT.begin(), m_h0_RT.end(), urt.begin());
     for (size_t i = 0; i < m_kk; i++) {
         urt[i] -= 1.0;
@@ -99,11 +103,13 @@ void MixtureFugacityTP::getIntEnergy_RT(span<double> urt) const
 
 void MixtureFugacityTP::getCp_R(span<double> cpr) const
 {
+    checkArraySize("MixtureFugacityTP::getCp_R", cpr.size(), m_kk);
     copy(m_cp0_R.begin(), m_cp0_R.end(), cpr.begin());
 }
 
 void MixtureFugacityTP::getStandardVolumes(span<double> vol) const
 {
+    checkArraySize("MixtureFugacityTP::getStandardVolumes", vol.size(), m_kk);
     for (size_t i = 0; i < m_kk; i++) {
         vol[i] = RT() / pressure();
     }
@@ -113,31 +119,37 @@ void MixtureFugacityTP::getStandardVolumes(span<double> vol) const
 
 void MixtureFugacityTP::getEnthalpy_RT_ref(span<double> hrt) const
 {
+    checkArraySize("MixtureFugacityTP::getEnthalpy_RT_ref", hrt.size(), m_kk);
     copy(m_h0_RT.begin(), m_h0_RT.end(), hrt.begin());
 }
 
 void MixtureFugacityTP::getGibbs_RT_ref(span<double> grt) const
 {
+    checkArraySize("MixtureFugacityTP::getGibbs_RT_ref", grt.size(), m_kk);
     copy(m_g0_RT.begin(), m_g0_RT.end(), grt.begin());
 }
 
 void MixtureFugacityTP::getGibbs_ref(span<double> g) const
 {
+    checkArraySize("MixtureFugacityTP::getGibbs_ref", g.size(), m_kk);
     scale(m_g0_RT.begin(), m_g0_RT.end(), g.begin(), RT());
 }
 
 void MixtureFugacityTP::getEntropy_R_ref(span<double> er) const
 {
+    checkArraySize("MixtureFugacityTP::getEntropy_R_ref", er.size(), m_kk);
     copy(m_s0_R.begin(), m_s0_R.end(), er.begin());
 }
 
 void MixtureFugacityTP::getCp_R_ref(span<double> cpr) const
 {
+    checkArraySize("MixtureFugacityTP::getCp_R_ref", cpr.size(), m_kk);
     copy(m_cp0_R.begin(), m_cp0_R.end(), cpr.begin());
 }
 
 void MixtureFugacityTP::getStandardVolumes_ref(span<double> vol) const
 {
+    checkArraySize("MixtureFugacityTP::getStandardVolumes_ref", vol.size(), m_kk);
     for (size_t i = 0; i < m_kk; i++) {
         vol[i]= RT() / refPressure();
     }

--- a/src/thermo/MolalityVPSSTP.cpp
+++ b/src/thermo/MolalityVPSSTP.cpp
@@ -59,7 +59,7 @@ double MolalityVPSSTP::moleFSolventMin() const
 
 void MolalityVPSSTP::calcMolalities() const
 {
-    getMoleFractions(m_molalities.data());
+    getMoleFractions(m_molalities);
     double xmolSolvent = std::max(m_molalities[0], m_xmolSolventMIN);
     double denomInv = 1.0/ (m_Mnaught * xmolSolvent);
     for (size_t k = 0; k < m_kk; k++) {
@@ -95,7 +95,7 @@ void MolalityVPSSTP::setMolalities(const double* const molal)
             m_molalities[k] *= tmp;
         }
     }
-    setMoleFractions(m_molalities.data());
+    setMoleFractions(m_molalities);
 
     // Essentially we don't trust the input: We calculate the molalities from
     // the mole fractions that we just obtained.
@@ -109,7 +109,7 @@ void MolalityVPSSTP::setMolalitiesByName(const Composition& mMap)
 
     // Get a vector of mole fractions
     vector<double> mf(m_kk, 0.0);
-    getMoleFractions(mf.data());
+    getMoleFractions(mf);
     double xmolSmin = std::max(mf[0], m_xmolSolventMIN);
     for (size_t k = 0; k < m_kk; k++) {
         double mol_k = getValue(mMap, speciesName(k), 0.0);
@@ -163,7 +163,7 @@ void MolalityVPSSTP::setMolalitiesByName(const Composition& mMap)
     for (size_t k = 0; k < m_kk; k++) {
         mf[k] *= sum;
     }
-    setMoleFractions(mf.data());
+    setMoleFractions(mf);
 
     // After we formally set the mole fractions, we calculate the molalities
     // again and store it in this object.
@@ -376,7 +376,7 @@ string MolalityVPSSTP::report(bool show_thermo, double threshold) const
         vector<double> muss(m_kk);
         vector<double> acMolal(m_kk);
         vector<double> actMolal(m_kk);
-        getMoleFractions(&x[0]);
+        getMoleFractions(x);
         getMolalities(&molal[0]);
         getChemPotentials(&mu[0]);
         getStandardChemPotentials(&muss[0]);

--- a/src/thermo/MolalityVPSSTP.cpp
+++ b/src/thermo/MolalityVPSSTP.cpp
@@ -67,7 +67,7 @@ void MolalityVPSSTP::calcMolalities() const
     }
 }
 
-void MolalityVPSSTP::getMolalities(double* const molal) const
+void MolalityVPSSTP::getMolalities(span<double> molal) const
 {
     calcMolalities();
     for (size_t k = 0; k < m_kk; k++) {
@@ -75,7 +75,7 @@ void MolalityVPSSTP::getMolalities(double* const molal) const
     }
 }
 
-void MolalityVPSSTP::setMolalities(const double* const molal)
+void MolalityVPSSTP::setMolalities(span<const double> molal)
 {
     double Lsum = 1.0 / m_Mnaught;
     for (size_t k = 1; k < m_kk; k++) {
@@ -183,7 +183,7 @@ int MolalityVPSSTP::activityConvention() const
     return cAC_CONVENTION_MOLALITY;
 }
 
-void MolalityVPSSTP::getActivityConcentrations(double* c) const
+void MolalityVPSSTP::getActivityConcentrations(span<double> c) const
 {
     throw NotImplementedError("MolalityVPSSTP::getActivityConcentrations");
 }
@@ -193,12 +193,12 @@ double MolalityVPSSTP::standardConcentration(size_t k) const
     throw NotImplementedError("MolalityVPSSTP::standardConcentration");
 }
 
-void MolalityVPSSTP::getActivities(double* ac) const
+void MolalityVPSSTP::getActivities(span<double> ac) const
 {
     throw NotImplementedError("MolalityVPSSTP::getActivities");
 }
 
-void MolalityVPSSTP::getActivityCoefficients(double* ac) const
+void MolalityVPSSTP::getActivityCoefficients(span<double> ac) const
 {
     getMolalityActivityCoefficients(ac);
     double xmolSolvent = std::max(moleFraction(0), m_xmolSolventMIN);
@@ -207,7 +207,7 @@ void MolalityVPSSTP::getActivityCoefficients(double* ac) const
     }
 }
 
-void MolalityVPSSTP::getMolalityActivityCoefficients(double* acMolality) const
+void MolalityVPSSTP::getMolalityActivityCoefficients(span<double> acMolality) const
 {
     getUnscaledMolalityActivityCoefficients(acMolality);
     applyphScale(acMolality);
@@ -217,7 +217,7 @@ double MolalityVPSSTP::osmoticCoefficient() const
 {
     // First, we calculate the activities all over again
     vector<double> act(m_kk);
-    getActivities(act.data());
+    getActivities(act);
 
     // Then, we calculate the sum of the solvent molalities
     double sum = 0;
@@ -231,7 +231,7 @@ double MolalityVPSSTP::osmoticCoefficient() const
     return oc;
 }
 
-void MolalityVPSSTP::setState_TPM(double t, double p, const double* const molalities)
+void MolalityVPSSTP::setState_TPM(double t, double p, span<const double> molalities)
 {
     setMolalities(molalities);
     setState_TP(t, p);
@@ -274,12 +274,12 @@ void MolalityVPSSTP::initThermo()
     m_indexCLM = findCLMIndex();
 }
 
-void MolalityVPSSTP::getUnscaledMolalityActivityCoefficients(double* acMolality) const
+void MolalityVPSSTP::getUnscaledMolalityActivityCoefficients(span<double> acMolality) const
 {
     throw NotImplementedError("MolalityVPSSTP::getUnscaledMolalityActivityCoefficients");
 }
 
-void MolalityVPSSTP::applyphScale(double* acMolality) const
+void MolalityVPSSTP::applyphScale(span<double> acMolality) const
 {
     throw NotImplementedError("MolalityVPSSTP::applyphScale");
 }
@@ -377,11 +377,11 @@ string MolalityVPSSTP::report(bool show_thermo, double threshold) const
         vector<double> acMolal(m_kk);
         vector<double> actMolal(m_kk);
         getMoleFractions(x);
-        getMolalities(&molal[0]);
-        getChemPotentials(&mu[0]);
-        getStandardChemPotentials(&muss[0]);
-        getMolalityActivityCoefficients(&acMolal[0]);
-        getActivities(&actMolal[0]);
+        getMolalities(molal);
+        getChemPotentials(mu);
+        getStandardChemPotentials(muss);
+        getMolalityActivityCoefficients(acMolal);
+        getActivities(actMolal);
 
         size_t iHp = speciesIndex("H+", false);
         if (iHp != npos) {

--- a/src/thermo/MolalityVPSSTP.cpp
+++ b/src/thermo/MolalityVPSSTP.cpp
@@ -69,6 +69,7 @@ void MolalityVPSSTP::calcMolalities() const
 
 void MolalityVPSSTP::getMolalities(span<double> molal) const
 {
+    checkArraySize("MolalityVPSSTP::getMolalities", molal.size(), m_kk);
     calcMolalities();
     for (size_t k = 0; k < m_kk; k++) {
         molal[k] = m_molalities[k];
@@ -77,6 +78,7 @@ void MolalityVPSSTP::getMolalities(span<double> molal) const
 
 void MolalityVPSSTP::setMolalities(span<const double> molal)
 {
+    checkArraySize("MolalityVPSSTP::setMolalities", molal.size(), m_kk);
     double Lsum = 1.0 / m_Mnaught;
     for (size_t k = 1; k < m_kk; k++) {
         m_molalities[k] = molal[k];

--- a/src/thermo/Mu0Poly.cpp
+++ b/src/thermo/Mu0Poly.cpp
@@ -20,7 +20,7 @@ Mu0Poly::Mu0Poly()
 {
 }
 
-Mu0Poly::Mu0Poly(double tlow, double thigh, double pref, const double* coeffs) :
+Mu0Poly::Mu0Poly(double tlow, double thigh, double pref, span<const double> coeffs) :
     SpeciesThermoInterpType(tlow, thigh, pref),
     m_numIntervals(0),
     m_H298(0.0)
@@ -99,11 +99,11 @@ void Mu0Poly::setParameters(double h0, const map<double, double>& T_mu)
     }
 }
 
-void Mu0Poly::updateProperties(const double* tt, double* cp_R,
-                               double* h_RT, double* s_R) const
+void Mu0Poly::updateProperties(span<const double> tt, double& cp_R,
+                               double& h_RT, double& s_R) const
 {
     size_t j = m_numIntervals;
-    double T = *tt;
+    double T = tt[0];
     for (size_t i = 0; i < m_numIntervals; i++) {
         double T2 = m_t0_int[i+1];
         if (T <=T2) {
@@ -113,17 +113,15 @@ void Mu0Poly::updateProperties(const double* tt, double* cp_R,
     }
     double T1 = m_t0_int[j];
     double cp_Rj = m_cp0_R_int[j];
-    *cp_R = cp_Rj;
-    *h_RT = (m_h0_R_int[j] + (T - T1) * cp_Rj)/T;
-    *s_R = m_s0_R_int[j] + cp_Rj * (log(T/T1));
+    cp_R = cp_Rj;
+    h_RT = (m_h0_R_int[j] + (T - T1) * cp_Rj)/T;
+    s_R = m_s0_R_int[j] + cp_Rj * (log(T/T1));
 }
 
-void Mu0Poly::updatePropertiesTemp(const double T,
-                                   double* cp_R,
-                                   double* h_RT,
-                                   double* s_R) const
+void Mu0Poly::updatePropertiesTemp(const double T, double& cp_R,
+                                   double& h_RT, double& s_R) const
 {
-    updateProperties(&T, cp_R, h_RT, s_R);
+    updateProperties(span<const double>(&T, 1), cp_R, h_RT, s_R);
 }
 
 size_t Mu0Poly::nCoeffs() const
@@ -132,7 +130,7 @@ size_t Mu0Poly::nCoeffs() const
 }
 
 void Mu0Poly::reportParameters(size_t& n, int& type, double& tlow, double& thigh,
-                               double& pref, double* const coeffs) const
+                               double& pref, span<double> coeffs) const
 {
     n = 0;
     type = MU0_INTERP;

--- a/src/thermo/Nasa9Poly1.cpp
+++ b/src/thermo/Nasa9Poly1.cpp
@@ -32,10 +32,7 @@ Nasa9Poly1::Nasa9Poly1(double tlow, double thigh, double pref,
 
 void Nasa9Poly1::setParameters(span<const double> coeffs)
 {
-    if (coeffs.size() != 9) {
-        throw CanteraError("Nasa9Poly1::setParameters", "Array must contain "
-            "9 coefficients, but {} were given.", coeffs.size());
-    }
+    checkArraySize("Nasa9Poly1::setParameters", coeffs.size(), 9);
     m_coeff.assign(coeffs.begin(), coeffs.end());
 }
 
@@ -90,6 +87,7 @@ void Nasa9Poly1::updatePropertiesTemp(const double temp, double& cp_R, double& h
 void Nasa9Poly1::reportParameters(size_t& n, int& type, double& tlow, double& thigh,
                                   double& pref, span<double> coeffs) const
 {
+    checkArraySize("Nasa9Poly1::reportParameters", coeffs.size(), 12);
     n = 0;
     type = NASA9;
     tlow = m_lowT;

--- a/src/thermo/Nasa9Poly1.cpp
+++ b/src/thermo/Nasa9Poly1.cpp
@@ -24,19 +24,19 @@ Nasa9Poly1::Nasa9Poly1()
 }
 
 Nasa9Poly1::Nasa9Poly1(double tlow, double thigh, double pref,
-                       const double* coeffs) :
+                       span<const double> coeffs) :
     SpeciesThermoInterpType(tlow, thigh, pref),
-    m_coeff(coeffs, coeffs + 9)
+    m_coeff(coeffs.begin(), coeffs.end())
 {
 }
 
-void Nasa9Poly1::setParameters(const vector<double> &coeffs)
+void Nasa9Poly1::setParameters(span<const double> coeffs)
 {
     if (coeffs.size() != 9) {
         throw CanteraError("Nasa9Poly1::setParameters", "Array must contain "
             "9 coefficients, but {} were given.", coeffs.size());
     }
-    m_coeff = coeffs;
+    m_coeff.assign(coeffs.begin(), coeffs.end());
 }
 
 int Nasa9Poly1::reportType() const
@@ -44,7 +44,7 @@ int Nasa9Poly1::reportType() const
     return NASA9;
 }
 
-void Nasa9Poly1::updateTemperaturePoly(double T, double* T_poly) const
+void Nasa9Poly1::updateTemperaturePoly(double T, span<double> T_poly) const
 {
     T_poly[0] = T;
     T_poly[1] = T * T;
@@ -55,8 +55,8 @@ void Nasa9Poly1::updateTemperaturePoly(double T, double* T_poly) const
     T_poly[6] = std::log(T);
 }
 
-void Nasa9Poly1::updateProperties(const double* tt, double* cp_R, double* h_RT,
-                                  double* s_R) const
+void Nasa9Poly1::updateProperties(span<const double> tt, double& cp_R,
+                                  double& h_RT, double& s_R) const
 {
 
     double ct0 = m_coeff[0] * tt[5]; // a0 / (T^2)
@@ -74,13 +74,13 @@ void Nasa9Poly1::updateProperties(const double* tt, double* cp_R, double* h_RT,
                        + 1.0/3.0*ct5 + 0.25*ct6 + m_coeff[8];
 
     // return the computed properties for this species
-    *cp_R = cpdivR;
-    *h_RT = hdivRT;
-    *s_R = sdivR;
+    cp_R = cpdivR;
+    h_RT = hdivRT;
+    s_R = sdivR;
 }
 
-void Nasa9Poly1::updatePropertiesTemp(const double temp, double* cp_R, double* h_RT,
-                                      double* s_R) const
+void Nasa9Poly1::updatePropertiesTemp(const double temp, double& cp_R, double& h_RT,
+                                      double& s_R) const
 {
     double tPoly[7];
     updateTemperaturePoly(temp, tPoly);
@@ -88,7 +88,7 @@ void Nasa9Poly1::updatePropertiesTemp(const double temp, double* cp_R, double* h
 }
 
 void Nasa9Poly1::reportParameters(size_t& n, int& type, double& tlow, double& thigh,
-                                  double& pref, double* const coeffs) const
+                                  double& pref, span<double> coeffs) const
 {
     n = 0;
     type = NASA9;

--- a/src/thermo/NasaPoly2.cpp
+++ b/src/thermo/NasaPoly2.cpp
@@ -10,8 +10,8 @@
 
 namespace Cantera {
 
-void NasaPoly2::setParameters(double Tmid, const vector<double>& low,
-                              const vector<double>& high) {
+void NasaPoly2::setParameters(double Tmid, span<const double> low,
+                              span<const double> high) {
     m_midT = Tmid;
     mnp_low.setMaxTemp(Tmid);
     mnp_high.setMinTemp(Tmid);
@@ -38,8 +38,8 @@ void NasaPoly2::validate(const string& name)
 
     double cp_low, h_low, s_low;
     double cp_high, h_high, s_high;
-    mnp_low.updatePropertiesTemp(m_midT, &cp_low, &h_low, &s_low);
-    mnp_high.updatePropertiesTemp(m_midT, &cp_high, &h_high, &s_high);
+    mnp_low.updatePropertiesTemp(m_midT, cp_low, h_low, s_low);
+    mnp_high.updatePropertiesTemp(m_midT, cp_high, h_high, s_high);
 
     double delta = cp_low - cp_high;
     if (fabs(delta/(fabs(cp_low)+1.0E-4)) > 0.01) {

--- a/src/thermo/PDSS_ConstVol.cpp
+++ b/src/thermo/PDSS_ConstVol.cpp
@@ -67,7 +67,7 @@ void PDSS_ConstVol::setPressure(double p)
 void PDSS_ConstVol::setTemperature(double temp)
 {
     m_temp = temp;
-    m_spthermo->updatePropertiesTemp(temp, &m_cp0_R, &m_h0_RT, &m_s0_R);
+    m_spthermo->updatePropertiesTemp(temp, m_cp0_R, m_h0_RT, m_s0_R);
     m_g0_RT = m_h0_RT - m_s0_R;
 
     double del_pRT = (m_pres - m_p0) / (GasConstant * m_temp);

--- a/src/thermo/PDSS_HKFT.cpp
+++ b/src/thermo/PDSS_HKFT.cpp
@@ -324,14 +324,14 @@ void PDSS_HKFT::setS0(double s0) {
     m_Entrop_tr_pr = m_units.convertFrom(s0, "J/kmol/K");
 }
 
-void PDSS_HKFT::set_a(double* a) {
+void PDSS_HKFT::set_a(span<const double> a) {
     m_a1 = m_units.convertFrom(a[0], "J/kmol/Pa");
     m_a2 = m_units.convertFrom(a[1], "J/kmol");
     m_a3 = m_units.convertFrom(a[2], "J*K/kmol/Pa");
     m_a4 = m_units.convertFrom(a[3], "J*K/kmol");
 }
 
-void PDSS_HKFT::set_c(double* c) {
+void PDSS_HKFT::set_c(span<const double> c) {
     m_c1 = m_units.convertFrom(c[0], "J/kmol/K");
     m_c2 = m_units.convertFrom(c[1], "J*K/kmol");
 }

--- a/src/thermo/PDSS_HKFT.cpp
+++ b/src/thermo/PDSS_HKFT.cpp
@@ -325,6 +325,7 @@ void PDSS_HKFT::setS0(double s0) {
 }
 
 void PDSS_HKFT::set_a(span<const double> a) {
+    checkArraySize("PDSS_HKFT::set_a", a.size(), 4);
     m_a1 = m_units.convertFrom(a[0], "J/kmol/Pa");
     m_a2 = m_units.convertFrom(a[1], "J/kmol");
     m_a3 = m_units.convertFrom(a[2], "J*K/kmol/Pa");
@@ -332,6 +333,7 @@ void PDSS_HKFT::set_a(span<const double> a) {
 }
 
 void PDSS_HKFT::set_c(span<const double> c) {
+    checkArraySize("PDSS_HKFT::set_c", c.size(), 2);
     m_c1 = m_units.convertFrom(c[0], "J/kmol/K");
     m_c2 = m_units.convertFrom(c[1], "J*K/kmol");
 }

--- a/src/thermo/PDSS_SSVol.cpp
+++ b/src/thermo/PDSS_SSVol.cpp
@@ -9,6 +9,7 @@
 
 #include "cantera/thermo/PDSS_SSVol.h"
 #include "cantera/thermo/VPStandardStateTP.h"
+#include <array>
 
 namespace Cantera
 {
@@ -18,14 +19,14 @@ PDSS_SSVol::PDSS_SSVol()
 {
 }
 
-void PDSS_SSVol::setVolumePolynomial(double* coeffs) {
+void PDSS_SSVol::setVolumePolynomial(span<const double> coeffs) {
     for (size_t i = 0; i < 4; i++) {
         TCoeff_[i] = coeffs[i];
     }
     volumeModel_ = SSVolume_Model::tpoly;
 }
 
-void PDSS_SSVol::setDensityPolynomial(double* coeffs) {
+void PDSS_SSVol::setDensityPolynomial(span<const double> coeffs) {
     for (size_t i = 0; i < 4; i++) {
         TCoeff_[i] = coeffs[i];
     }
@@ -59,7 +60,7 @@ void PDSS_SSVol::initThermo()
         const string& model = m_input["model"].asString();
         auto& data = m_input["data"].asVector<AnyValue>(4);
         if (model == "density-temperature-polynomial") {
-            double coeffs[] {
+            std::array coeffs{
                 m_input.units().convert(data[0], "kg/m^3"),
                 m_input.units().convert(data[1], "kg/m^3/K"),
                 m_input.units().convert(data[2], "kg/m^3/K^2"),
@@ -67,7 +68,7 @@ void PDSS_SSVol::initThermo()
             };
             setDensityPolynomial(coeffs);
         } else if (model == "molar-volume-temperature-polynomial") {
-            double coeffs[] {
+            std::array coeffs{
                 m_input.units().convert(data[0], "m^3/kmol"),
                 m_input.units().convert(data[1], "m^3/kmol/K"),
                 m_input.units().convert(data[2], "m^3/kmol/K^2"),

--- a/src/thermo/PDSS_SSVol.cpp
+++ b/src/thermo/PDSS_SSVol.cpp
@@ -135,7 +135,7 @@ void PDSS_SSVol::setPressure(double p)
 void PDSS_SSVol::setTemperature(double temp)
 {
     m_temp = temp;
-    m_spthermo->updatePropertiesTemp(temp, &m_cp0_R, &m_h0_RT, &m_s0_R);
+    m_spthermo->updatePropertiesTemp(temp, m_cp0_R, m_h0_RT, m_s0_R);
     calcMolarVolume();
     m_g0_RT = m_h0_RT - m_s0_R;
     double deltaP = m_pres - m_p0;

--- a/src/thermo/PDSS_SSVol.cpp
+++ b/src/thermo/PDSS_SSVol.cpp
@@ -20,6 +20,7 @@ PDSS_SSVol::PDSS_SSVol()
 }
 
 void PDSS_SSVol::setVolumePolynomial(span<const double> coeffs) {
+    checkArraySize("PDSS_SSVol::setVolumePolynomial", coeffs.size(), 4);
     for (size_t i = 0; i < 4; i++) {
         TCoeff_[i] = coeffs[i];
     }
@@ -27,6 +28,7 @@ void PDSS_SSVol::setVolumePolynomial(span<const double> coeffs) {
 }
 
 void PDSS_SSVol::setDensityPolynomial(span<const double> coeffs) {
+    checkArraySize("PDSS_SSVol::setDensityPolynomial", coeffs.size(), 4);
     for (size_t i = 0; i < 4; i++) {
         TCoeff_[i] = coeffs[i];
     }

--- a/src/thermo/PengRobinson.cpp
+++ b/src/thermo/PengRobinson.cpp
@@ -114,11 +114,11 @@ double PengRobinson::pressure() const
 
 double PengRobinson::standardConcentration(size_t k) const
 {
-    getStandardVolumes(m_workS.data());
+    getStandardVolumes(m_workS);
     return 1.0 / m_workS[k];
 }
 
-void PengRobinson::getActivityCoefficients(double* ac) const
+void PengRobinson::getActivityCoefficients(span<double> ac) const
 {
     double mv = molarVolume();
     double vpb2 = mv + (1 + Sqrt2) * m_b;
@@ -151,7 +151,7 @@ void PengRobinson::getActivityCoefficients(double* ac) const
 
 // ---- Partial Molar Properties of the Solution -----------------
 
-void PengRobinson::getChemPotentials(double* mu) const
+void PengRobinson::getChemPotentials(span<double> mu) const
 {
     getGibbs_ref(mu);
     double RT_ = RT();
@@ -186,11 +186,11 @@ void PengRobinson::getChemPotentials(double* mu) const
     }
 }
 
-void PengRobinson::getPartialMolarEnthalpies(double* hbar) const
+void PengRobinson::getPartialMolarEnthalpies(span<double> hbar) const
 {
     // First we get the reference state contributions
     getEnthalpy_RT_ref(hbar);
-    scale(hbar, hbar+m_kk, hbar, RT());
+    scale(hbar.begin(), hbar.end(), hbar.begin(), RT());
     vector<double> tmp;
     tmp.resize(m_kk,0.0);
 
@@ -236,34 +236,34 @@ void PengRobinson::getPartialMolarEnthalpies(double* hbar) const
     }
 }
 
-void PengRobinson::getPartialMolarEntropies(double* sbar) const
+void PengRobinson::getPartialMolarEntropies(span<double> sbar) const
 {
     // Using the identity : (hk - T*sk) = gk
     double T = temperature();
     getPartialMolarEnthalpies(sbar);
-    getChemPotentials(m_workS.data());
+    getChemPotentials(m_workS);
     for (size_t k = 0; k < m_kk; k++) {
         sbar[k] = (sbar[k] - m_workS[k])/T;
     }
 }
 
-void PengRobinson::getPartialMolarIntEnergies(double* ubar) const
+void PengRobinson::getPartialMolarIntEnergies(span<double> ubar) const
 {
     // u_i = h_i - p*v_i
     double p = pressure();
     getPartialMolarEnthalpies(ubar);
-    getPartialMolarVolumes(m_workS.data());
+    getPartialMolarVolumes(m_workS);
     for (size_t k = 0; k < m_kk; k++) {
         ubar[k] = ubar[k] - p*m_workS[k];
     }
 }
 
-void PengRobinson::getPartialMolarCp(double* cpbar) const
+void PengRobinson::getPartialMolarCp(span<double> cpbar) const
 {
     throw NotImplementedError("PengRobinson::getPartialMolarCp");
 }
 
-void PengRobinson::getPartialMolarVolumes(double* vbar) const
+void PengRobinson::getPartialMolarVolumes(span<double> vbar) const
 {
     for (size_t k = 0; k < m_kk; k++) {
         m_pp[k] = 0.0;

--- a/src/thermo/PengRobinson.cpp
+++ b/src/thermo/PengRobinson.cpp
@@ -120,6 +120,7 @@ double PengRobinson::standardConcentration(size_t k) const
 
 void PengRobinson::getActivityCoefficients(span<double> ac) const
 {
+    checkArraySize("PengRobinson::getActivityCoefficients", ac.size(), m_kk);
     double mv = molarVolume();
     double vpb2 = mv + (1 + Sqrt2) * m_b;
     double vmb2 = mv + (1 - Sqrt2) * m_b;
@@ -265,6 +266,7 @@ void PengRobinson::getPartialMolarCp(span<double> cpbar) const
 
 void PengRobinson::getPartialMolarVolumes(span<double> vbar) const
 {
+    checkArraySize("PengRobinson::getPartialMolarVolumes", vbar.size(), m_kk);
     for (size_t k = 0; k < m_kk; k++) {
         m_pp[k] = 0.0;
         for (size_t i = 0; i < m_kk; i++) {

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -224,10 +224,7 @@ vector<string> Phase::partialStates() const
 
 void Phase::savePartialState(span<double> state) const
 {
-    if (state.size() < partialStateSize()) {
-        throw ArraySizeError("Phase::savePartialState", state.size(), partialStateSize());
-    }
-
+    checkArraySize("Phase::savePartialState", state.size(), partialStateSize());
     auto native = nativeState();
     state[native.at("T")] = temperature();
     if (isCompressible()) {
@@ -239,10 +236,7 @@ void Phase::savePartialState(span<double> state) const
 
 void Phase::restorePartialState(span<const double> state)
 {
-    if (state.size() < partialStateSize()) {
-        throw ArraySizeError("Phase::restorePartialState", state.size(), partialStateSize());
-    }
-
+    checkArraySize("Phase::restorePartialState", state.size(), partialStateSize());
     auto native = nativeState();
     setTemperature(state[native.at("T")]);
     if (isCompressible()) {
@@ -262,9 +256,7 @@ size_t Phase::stateSize() const {
 
 void Phase::saveState(span<double> state) const
 {
-    if (state.size() < stateSize()) {
-        throw ArraySizeError("Phase::saveState", state.size(), stateSize());
-    }
+    checkArraySize("Phase::saveState", state.size(), stateSize());
     savePartialState(state);
     auto native = nativeState();
     if (native.count("X")) {
@@ -276,13 +268,8 @@ void Phase::saveState(span<double> state) const
 
 void Phase::restoreState(span<const double> state)
 {
-    size_t ls = stateSize();
-    if (state.size() < ls) {
-        throw ArraySizeError("Phase::restoreState",
-                             state.size(), ls);
-    }
+    checkArraySize("Phase::restoreState", state.size(), stateSize());
     restorePartialState(state);
-
     auto native = nativeState();
 
     if (native.count("X")) {
@@ -295,9 +282,7 @@ void Phase::restoreState(span<const double> state)
 
 void Phase::setMoleFractions(span<const double> x)
 {
-    if (x.size() < m_kk) {
-        throw ArraySizeError("Phase::setMoleFractions", x.size(), m_kk);
-    }
+    checkArraySize("Phase::setMoleFractions", x.size(), m_kk);
     // Use m_y as a temporary work vector for the non-negative mole fractions
     double norm = 0.0;
     // sum is calculated below as the unnormalized molecular weight
@@ -330,9 +315,7 @@ void Phase::setMoleFractions(span<const double> x)
 
 void Phase::setMoleFractions_NoNorm(span<const double> x)
 {
-    if (x.size() < m_kk) {
-        throw ArraySizeError("Phase::setMoleFractions_NoNorm", x.size(), m_kk);
-    }
+    checkArraySize("Phase::setMoleFractions_NoNorm", x.size(), m_kk);
     m_mmw = dot(x.begin(), x.begin() + m_kk, m_molwts.begin());
     scale(x.begin(), x.begin() + m_kk, m_ym.begin(), 1.0/m_mmw);
     transform(m_ym.begin(), m_ym.begin() + m_kk, m_molwts.begin(),
@@ -353,9 +336,7 @@ void Phase::setMoleFractionsByName(const string& x)
 
 void Phase::setMassFractions(span<const double> y)
 {
-    if (y.size() < m_kk) {
-        throw ArraySizeError("Phase::setMassFractions", y.size(), m_kk);
-    }
+    checkArraySize("Phase::setMassFractions", y.size(), m_kk);
     for (size_t k = 0; k < m_kk; k++) {
         m_y[k] = std::max(y[k], 0.0); // Ignore negative mass fractions
     }
@@ -370,10 +351,8 @@ void Phase::setMassFractions(span<const double> y)
 
 void Phase::setMassFractions_NoNorm(span<const double> y)
 {
+    checkArraySize("Phase::setMassFractions_NoNorm", y.size(), m_kk);
     double sum = 0.0;
-    if (y.size() < m_kk) {
-        throw ArraySizeError("Phase::setMassFractions_NoNorm", y.size(), m_kk);
-    }
     copy(y.begin(), y.begin() + m_kk, m_y.begin());
     transform(m_y.begin(), m_y.end(), m_rmolwts.begin(), m_ym.begin(),
               multiplies<double>());
@@ -415,9 +394,7 @@ double Phase::molecularWeight(size_t k) const
 void Phase::getMolecularWeights(span<double> weights) const
 {
     auto mw = molecularWeights();
-    if (weights.size() < mw.size()) {
-        throw ArraySizeError("Phase::getMolecularWeights", weights.size(), mw.size());
-    }
+    checkArraySize("Phase::getMolecularWeights", weights.size(), mw.size());
     copy(mw.begin(), mw.end(), weights.begin());
 }
 
@@ -433,9 +410,7 @@ span<const double> Phase::inverseMolecularWeights() const
 
 void Phase::getCharges(span<double> charges) const
 {
-    if (charges.size() < m_speciesCharge.size()) {
-        throw ArraySizeError("Phase::getCharges", charges.size(), m_speciesCharge.size());
-    }
+    checkArraySize("Phase::getCharges", charges.size(), m_speciesCharge.size());
     copy(m_speciesCharge.begin(), m_speciesCharge.end(), charges.begin());
 }
 
@@ -465,9 +440,7 @@ Composition Phase::getMassFractionsByName(double threshold) const
 
 void Phase::getMoleFractions(span<double> x) const
 {
-    if (x.size() < m_kk) {
-        throw ArraySizeError("Phase::getMoleFractions", x.size(), m_kk);
-    }
+    checkArraySize("Phase::getMoleFractions", x.size(), m_kk);
     scale(m_ym.begin(), m_ym.end(), x.begin(), m_mmw);
 }
 
@@ -505,9 +478,7 @@ double Phase::massFraction(const string& nameSpec) const
 
 void Phase::getMassFractions(span<double> y) const
 {
-    if (y.size() < m_kk) {
-        throw ArraySizeError("Phase::getMassFractions", y.size(), m_kk);
-    }
+    checkArraySize("Phase::getMassFractions", y.size(), m_kk);
     copy(m_y.begin(), m_y.end(), y.begin());
 }
 
@@ -519,18 +490,14 @@ double Phase::concentration(const size_t k) const
 
 void Phase::getConcentrations(span<double> c) const
 {
-    if (c.size() < m_kk) {
-        throw ArraySizeError("Phase::getConcentrations", c.size(), m_kk);
-    }
+    checkArraySize("Phase::getConcentrations", c.size(), m_kk);
     scale(m_ym.begin(), m_ym.end(), c.begin(), m_dens);
 }
 
 void Phase::setConcentrations(span<const double> conc)
 {
     assertCompressible("setConcentrations");
-    if (conc.size() < m_kk) {
-        throw ArraySizeError("Phase::setConcentrations", conc.size(), m_kk);
-    }
+    checkArraySize("Phase::setConcentrations", conc.size(), m_kk);
 
     // Use m_y as temporary storage for non-negative concentrations
     double sum = 0.0, norm = 0.0;
@@ -553,9 +520,7 @@ void Phase::setConcentrations(span<const double> conc)
 void Phase::setConcentrationsNoNorm(span<const double> conc)
 {
     assertCompressible("setConcentrationsNoNorm");
-    if (conc.size() < m_kk) {
-        throw ArraySizeError("Phase::setConcentrationsNoNorm", conc.size(), m_kk);
-    }
+    checkArraySize("Phase::setConcentrationsNoNorm", conc.size(), m_kk);
 
     double sum = 0.0, norm = 0.0;
     for (size_t k = 0; k != m_kk; ++k) {
@@ -574,9 +539,7 @@ void Phase::setConcentrationsNoNorm(span<const double> conc)
 
 void Phase::setMolesNoTruncate(span<const double> N)
 {
-    if (N.size() < m_kk) {
-        throw ArraySizeError("Phase::setMolesNoTruncate", N.size(), m_kk);
-    }
+    checkArraySize("Phase::setMolesNoTruncate", N.size(), m_kk);
     // get total moles
     copy(N.begin(), N.begin() + m_kk, m_ym.begin());
     double totalMoles = accumulate(m_ym.begin(), m_ym.end(), 0.0);
@@ -663,6 +626,7 @@ double Phase::chargeDensity() const
 
 double Phase::mean_X(span<const double> Q) const
 {
+    checkArraySize("Phase::mean_X", Q.size(), m_kk);
     return m_mmw*std::inner_product(m_ym.begin(), m_ym.end(), Q.begin(), 0.0);
 }
 
@@ -974,6 +938,8 @@ vector<double> Phase::getCompositionFromMap(const Composition& comp) const
 
 void Phase::massFractionsToMoleFractions(span<const double> Y, span<double> X) const
 {
+    checkArraySize("Phase::massFractionsToMoleFractions", Y.size(), m_kk);
+    checkArraySize("Phase::massFractionsToMoleFractions", X.size(), m_kk);
     double rmmw = 0.0;
     for (size_t k = 0; k != m_kk; ++k) {
         rmmw += Y[k]/m_molwts[k];
@@ -989,6 +955,8 @@ void Phase::massFractionsToMoleFractions(span<const double> Y, span<double> X) c
 
 void Phase::moleFractionsToMassFractions(span<const double> X, span<double> Y) const
 {
+    checkArraySize("Phase::moleFractionsToMassFractions", X.size(), m_kk);
+    checkArraySize("Phase::moleFractionsToMassFractions", Y.size(), m_kk);
     double mmw = dot(m_molwts.begin(), m_molwts.end(), X.begin());
     if (mmw == 0.0) {
         throw CanteraError("Phase::moleFractionsToMassFractions",

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -76,7 +76,7 @@ double Phase::entropyElement298(size_t m) const
     return m_entropy298[checkElementIndex(m)];
 }
 
-const vector<double>& Phase::atomicWeights() const
+span<const double> Phase::atomicWeights() const
 {
     return m_atomicWeights;
 }
@@ -414,16 +414,16 @@ double Phase::molecularWeight(size_t k) const
 
 void Phase::getMolecularWeights(double* weights) const
 {
-    const vector<double>& mw = molecularWeights();
+    auto mw = molecularWeights();
     copy(mw.begin(), mw.end(), weights);
 }
 
-const vector<double>& Phase::molecularWeights() const
+span<const double> Phase::molecularWeights() const
 {
     return m_molwts;
 }
 
-const vector<double>& Phase::inverseMolecularWeights() const
+span<const double> Phase::inverseMolecularWeights() const
 {
     return m_rmolwts;
 }
@@ -768,7 +768,7 @@ bool Phase::addSpecies(shared_ptr<Species> spec)
     }
 
     size_t ne = nElements();
-    const vector<double>& aw = atomicWeights();
+    auto aw = atomicWeights();
     if (spec->charge != 0.0) {
         size_t eindex = elementIndex("E", false);
         if (eindex != npos) {

--- a/src/thermo/PlasmaPhase.cpp
+++ b/src/thermo/PlasmaPhase.cpp
@@ -617,7 +617,7 @@ void PlasmaPhase::updateThermo() const
     // properties were computed, recompute them.
     if (cached.state1 != tempNow || cached.state2 != electronTempNow) {
         m_spthermo.update_single(k, electronTemperature(),
-                &m_cp0_R[k], &m_h0_RT[k], &m_s0_R[k]);
+                m_cp0_R[k], m_h0_RT[k], m_s0_R[k]);
         cached.state1 = tempNow;
         cached.state2 = electronTempNow;
     }

--- a/src/thermo/PlasmaPhase.cpp
+++ b/src/thermo/PlasmaPhase.cpp
@@ -636,7 +636,7 @@ double PlasmaPhase::enthalpy_mole() const {
 double PlasmaPhase::intEnergy_mole() const
 {
     m_work.resize(m_kk);
-    getPartialMolarIntEnergies(m_work.data());
+    getPartialMolarIntEnergies(m_work);
     double u = 0.0;
     for (size_t k = 0; k < m_kk; ++k) {
         u += moleFraction(k) * m_work[k];
@@ -647,7 +647,7 @@ double PlasmaPhase::intEnergy_mole() const
 double PlasmaPhase::entropy_mole() const
 {
     m_work.resize(m_kk);
-    getPartialMolarEntropies(m_work.data());
+    getPartialMolarEntropies(m_work);
     double s = 0.0;
     for (size_t k = 0; k < m_kk; ++k) {
         s += moleFraction(k) * m_work[k];
@@ -658,7 +658,7 @@ double PlasmaPhase::entropy_mole() const
 double PlasmaPhase::gibbs_mole() const
 {
     m_work.resize(m_kk);
-    getChemPotentials(m_work.data());
+    getChemPotentials(m_work);
     double g = 0.0;
     for (size_t k = 0; k < m_kk; ++k) {
         g += moleFraction(k) * m_work[k];
@@ -666,25 +666,25 @@ double PlasmaPhase::gibbs_mole() const
     return g;
 }
 
-void PlasmaPhase::getGibbs_ref(double* g) const
+void PlasmaPhase::getGibbs_ref(span<double> g) const
 {
     IdealGasPhase::getGibbs_ref(g);
     g[m_electronSpeciesIndex] *= electronTemperature() / temperature();
 }
 
-void PlasmaPhase::getStandardVolumes_ref(double* vol) const
+void PlasmaPhase::getStandardVolumes_ref(span<double> vol) const
 {
     IdealGasPhase::getStandardVolumes_ref(vol);
     vol[m_electronSpeciesIndex] *= electronTemperature() / temperature();
 }
 
-void PlasmaPhase::getPartialMolarEnthalpies(double* hbar) const
+void PlasmaPhase::getPartialMolarEnthalpies(span<double> hbar) const
 {
     IdealGasPhase::getPartialMolarEnthalpies(hbar);
     hbar[m_electronSpeciesIndex] *= electronTemperature() / temperature();
 }
 
-void PlasmaPhase::getPartialMolarEntropies(double* sbar) const
+void PlasmaPhase::getPartialMolarEntropies(span<double> sbar) const
 {
     IdealGasPhase::getPartialMolarEntropies(sbar);
     double logp = log(pressure());
@@ -692,7 +692,7 @@ void PlasmaPhase::getPartialMolarEntropies(double* sbar) const
     sbar[m_electronSpeciesIndex] += GasConstant * (logp - logpe);
 }
 
-void PlasmaPhase::getPartialMolarIntEnergies(double* ubar) const
+void PlasmaPhase::getPartialMolarIntEnergies(span<double> ubar) const
 {
     const vector<double>& _h = enthalpy_RT_ref();
     for (size_t k = 0; k < m_kk; k++) {
@@ -702,7 +702,7 @@ void PlasmaPhase::getPartialMolarIntEnergies(double* ubar) const
     ubar[k] = RTe() * (_h[k] - 1.0);
 }
 
-void PlasmaPhase::getChemPotentials(double* mu) const
+void PlasmaPhase::getChemPotentials(span<double> mu) const
 {
     IdealGasPhase::getChemPotentials(mu);
     size_t k = m_electronSpeciesIndex;
@@ -710,7 +710,7 @@ void PlasmaPhase::getChemPotentials(double* mu) const
     mu[k] += (RTe() - RT()) * log(xx);
 }
 
-void PlasmaPhase::getStandardChemPotentials(double* muStar) const
+void PlasmaPhase::getStandardChemPotentials(span<double> muStar) const
 {
     IdealGasPhase::getStandardChemPotentials(muStar);
     size_t k = m_electronSpeciesIndex;
@@ -718,10 +718,10 @@ void PlasmaPhase::getStandardChemPotentials(double* muStar) const
     muStar[k] += log(electronPressure() / refPressure()) * RTe();
 }
 
-void PlasmaPhase::getEntropy_R(double* sr) const
+void PlasmaPhase::getEntropy_R(span<double> sr) const
 {
     const vector<double>& _s = entropy_R_ref();
-    copy(_s.begin(), _s.end(), sr);
+    copy(_s.begin(), _s.end(), sr.begin());
     double tmp = log(pressure() / refPressure());
     for (size_t k = 0; k < m_kk; k++) {
         if (k != m_electronSpeciesIndex) {
@@ -732,10 +732,10 @@ void PlasmaPhase::getEntropy_R(double* sr) const
     }
 }
 
-void PlasmaPhase::getGibbs_RT(double* grt) const
+void PlasmaPhase::getGibbs_RT(span<double> grt) const
 {
     const vector<double>& gibbsrt = gibbs_RT_ref();
-    copy(gibbsrt.begin(), gibbsrt.end(), grt);
+    copy(gibbsrt.begin(), gibbsrt.end(), grt.begin());
     double tmp = log(pressure() / refPressure());
     for (size_t k = 0; k < m_kk; k++) {
         if (k != m_electronSpeciesIndex) {

--- a/src/thermo/PlasmaPhase.cpp
+++ b/src/thermo/PlasmaPhase.cpp
@@ -692,6 +692,7 @@ void PlasmaPhase::getPartialMolarEntropies(span<double> sbar) const
 
 void PlasmaPhase::getPartialMolarIntEnergies(span<double> ubar) const
 {
+    checkArraySize("PlasmaPhase::getPartialMolarIntEnergies", ubar.size(), m_kk);
     auto _h = enthalpy_RT_ref();
     for (size_t k = 0; k < m_kk; k++) {
         ubar[k] = RT() * (_h[k] - 1.0);
@@ -718,6 +719,7 @@ void PlasmaPhase::getStandardChemPotentials(span<double> muStar) const
 
 void PlasmaPhase::getEntropy_R(span<double> sr) const
 {
+    checkArraySize("PlasmaPhase::getEntropy_R", sr.size(), m_kk);
     auto _s = entropy_R_ref();
     copy(_s.begin(), _s.end(), sr.begin());
     double tmp = log(pressure() / refPressure());
@@ -732,6 +734,7 @@ void PlasmaPhase::getEntropy_R(span<double> sr) const
 
 void PlasmaPhase::getGibbs_RT(span<double> grt) const
 {
+    checkArraySize("PlasmaPhase::getGibbs_RT", grt.size(), m_kk);
     auto gibbsrt = gibbs_RT_ref();
     copy(gibbsrt.begin(), gibbsrt.end(), grt.begin());
     double tmp = log(pressure() / refPressure());

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -163,26 +163,31 @@ tpx::Substance& PureFluidPhase::TPX_Substance()
 
 void PureFluidPhase::getPartialMolarEnthalpies(span<double> hbar) const
 {
+    checkArraySize("PureFluidPhase::getPartialMolarEnthalpies", hbar.size(), 1);
     hbar[0] = enthalpy_mole();
 }
 
 void PureFluidPhase::getPartialMolarEntropies(span<double> sbar) const
 {
+    checkArraySize("PureFluidPhase::getPartialMolarEntropies", sbar.size(), 1);
     sbar[0] = entropy_mole();
 }
 
 void PureFluidPhase::getPartialMolarIntEnergies(span<double> ubar) const
 {
+    checkArraySize("PureFluidPhase::getPartialMolarIntEnergies", ubar.size(), 1);
     ubar[0] = intEnergy_mole();
 }
 
 void PureFluidPhase::getPartialMolarCp(span<double> cpbar) const
 {
+    checkArraySize("PureFluidPhase::getPartialMolarCp", cpbar.size(), 1);
     cpbar[0] = cp_mole();
 }
 
 void PureFluidPhase::getPartialMolarVolumes(span<double> vbar) const
 {
+    checkArraySize("PureFluidPhase::getPartialMolarVolumes", vbar.size(), 1);
     vbar[0] = 1.0 / molarDensity();
 }
 
@@ -193,6 +198,7 @@ Units PureFluidPhase::standardConcentrationUnits() const
 
 void PureFluidPhase::getActivityConcentrations(span<double> c) const
 {
+    checkArraySize("PureFluidPhase::getActivityConcentrations", c.size(), 1);
     c[0] = 1.0;
 }
 
@@ -203,26 +209,31 @@ double PureFluidPhase::standardConcentration(size_t k) const
 
 void PureFluidPhase::getActivities(span<double> a) const
 {
+    checkArraySize("PureFluidPhase::getActivities", a.size(), 1);
     a[0] = 1.0;
 }
 
 void PureFluidPhase::getStandardChemPotentials(span<double> mu) const
 {
+    checkArraySize("PureFluidPhase::getStandardChemPotentials", mu.size(), 1);
     mu[0] = gibbs_mole();
 }
 
 void PureFluidPhase::getEnthalpy_RT(span<double> hrt) const
 {
+    checkArraySize("PureFluidPhase::getEnthalpy_RT", hrt.size(), 1);
     hrt[0] = enthalpy_mole() / RT();
 }
 
 void PureFluidPhase::getEntropy_R(span<double> sr) const
 {
+    checkArraySize("PureFluidPhase::getEntropy_R", sr.size(), 1);
     sr[0] = entropy_mole() / GasConstant;
 }
 
 void PureFluidPhase::getGibbs_RT(span<double> grt) const
 {
+    checkArraySize("PureFluidPhase::getGibbs_RT", grt.size(), 1);
     grt[0] = gibbs_mole() / RT();
 }
 

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -40,7 +40,7 @@ void PureFluidPhase::initThermo()
     p = 0.001 * p;
     m_sub->Set(tpx::PropertyPair::TP, T0, p);
 
-    m_spthermo.update_single(0, T0, &cp0_R, &h0_RT, &s0_R);
+    m_spthermo.update_single(0, T0, cp0_R, h0_RT, s0_R);
     double s_R = s0_R - log(p/refPressure());
     m_sub->setStdState(h0_RT*GasConstant*298.15/m_mw,
                        s_R*GasConstant/m_mw, T0, p);

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -161,27 +161,27 @@ tpx::Substance& PureFluidPhase::TPX_Substance()
     return *m_sub;
 }
 
-void PureFluidPhase::getPartialMolarEnthalpies(double* hbar) const
+void PureFluidPhase::getPartialMolarEnthalpies(span<double> hbar) const
 {
     hbar[0] = enthalpy_mole();
 }
 
-void PureFluidPhase::getPartialMolarEntropies(double* sbar) const
+void PureFluidPhase::getPartialMolarEntropies(span<double> sbar) const
 {
     sbar[0] = entropy_mole();
 }
 
-void PureFluidPhase::getPartialMolarIntEnergies(double* ubar) const
+void PureFluidPhase::getPartialMolarIntEnergies(span<double> ubar) const
 {
     ubar[0] = intEnergy_mole();
 }
 
-void PureFluidPhase::getPartialMolarCp(double* cpbar) const
+void PureFluidPhase::getPartialMolarCp(span<double> cpbar) const
 {
     cpbar[0] = cp_mole();
 }
 
-void PureFluidPhase::getPartialMolarVolumes(double* vbar) const
+void PureFluidPhase::getPartialMolarVolumes(span<double> vbar) const
 {
     vbar[0] = 1.0 / molarDensity();
 }
@@ -191,7 +191,7 @@ Units PureFluidPhase::standardConcentrationUnits() const
     return Units(1.0);
 }
 
-void PureFluidPhase::getActivityConcentrations(double* c) const
+void PureFluidPhase::getActivityConcentrations(span<double> c) const
 {
     c[0] = 1.0;
 }
@@ -201,32 +201,32 @@ double PureFluidPhase::standardConcentration(size_t k) const
     return 1.0;
 }
 
-void PureFluidPhase::getActivities(double* a) const
+void PureFluidPhase::getActivities(span<double> a) const
 {
     a[0] = 1.0;
 }
 
-void PureFluidPhase::getStandardChemPotentials(double* mu) const
+void PureFluidPhase::getStandardChemPotentials(span<double> mu) const
 {
     mu[0] = gibbs_mole();
 }
 
-void PureFluidPhase::getEnthalpy_RT(double* hrt) const
+void PureFluidPhase::getEnthalpy_RT(span<double> hrt) const
 {
     hrt[0] = enthalpy_mole() / RT();
 }
 
-void PureFluidPhase::getEntropy_R(double* sr) const
+void PureFluidPhase::getEntropy_R(span<double> sr) const
 {
     sr[0] = entropy_mole() / GasConstant;
 }
 
-void PureFluidPhase::getGibbs_RT(double* grt) const
+void PureFluidPhase::getGibbs_RT(span<double> grt) const
 {
     grt[0] = gibbs_mole() / RT();
 }
 
-void PureFluidPhase::getEnthalpy_RT_ref(double* hrt) const
+void PureFluidPhase::getEnthalpy_RT_ref(span<double> hrt) const
 {
     double rhoSave = density();
     double t = temperature();
@@ -237,7 +237,7 @@ void PureFluidPhase::getEnthalpy_RT_ref(double* hrt) const
 
 }
 
-void PureFluidPhase::getGibbs_RT_ref(double* grt) const
+void PureFluidPhase::getGibbs_RT_ref(span<double> grt) const
 {
     double rhoSave = density();
     double t = temperature();
@@ -249,13 +249,13 @@ void PureFluidPhase::getGibbs_RT_ref(double* grt) const
     Set(tpx::PropertyPair::TV, t, 1 / rhoSave);
 }
 
-void PureFluidPhase::getGibbs_ref(double* g) const
+void PureFluidPhase::getGibbs_ref(span<double> g) const
 {
     getGibbs_RT_ref(g);
     g[0] *= RT();
 }
 
-void PureFluidPhase::getEntropy_R_ref(double* er) const
+void PureFluidPhase::getEntropy_R_ref(span<double> er) const
 {
     double rhoSave = density();
     double t = temperature();

--- a/src/thermo/RedlichKisterVPSSTP.cpp
+++ b/src/thermo/RedlichKisterVPSSTP.cpp
@@ -26,6 +26,7 @@ RedlichKisterVPSSTP::RedlichKisterVPSSTP(const string& inputFile, const string& 
 
 void RedlichKisterVPSSTP::getLnActivityCoefficients(span<double> lnac) const
 {
+    checkArraySize("RedlichKisterVPSSTP::getLnActivityCoefficients", lnac.size(), m_kk);
     // Update the activity coefficients
     s_update_lnActCoeff();
 
@@ -249,6 +250,7 @@ void RedlichKisterVPSSTP::s_update_dlnActCoeff_dT() const
 
 void RedlichKisterVPSSTP::getdlnActCoeffdT(span<double> dlnActCoeffdT) const
 {
+    checkArraySize("RedlichKisterVPSSTP::getdlnActCoeffdT", dlnActCoeffdT.size(), m_kk);
     s_update_dlnActCoeff_dT();
     for (size_t k = 0; k < m_kk; k++) {
         dlnActCoeffdT[k] = dlnActCoeffdT_Scaled_[k];
@@ -257,6 +259,8 @@ void RedlichKisterVPSSTP::getdlnActCoeffdT(span<double> dlnActCoeffdT) const
 
 void RedlichKisterVPSSTP::getd2lnActCoeffdT2(span<double> d2lnActCoeffdT2) const
 {
+    checkArraySize("RedlichKisterVPSSTP::getd2lnActCoeffdT2",
+                   d2lnActCoeffdT2.size(), m_kk);
     s_update_dlnActCoeff_dT();
     for (size_t k = 0; k < m_kk; k++) {
         d2lnActCoeffdT2[k] = d2lnActCoeffdT2_Scaled_[k];
@@ -377,6 +381,8 @@ void RedlichKisterVPSSTP::s_update_dlnActCoeff_dX_() const
 void RedlichKisterVPSSTP::getdlnActCoeffds(const double dTds, span<const double> const dXds,
         span<double> dlnActCoeffds) const
 {
+    checkArraySize("RedlichKisterVPSSTP::getdlnActCoeffds", dXds.size(), m_kk);
+    checkArraySize("RedlichKisterVPSSTP::getdlnActCoeffds", dlnActCoeffds.size(), m_kk);
     s_update_dlnActCoeff_dT();
     s_update_dlnActCoeff_dX_();
     for (size_t k = 0; k < m_kk; k++) {
@@ -389,6 +395,8 @@ void RedlichKisterVPSSTP::getdlnActCoeffds(const double dTds, span<const double>
 
 void RedlichKisterVPSSTP::getdlnActCoeffdlnN_diag(span<double> dlnActCoeffdlnN_diag) const
 {
+    checkArraySize("RedlichKisterVPSSTP::getdlnActCoeffdlnN_diag",
+                   dlnActCoeffdlnN_diag.size(), m_kk);
     s_update_dlnActCoeff_dX_();
     for (size_t j = 0; j < m_kk; j++) {
         dlnActCoeffdlnN_diag[j] = dlnActCoeff_dX_(j, j);
@@ -400,6 +408,8 @@ void RedlichKisterVPSSTP::getdlnActCoeffdlnN_diag(span<double> dlnActCoeffdlnN_d
 
 void RedlichKisterVPSSTP::getdlnActCoeffdlnX_diag(span<double> dlnActCoeffdlnX_diag) const
 {
+    checkArraySize("RedlichKisterVPSSTP::getdlnActCoeffdlnX_diag",
+                   dlnActCoeffdlnX_diag.size(), m_kk);
     s_update_dlnActCoeff_dlnX_diag();
     for (size_t k = 0; k < m_kk; k++) {
         dlnActCoeffdlnX_diag[k] = dlnActCoeffdlnX_diag_[k];
@@ -408,6 +418,8 @@ void RedlichKisterVPSSTP::getdlnActCoeffdlnX_diag(span<double> dlnActCoeffdlnX_d
 
 void RedlichKisterVPSSTP::getdlnActCoeffdlnN(const size_t ld, span<double> dlnActCoeffdlnN)
 {
+    checkArraySize("RedlichKisterVPSSTP::getdlnActCoeffdlnN",
+                   dlnActCoeffdlnN.size(), ld * m_kk);
     s_update_dlnActCoeff_dX_();
     double* data =  & dlnActCoeffdlnN_(0,0);
     for (size_t k = 0; k < m_kk; k++) {

--- a/src/thermo/RedlichKisterVPSSTP.cpp
+++ b/src/thermo/RedlichKisterVPSSTP.cpp
@@ -24,7 +24,7 @@ RedlichKisterVPSSTP::RedlichKisterVPSSTP(const string& inputFile, const string& 
 
 // - Activities, Standard States, Activity Concentrations -----------
 
-void RedlichKisterVPSSTP::getLnActivityCoefficients(double* lnac) const
+void RedlichKisterVPSSTP::getLnActivityCoefficients(span<double> lnac) const
 {
     // Update the activity coefficients
     s_update_lnActCoeff();
@@ -36,7 +36,7 @@ void RedlichKisterVPSSTP::getLnActivityCoefficients(double* lnac) const
 
 // ------------ Partial Molar Properties of the Solution ------------
 
-void RedlichKisterVPSSTP::getChemPotentials(double* mu) const
+void RedlichKisterVPSSTP::getChemPotentials(span<double> mu) const
 {
     // First get the standard chemical potentials in molar form. This requires
     // updates of standard state as a function of T and P
@@ -55,7 +55,7 @@ double RedlichKisterVPSSTP::cv_mole() const
     return cp_mole();
 }
 
-void RedlichKisterVPSSTP::getPartialMolarEnthalpies(double* hbar) const
+void RedlichKisterVPSSTP::getPartialMolarEnthalpies(span<double> hbar) const
 {
     // Get the nondimensional standard state enthalpies
     getEnthalpy_RT(hbar);
@@ -74,7 +74,7 @@ void RedlichKisterVPSSTP::getPartialMolarEnthalpies(double* hbar) const
     }
 }
 
-void RedlichKisterVPSSTP::getPartialMolarCp(double* cpbar) const
+void RedlichKisterVPSSTP::getPartialMolarCp(span<double> cpbar) const
 {
     getCp_R(cpbar);
     // dimensionalize it.
@@ -83,7 +83,7 @@ void RedlichKisterVPSSTP::getPartialMolarCp(double* cpbar) const
     }
 }
 
-void RedlichKisterVPSSTP::getPartialMolarEntropies(double* sbar) const
+void RedlichKisterVPSSTP::getPartialMolarEntropies(span<double> sbar) const
 {
     // Get the nondimensional standard state entropies
     getEntropy_R(sbar);
@@ -104,7 +104,7 @@ void RedlichKisterVPSSTP::getPartialMolarEntropies(double* sbar) const
     }
 }
 
-void RedlichKisterVPSSTP::getPartialMolarVolumes(double* vbar) const
+void RedlichKisterVPSSTP::getPartialMolarVolumes(span<double> vbar) const
 {
     // Get the standard state values in m^3 kmol-1
     getStandardVolumes(vbar);
@@ -249,7 +249,7 @@ void RedlichKisterVPSSTP::s_update_dlnActCoeff_dT() const
     }
 }
 
-void RedlichKisterVPSSTP::getdlnActCoeffdT(double* dlnActCoeffdT) const
+void RedlichKisterVPSSTP::getdlnActCoeffdT(span<double> dlnActCoeffdT) const
 {
     s_update_dlnActCoeff_dT();
     for (size_t k = 0; k < m_kk; k++) {
@@ -376,8 +376,8 @@ void RedlichKisterVPSSTP::s_update_dlnActCoeff_dX_() const
     }
 }
 
-void RedlichKisterVPSSTP::getdlnActCoeffds(const double dTds, const double* const dXds,
-        double* dlnActCoeffds) const
+void RedlichKisterVPSSTP::getdlnActCoeffds(const double dTds, span<const double> const dXds,
+        span<double> dlnActCoeffds) const
 {
     s_update_dlnActCoeff_dT();
     s_update_dlnActCoeff_dX_();
@@ -389,7 +389,7 @@ void RedlichKisterVPSSTP::getdlnActCoeffds(const double dTds, const double* cons
     }
 }
 
-void RedlichKisterVPSSTP::getdlnActCoeffdlnN_diag(double* dlnActCoeffdlnN_diag) const
+void RedlichKisterVPSSTP::getdlnActCoeffdlnN_diag(span<double> dlnActCoeffdlnN_diag) const
 {
     s_update_dlnActCoeff_dX_();
     for (size_t j = 0; j < m_kk; j++) {
@@ -400,7 +400,7 @@ void RedlichKisterVPSSTP::getdlnActCoeffdlnN_diag(double* dlnActCoeffdlnN_diag) 
     }
 }
 
-void RedlichKisterVPSSTP::getdlnActCoeffdlnX_diag(double* dlnActCoeffdlnX_diag) const
+void RedlichKisterVPSSTP::getdlnActCoeffdlnX_diag(span<double> dlnActCoeffdlnX_diag) const
 {
     s_update_dlnActCoeff_dlnX_diag();
     for (size_t k = 0; k < m_kk; k++) {
@@ -408,7 +408,7 @@ void RedlichKisterVPSSTP::getdlnActCoeffdlnX_diag(double* dlnActCoeffdlnX_diag) 
     }
 }
 
-void RedlichKisterVPSSTP::getdlnActCoeffdlnN(const size_t ld, double* dlnActCoeffdlnN)
+void RedlichKisterVPSSTP::getdlnActCoeffdlnN(const size_t ld, span<double> dlnActCoeffdlnN)
 {
     s_update_dlnActCoeff_dX_();
     double* data =  & dlnActCoeffdlnN_(0,0);

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -125,11 +125,11 @@ double RedlichKwongMFTP::pressure() const
 
 double RedlichKwongMFTP::standardConcentration(size_t k) const
 {
-    getStandardVolumes(m_workS.data());
+    getStandardVolumes(m_workS);
     return 1.0 / m_workS[k];
 }
 
-void RedlichKwongMFTP::getActivityCoefficients(double* ac) const
+void RedlichKwongMFTP::getActivityCoefficients(span<double> ac) const
 {
     double mv = molarVolume();
     double sqt = sqrt(temperature());
@@ -161,7 +161,7 @@ void RedlichKwongMFTP::getActivityCoefficients(double* ac) const
 
 // ---- Partial Molar Properties of the Solution -----------------
 
-void RedlichKwongMFTP::getChemPotentials(double* mu) const
+void RedlichKwongMFTP::getChemPotentials(span<double> mu) const
 {
     getGibbs_ref(mu);
     for (size_t k = 0; k < m_kk; k++) {
@@ -195,11 +195,11 @@ void RedlichKwongMFTP::getChemPotentials(double* mu) const
     }
 }
 
-void RedlichKwongMFTP::getPartialMolarEnthalpies(double* hbar) const
+void RedlichKwongMFTP::getPartialMolarEnthalpies(span<double> hbar) const
 {
     // First we get the reference state contributions
     getEnthalpy_RT_ref(hbar);
-    scale(hbar, hbar+m_kk, hbar, RT());
+    scale(hbar.begin(), hbar.end(), hbar.begin(), RT());
 
     // We calculate dpdni_
     double TKelvin = temperature();
@@ -240,10 +240,10 @@ void RedlichKwongMFTP::getPartialMolarEnthalpies(double* hbar) const
     }
 }
 
-void RedlichKwongMFTP::getPartialMolarEntropies(double* sbar) const
+void RedlichKwongMFTP::getPartialMolarEntropies(span<double> sbar) const
 {
     getEntropy_R_ref(sbar);
-    scale(sbar, sbar+m_kk, sbar, GasConstant);
+    scale(sbar.begin(), sbar.end(), sbar.begin(), GasConstant);
     double TKelvin = temperature();
     double sqt = sqrt(TKelvin);
     double mv = molarVolume();
@@ -285,16 +285,16 @@ void RedlichKwongMFTP::getPartialMolarEntropies(double* sbar) const
     }
 
     pressureDerivatives();
-    getPartialMolarVolumes(m_partialMolarVolumes.data());
+    getPartialMolarVolumes(m_partialMolarVolumes);
     for (size_t k = 0; k < m_kk; k++) {
         sbar[k] -= -m_partialMolarVolumes[k] * dpdT_;
     }
 }
 
-void RedlichKwongMFTP::getPartialMolarIntEnergies(double* ubar) const
+void RedlichKwongMFTP::getPartialMolarIntEnergies(span<double> ubar) const
 {
     // u_k = h_k - P * v_k
-    getPartialMolarVolumes(m_partialMolarVolumes.data());
+    getPartialMolarVolumes(m_partialMolarVolumes);
     getPartialMolarEnthalpies(ubar);
     double p = pressure();
     for (size_t k = 0; k < nSpecies(); k++) {
@@ -302,7 +302,7 @@ void RedlichKwongMFTP::getPartialMolarIntEnergies(double* ubar) const
     }
 }
 
-void RedlichKwongMFTP::getPartialMolarVolumes(double* vbar) const
+void RedlichKwongMFTP::getPartialMolarVolumes(span<double> vbar) const
 {
     for (size_t k = 0; k < m_kk; k++) {
         m_pp[k] = 0.0;

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -131,6 +131,7 @@ double RedlichKwongMFTP::standardConcentration(size_t k) const
 
 void RedlichKwongMFTP::getActivityCoefficients(span<double> ac) const
 {
+    checkArraySize("RedlichKwongMFTP::getActivityCoefficients", ac.size(), m_kk);
     double mv = molarVolume();
     double sqt = sqrt(temperature());
     double vpb = mv + m_b_current;
@@ -304,6 +305,7 @@ void RedlichKwongMFTP::getPartialMolarIntEnergies(span<double> ubar) const
 
 void RedlichKwongMFTP::getPartialMolarVolumes(span<double> vbar) const
 {
+    checkArraySize("RedlichKwongMFTP::getPartialMolarVolumes", vbar.size(), m_kk);
     for (size_t k = 0; k < m_kk; k++) {
         m_pp[k] = 0.0;
         for (size_t i = 0; i < m_kk; i++) {

--- a/src/thermo/SingleSpeciesTP.cpp
+++ b/src/thermo/SingleSpeciesTP.cpp
@@ -167,7 +167,7 @@ void SingleSpeciesTP::_updateThermo() const
 {
     double tnow = temperature();
     if (m_tlast != tnow) {
-        m_spthermo.update(tnow, &m_cp0_R, &m_h0_RT, &m_s0_R);
+        m_spthermo.update_single(0, tnow, m_cp0_R, m_h0_RT, m_s0_R);
         m_tlast = tnow;
     }
 }

--- a/src/thermo/SingleSpeciesTP.cpp
+++ b/src/thermo/SingleSpeciesTP.cpp
@@ -20,21 +20,21 @@ namespace Cantera
 double SingleSpeciesTP::enthalpy_mole() const
 {
     double hbar;
-    getPartialMolarEnthalpies(&hbar);
+    getPartialMolarEnthalpies(span<double>(&hbar, 1));
     return hbar;
 }
 
 double SingleSpeciesTP::intEnergy_mole() const
 {
     double ubar;
-    getPartialMolarIntEnergies(&ubar);
+    getPartialMolarIntEnergies(span<double>(&ubar, 1));
     return ubar;
 }
 
 double SingleSpeciesTP::entropy_mole() const
 {
     double sbar;
-    getPartialMolarEntropies(&sbar);
+    getPartialMolarEntropies(span<double>(&sbar, 1));
     return sbar;
 }
 
@@ -44,7 +44,7 @@ double SingleSpeciesTP::gibbs_mole() const
 
     // Get the chemical potential of the first species. This is the same as the
     // partial molar Gibbs free energy.
-    getChemPotentials(&gbar);
+    getChemPotentials(span<double>(&gbar, 1));
     return gbar;
 }
 
@@ -54,7 +54,7 @@ double SingleSpeciesTP::cp_mole() const
 
     // Really should have a partial molar heat capacity function in ThermoPhase.
     // However, the standard state heat capacity will do fine here for now.
-    getCp_R(&cpbar);
+    getCp_R(span<double>(&cpbar, 1));
     cpbar *= GasConstant;
     return cpbar;
 }
@@ -81,74 +81,74 @@ double SingleSpeciesTP::cv_mole() const
 
 // ----------- Partial Molar Properties of the Solution -----------------
 
-void SingleSpeciesTP::getChemPotentials(double* mu) const
+void SingleSpeciesTP::getChemPotentials(span<double> mu) const
 {
     getStandardChemPotentials(mu);
 }
 
-void SingleSpeciesTP::getPartialMolarEnthalpies(double* hbar) const
+void SingleSpeciesTP::getPartialMolarEnthalpies(span<double> hbar) const
 {
     getEnthalpy_RT(hbar);
     hbar[0] *= RT();
 }
 
-void SingleSpeciesTP::getPartialMolarIntEnergies(double* ubar) const
+void SingleSpeciesTP::getPartialMolarIntEnergies(span<double> ubar) const
 {
     getIntEnergy_RT(ubar);
     ubar[0] *= RT();
 }
 
-void SingleSpeciesTP::getPartialMolarEntropies(double* sbar) const
+void SingleSpeciesTP::getPartialMolarEntropies(span<double> sbar) const
 {
     getEntropy_R(sbar);
     sbar[0] *= GasConstant;
 }
 
-void SingleSpeciesTP::getPartialMolarCp(double* cpbar) const
+void SingleSpeciesTP::getPartialMolarCp(span<double> cpbar) const
 {
     getCp_R(cpbar);
     cpbar[0] *= GasConstant;
 }
 
-void SingleSpeciesTP::getPartialMolarVolumes(double* vbar) const
+void SingleSpeciesTP::getPartialMolarVolumes(span<double> vbar) const
 {
     vbar[0] = molecularWeight(0) / density();
 }
 
 // Properties of the Standard State of the Species in the Solution
 
-void SingleSpeciesTP::getStandardVolumes(double* vbar) const
+void SingleSpeciesTP::getStandardVolumes(span<double> vbar) const
 {
     vbar[0] = molecularWeight(0) / density();
 }
 
 // ---- Thermodynamic Values for the Species Reference States -------
 
-void SingleSpeciesTP::getEnthalpy_RT_ref(double* hrt) const
+void SingleSpeciesTP::getEnthalpy_RT_ref(span<double> hrt) const
 {
     _updateThermo();
     hrt[0] = m_h0_RT;
 }
 
-void SingleSpeciesTP::getGibbs_RT_ref(double* grt) const
+void SingleSpeciesTP::getGibbs_RT_ref(span<double> grt) const
 {
     _updateThermo();
     grt[0] = m_h0_RT - m_s0_R;
 }
 
-void SingleSpeciesTP::getGibbs_ref(double* g) const
+void SingleSpeciesTP::getGibbs_ref(span<double> g) const
 {
     getGibbs_RT_ref(g);
     g[0] *= RT();
 }
 
-void SingleSpeciesTP::getEntropy_R_ref(double* er) const
+void SingleSpeciesTP::getEntropy_R_ref(span<double> er) const
 {
     _updateThermo();
     er[0] = m_s0_R;
 }
 
-void SingleSpeciesTP::getCp_R_ref(double* cpr) const
+void SingleSpeciesTP::getCp_R_ref(span<double> cpr) const
 {
     _updateThermo();
     cpr[0] = m_cp0_R;

--- a/src/thermo/SingleSpeciesTP.cpp
+++ b/src/thermo/SingleSpeciesTP.cpp
@@ -112,6 +112,7 @@ void SingleSpeciesTP::getPartialMolarCp(span<double> cpbar) const
 
 void SingleSpeciesTP::getPartialMolarVolumes(span<double> vbar) const
 {
+    checkArraySize("SingleSpeciesTP::getPartialMolarVolumes", vbar.size(), 1);
     vbar[0] = molecularWeight(0) / density();
 }
 
@@ -119,6 +120,7 @@ void SingleSpeciesTP::getPartialMolarVolumes(span<double> vbar) const
 
 void SingleSpeciesTP::getStandardVolumes(span<double> vbar) const
 {
+    checkArraySize("SingleSpeciesTP::getStandardVolumes", vbar.size(), 1);
     vbar[0] = molecularWeight(0) / density();
 }
 
@@ -126,12 +128,14 @@ void SingleSpeciesTP::getStandardVolumes(span<double> vbar) const
 
 void SingleSpeciesTP::getEnthalpy_RT_ref(span<double> hrt) const
 {
+    checkArraySize("SingleSpeciesTP::getEnthalpy_RT_ref", hrt.size(), 1);
     _updateThermo();
     hrt[0] = m_h0_RT;
 }
 
 void SingleSpeciesTP::getGibbs_RT_ref(span<double> grt) const
 {
+    checkArraySize("SingleSpeciesTP::getGibbs_RT_ref", grt.size(), 1);
     _updateThermo();
     grt[0] = m_h0_RT - m_s0_R;
 }
@@ -144,12 +148,14 @@ void SingleSpeciesTP::getGibbs_ref(span<double> g) const
 
 void SingleSpeciesTP::getEntropy_R_ref(span<double> er) const
 {
+    checkArraySize("SingleSpeciesTP::getEntropy_R_ref", er.size(), 1);
     _updateThermo();
     er[0] = m_s0_R;
 }
 
 void SingleSpeciesTP::getCp_R_ref(span<double> cpr) const
 {
+    checkArraySize("SingleSpeciesTP::getCp_R_ref", cpr.size(), 1);
     _updateThermo();
     cpr[0] = m_cp0_R;
 }

--- a/src/thermo/SpeciesThermoFactory.cpp
+++ b/src/thermo/SpeciesThermoFactory.cpp
@@ -25,7 +25,7 @@ namespace Cantera
 {
 
 SpeciesThermoInterpType* newSpeciesThermoInterpType(int type, double tlow,
-    double thigh, double pref, const double* coeffs)
+    double thigh, double pref, span<const double> coeffs)
 {
     switch (type) {
     case NASA1:
@@ -50,7 +50,7 @@ SpeciesThermoInterpType* newSpeciesThermoInterpType(int type, double tlow,
 }
 
 SpeciesThermoInterpType* newSpeciesThermoInterpType(const string& stype,
-    double tlow, double thigh, double pref, const double* coeffs)
+    double tlow, double thigh, double pref, span<const double> coeffs)
 {
     int itype = -1;
     string type = toLowerCopy(stype);

--- a/src/thermo/SpeciesThermoInterpType.cpp
+++ b/src/thermo/SpeciesThermoInterpType.cpp
@@ -20,15 +20,15 @@ SpeciesThermoInterpType::SpeciesThermoInterpType(double tlow,
 {
 }
 
-void SpeciesThermoInterpType::updateProperties(const double* tempPoly,
-        double* cp_R, double* h_RT, double* s_R) const
+void SpeciesThermoInterpType::updateProperties(span<const double> tempPoly,
+        double& cp_R, double& h_RT, double& s_R) const
 {
     double T = tempPoly[0];
     updatePropertiesTemp(T, cp_R, h_RT, s_R);
 }
 
 void SpeciesThermoInterpType::updatePropertiesTemp(const double temp,
-        double* cp_R, double* h_RT, double* s_R) const
+        double& cp_R, double& h_RT, double& s_R) const
 {
     throw NotImplementedError("SpeciesThermoInterpType::updatePropertiesTemp");
 }
@@ -40,7 +40,7 @@ size_t SpeciesThermoInterpType::nCoeffs() const
 
 void SpeciesThermoInterpType::reportParameters(size_t& index, int& type,
         double& minTemp, double& maxTemp, double& refPressure,
-        double* const coeffs) const
+        span<double> coeffs) const
 {
     throw NotImplementedError("SpeciesThermoInterpType::reportParameters");
 }
@@ -62,7 +62,7 @@ void SpeciesThermoInterpType::getParameters(AnyMap& thermo) const
     }
 }
 
-double SpeciesThermoInterpType::reportHf298(double* const h298) const
+double SpeciesThermoInterpType::reportHf298(span<double> h298) const
 {
     throw NotImplementedError("SpeciesThermoInterpType::reportHf298");
 }

--- a/src/thermo/SpeciesThermoInterpType.cpp
+++ b/src/thermo/SpeciesThermoInterpType.cpp
@@ -62,7 +62,7 @@ void SpeciesThermoInterpType::getParameters(AnyMap& thermo) const
     }
 }
 
-double SpeciesThermoInterpType::reportHf298(span<double> h298) const
+double SpeciesThermoInterpType::reportHf298() const
 {
     throw NotImplementedError("SpeciesThermoInterpType::reportHf298");
 }

--- a/src/thermo/StoichSubstance.cpp
+++ b/src/thermo/StoichSubstance.cpp
@@ -51,7 +51,7 @@ Units StoichSubstance::standardConcentrationUnits() const
     return Units(1.0);
 }
 
-void StoichSubstance::getActivityConcentrations(double* c) const
+void StoichSubstance::getActivityConcentrations(span<double> c) const
 {
     c[0] = 1.0;
 }
@@ -68,37 +68,37 @@ double StoichSubstance::logStandardConc(size_t k) const
 
 // Properties of the Standard State of the Species in the Solution
 
-void StoichSubstance::getStandardChemPotentials(double* mu0) const
+void StoichSubstance::getStandardChemPotentials(span<double> mu0) const
 {
     getGibbs_RT(mu0);
     mu0[0] *= RT();
 }
 
-void StoichSubstance::getEnthalpy_RT(double* hrt) const
+void StoichSubstance::getEnthalpy_RT(span<double> hrt) const
 {
     getEnthalpy_RT_ref(hrt);
     double presCorrect = (m_press - m_p0) / molarDensity();
     hrt[0] += presCorrect / RT();
 }
 
-void StoichSubstance::getEntropy_R(double* sr) const
+void StoichSubstance::getEntropy_R(span<double> sr) const
 {
     getEntropy_R_ref(sr);
 }
 
-void StoichSubstance::getGibbs_RT(double* grt) const
+void StoichSubstance::getGibbs_RT(span<double> grt) const
 {
     getEnthalpy_RT(grt);
     grt[0] -= m_s0_R;
 }
 
-void StoichSubstance::getCp_R(double* cpr) const
+void StoichSubstance::getCp_R(span<double> cpr) const
 {
     _updateThermo();
     cpr[0] = m_cp0_R;
 }
 
-void StoichSubstance::getIntEnergy_RT(double* urt) const
+void StoichSubstance::getIntEnergy_RT(span<double> urt) const
 {
     _updateThermo();
     urt[0] = m_h0_RT - m_p0 / molarDensity() / RT();
@@ -106,7 +106,7 @@ void StoichSubstance::getIntEnergy_RT(double* urt) const
 
 // ---- Thermodynamic Values for the Species Reference States ----
 
-void StoichSubstance::getIntEnergy_RT_ref(double* urt) const
+void StoichSubstance::getIntEnergy_RT_ref(span<double> urt) const
 {
     _updateThermo();
     urt[0] = m_h0_RT - m_p0 / molarDensity() / RT();

--- a/src/thermo/StoichSubstance.cpp
+++ b/src/thermo/StoichSubstance.cpp
@@ -53,6 +53,7 @@ Units StoichSubstance::standardConcentrationUnits() const
 
 void StoichSubstance::getActivityConcentrations(span<double> c) const
 {
+    checkArraySize("StoichSubstance::getActivityConcentrations", c.size(), 1);
     c[0] = 1.0;
 }
 
@@ -94,12 +95,14 @@ void StoichSubstance::getGibbs_RT(span<double> grt) const
 
 void StoichSubstance::getCp_R(span<double> cpr) const
 {
+    checkArraySize("StoichSubstance::getCp_R", cpr.size(), 1);
     _updateThermo();
     cpr[0] = m_cp0_R;
 }
 
 void StoichSubstance::getIntEnergy_RT(span<double> urt) const
 {
+    checkArraySize("StoichSubstance::getIntEnergy_RT", urt.size(), 1);
     _updateThermo();
     urt[0] = m_h0_RT - m_p0 / molarDensity() / RT();
 }
@@ -108,6 +111,7 @@ void StoichSubstance::getIntEnergy_RT(span<double> urt) const
 
 void StoichSubstance::getIntEnergy_RT_ref(span<double> urt) const
 {
+    checkArraySize("StoichSubstance::getIntEnergy_RT_ref", urt.size(), 1);
     _updateThermo();
     urt[0] = m_h0_RT - m_p0 / molarDensity() / RT();
 }

--- a/src/thermo/SurfPhase.cpp
+++ b/src/thermo/SurfPhase.cpp
@@ -61,7 +61,7 @@ double SurfPhase::cv_mole() const
     return cp_mole();
 }
 
-void SurfPhase::getPartialMolarEnthalpies(double* hbar) const
+void SurfPhase::getPartialMolarEnthalpies(span<double> hbar) const
 {
     getEnthalpy_RT(hbar);
     for (size_t k = 0; k < m_kk; k++) {
@@ -69,17 +69,17 @@ void SurfPhase::getPartialMolarEnthalpies(double* hbar) const
     }
 }
 
-void SurfPhase::getPartialMolarEntropies(double* sbar) const
+void SurfPhase::getPartialMolarEntropies(span<double> sbar) const
 {
     getEntropy_R(sbar);
-    getActivityConcentrations(m_work.data());
+    getActivityConcentrations(m_work);
     for (size_t k = 0; k < m_kk; k++) {
         sbar[k] -= log(std::max(m_work[k], SmallNumber)) - logStandardConc(k);
         sbar[k] *= GasConstant;
     }
 }
 
-void SurfPhase::getPartialMolarCp(double* cpbar) const
+void SurfPhase::getPartialMolarCp(span<double> cpbar) const
 {
     getCp_R(cpbar);
     for (size_t k = 0; k < m_kk; k++) {
@@ -89,30 +89,30 @@ void SurfPhase::getPartialMolarCp(double* cpbar) const
 
 // HKM 9/1/11  The partial molar volumes returned here are really partial molar areas.
 //             Partial molar volumes for this phase should actually be equal to zero.
-void SurfPhase::getPartialMolarVolumes(double* vbar) const
+void SurfPhase::getPartialMolarVolumes(span<double> vbar) const
 {
     getStandardVolumes(vbar);
 }
 
-void SurfPhase::getStandardChemPotentials(double* mu0) const
+void SurfPhase::getStandardChemPotentials(span<double> mu0) const
 {
     _updateThermo();
-    copy(m_mu0.begin(), m_mu0.end(), mu0);
+    copy(m_mu0.begin(), m_mu0.end(), mu0.begin());
 }
 
-void SurfPhase::getChemPotentials(double* mu) const
+void SurfPhase::getChemPotentials(span<double> mu) const
 {
     _updateThermo();
-    copy(m_mu0.begin(), m_mu0.end(), mu);
-    getActivityConcentrations(m_work.data());
+    copy(m_mu0.begin(), m_mu0.end(), mu.begin());
+    getActivityConcentrations(m_work);
     for (size_t k = 0; k < m_kk; k++) {
         mu[k] += RT() * (log(std::max(m_work[k], SmallNumber)) - logStandardConc(k));
     }
 }
 
-void SurfPhase::getActivityConcentrations(double* c) const
+void SurfPhase::getActivityConcentrations(span<double> c) const
 {
-    getConcentrations(span<double>(c, m_kk));
+    getConcentrations(c);
 }
 
 double SurfPhase::standardConcentration(size_t k) const
@@ -125,53 +125,53 @@ double SurfPhase::logStandardConc(size_t k) const
     return m_logn0 - m_logsize[k];
 }
 
-void SurfPhase::getGibbs_RT(double* grt) const
+void SurfPhase::getGibbs_RT(span<double> grt) const
 {
     _updateThermo();
-    scale(m_mu0.begin(), m_mu0.end(), grt, 1.0/RT());
+    scale(m_mu0.begin(), m_mu0.end(), grt.begin(), 1.0/RT());
 }
 
-void SurfPhase::getEnthalpy_RT(double* hrt) const
+void SurfPhase::getEnthalpy_RT(span<double> hrt) const
 {
     _updateThermo();
-    scale(m_h0.begin(), m_h0.end(), hrt, 1.0/RT());
+    scale(m_h0.begin(), m_h0.end(), hrt.begin(), 1.0/RT());
 }
 
-void SurfPhase::getEntropy_R(double* sr) const
+void SurfPhase::getEntropy_R(span<double> sr) const
 {
     _updateThermo();
-    scale(m_s0.begin(), m_s0.end(), sr, 1.0/GasConstant);
+    scale(m_s0.begin(), m_s0.end(), sr.begin(), 1.0/GasConstant);
 }
 
-void SurfPhase::getCp_R(double* cpr) const
+void SurfPhase::getCp_R(span<double> cpr) const
 {
     _updateThermo();
-    scale(m_cp0.begin(), m_cp0.end(), cpr, 1.0/GasConstant);
+    scale(m_cp0.begin(), m_cp0.end(), cpr.begin(), 1.0/GasConstant);
 }
 
-void SurfPhase::getStandardVolumes(double* vol) const
+void SurfPhase::getStandardVolumes(span<double> vol) const
 {
     for (size_t k = 0; k < m_kk; k++) {
         vol[k] = 0.0;
     }
 }
 
-void SurfPhase::getGibbs_RT_ref(double* grt) const
+void SurfPhase::getGibbs_RT_ref(span<double> grt) const
 {
     getGibbs_RT(grt);
 }
 
-void SurfPhase::getEnthalpy_RT_ref(double* hrt) const
+void SurfPhase::getEnthalpy_RT_ref(span<double> hrt) const
 {
     getEnthalpy_RT(hrt);
 }
 
-void SurfPhase::getEntropy_R_ref(double* sr) const
+void SurfPhase::getEntropy_R_ref(span<double> sr) const
 {
     getEntropy_R(sr);
 }
 
-void SurfPhase::getCp_R_ref(double* cprt) const
+void SurfPhase::getCp_R_ref(span<double> cprt) const
 {
     getCp_R(cprt);
 }

--- a/src/thermo/SurfPhase.cpp
+++ b/src/thermo/SurfPhase.cpp
@@ -112,7 +112,7 @@ void SurfPhase::getChemPotentials(double* mu) const
 
 void SurfPhase::getActivityConcentrations(double* c) const
 {
-    getConcentrations(c);
+    getConcentrations(span<double>(c, m_kk));
 }
 
 double SurfPhase::standardConcentration(size_t k) const

--- a/src/thermo/SurfPhase.cpp
+++ b/src/thermo/SurfPhase.cpp
@@ -189,7 +189,7 @@ bool SurfPhase::addSpecies(shared_ptr<Species> spec)
         m_logsize.push_back(log(spec->size));
         if (m_kk == 1) {
             vector<double> cov{1.0};
-            setCoverages(cov.data());
+            setCoverages({cov});
         }
     }
     return added;
@@ -206,7 +206,7 @@ void SurfPhase::setSiteDensity(double n0)
     compositionChanged(); // trigger update of density
 }
 
-void SurfPhase::setCoverages(const double* theta)
+void SurfPhase::setCoverages(span<const double> theta)
 {
     double sum = 0.0;
     for (size_t k = 0; k < m_kk; k++) {
@@ -222,7 +222,7 @@ void SurfPhase::setCoverages(const double* theta)
     setMoleFractions(m_work);
 }
 
-void SurfPhase::setCoveragesNoNorm(const double* theta)
+void SurfPhase::setCoveragesNoNorm(span<const double> theta)
 {
     double sum = 0.0;
     double sum2 = 0.0;
@@ -240,11 +240,11 @@ void SurfPhase::setCoveragesNoNorm(const double* theta)
     setMoleFractions_NoNorm(m_work);
 }
 
-void SurfPhase::getCoverages(double* theta) const
+void SurfPhase::getCoverages(span<double> theta) const
 {
     double sum_X = 0.0;
     double sum_X_s = 0.0;
-    getMoleFractions(span<double>(theta, m_kk));
+    getMoleFractions(theta);
     for (size_t k = 0; k < m_kk; k++) {
         sum_X += theta[k];
         sum_X_s += theta[k] * size(k);
@@ -274,7 +274,7 @@ void SurfPhase::setCoveragesByName(const Composition& cov)
         throw CanteraError("SurfPhase::setCoveragesByName",
                            "Input coverages are all zero or negative");
     }
-    setCoverages(cv.data());
+    setCoverages(cv);
 }
 
 void SurfPhase::setState(const AnyMap& state) {

--- a/src/thermo/SurfPhase.cpp
+++ b/src/thermo/SurfPhase.cpp
@@ -219,7 +219,7 @@ void SurfPhase::setCoverages(const double* theta)
     for (size_t k = 0; k < m_kk; k++) {
         m_work[k] = theta[k] / (sum * size(k));
     }
-    setMoleFractions(m_work.data());
+    setMoleFractions(m_work);
 }
 
 void SurfPhase::setCoveragesNoNorm(const double* theta)
@@ -237,14 +237,14 @@ void SurfPhase::setCoveragesNoNorm(const double* theta)
     for (size_t k = 0; k < m_kk; k++) {
         m_work[k] = theta[k] * sum2 / (sum * size(k));
     }
-    setMoleFractions_NoNorm(m_work.data());
+    setMoleFractions_NoNorm(m_work);
 }
 
 void SurfPhase::getCoverages(double* theta) const
 {
     double sum_X = 0.0;
     double sum_X_s = 0.0;
-    getMoleFractions(theta);
+    getMoleFractions(span<double>(theta, m_kk));
     for (size_t k = 0; k < m_kk; k++) {
         sum_X += theta[k];
         sum_X_s += theta[k] * size(k);
@@ -291,7 +291,7 @@ void SurfPhase::setState(const AnyMap& state) {
 void SurfPhase::compositionChanged()
 {
     ThermoPhase::compositionChanged();
-    getMoleFractions(m_work.data());
+    getMoleFractions(m_work);
     double q = 0;
     double sumX = 0;
     for (size_t k = 0; k < m_kk; k++) {

--- a/src/thermo/SurfPhase.cpp
+++ b/src/thermo/SurfPhase.cpp
@@ -96,12 +96,14 @@ void SurfPhase::getPartialMolarVolumes(span<double> vbar) const
 
 void SurfPhase::getStandardChemPotentials(span<double> mu0) const
 {
+    checkArraySize("SurfPhase::getStandardChemPotentials", mu0.size(), m_kk);
     _updateThermo();
     copy(m_mu0.begin(), m_mu0.end(), mu0.begin());
 }
 
 void SurfPhase::getChemPotentials(span<double> mu) const
 {
+    checkArraySize("SurfPhase::getChemPotentials", mu.size(), m_kk);
     _updateThermo();
     copy(m_mu0.begin(), m_mu0.end(), mu.begin());
     getActivityConcentrations(m_work);
@@ -127,30 +129,35 @@ double SurfPhase::logStandardConc(size_t k) const
 
 void SurfPhase::getGibbs_RT(span<double> grt) const
 {
+    checkArraySize("SurfPhase::getGibbs_RT", grt.size(), m_kk);
     _updateThermo();
     scale(m_mu0.begin(), m_mu0.end(), grt.begin(), 1.0/RT());
 }
 
 void SurfPhase::getEnthalpy_RT(span<double> hrt) const
 {
+    checkArraySize("SurfPhase::getEnthalpy_RT", hrt.size(), m_kk);
     _updateThermo();
     scale(m_h0.begin(), m_h0.end(), hrt.begin(), 1.0/RT());
 }
 
 void SurfPhase::getEntropy_R(span<double> sr) const
 {
+    checkArraySize("SurfPhase::getEntropy_R", sr.size(), m_kk);
     _updateThermo();
     scale(m_s0.begin(), m_s0.end(), sr.begin(), 1.0/GasConstant);
 }
 
 void SurfPhase::getCp_R(span<double> cpr) const
 {
+    checkArraySize("SurfPhase::getCp_R", cpr.size(), m_kk);
     _updateThermo();
     scale(m_cp0.begin(), m_cp0.end(), cpr.begin(), 1.0/GasConstant);
 }
 
 void SurfPhase::getStandardVolumes(span<double> vol) const
 {
+    checkArraySize("SurfPhase::getStandardVolumes", vol.size(), m_kk);
     for (size_t k = 0; k < m_kk; k++) {
         vol[k] = 0.0;
     }
@@ -208,6 +215,7 @@ void SurfPhase::setSiteDensity(double n0)
 
 void SurfPhase::setCoverages(span<const double> theta)
 {
+    checkArraySize("SurfPhase::setCoverages", theta.size(), m_kk);
     double sum = 0.0;
     for (size_t k = 0; k < m_kk; k++) {
         sum += theta[k] / size(k);
@@ -224,6 +232,7 @@ void SurfPhase::setCoverages(span<const double> theta)
 
 void SurfPhase::setCoveragesNoNorm(span<const double> theta)
 {
+    checkArraySize("SurfPhase::setCoveragesNoNorm", theta.size(), m_kk);
     double sum = 0.0;
     double sum2 = 0.0;
     for (size_t k = 0; k < m_kk; k++) {
@@ -242,6 +251,7 @@ void SurfPhase::setCoveragesNoNorm(span<const double> theta)
 
 void SurfPhase::getCoverages(span<double> theta) const
 {
+    checkArraySize("SurfPhase::getCoverages", theta.size(), m_kk);
     double sum_X = 0.0;
     double sum_X_s = 0.0;
     getMoleFractions(theta);

--- a/src/thermo/SurfPhase.cpp
+++ b/src/thermo/SurfPhase.cpp
@@ -307,7 +307,7 @@ void SurfPhase::_updateThermo(bool force) const
 {
     double tnow = temperature();
     if (m_tlast != tnow || force) {
-        m_spthermo.update(tnow, m_cp0.data(), m_h0.data(), m_s0.data());
+        m_spthermo.update(tnow, m_cp0, m_h0, m_s0);
         m_tlast = tnow;
         for (size_t k = 0; k < m_kk; k++) {
             m_h0[k] *= GasConstant * tnow;

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -119,7 +119,7 @@ void ThermoPhase::getElectrochemPotentials(double* mu) const
 
 void ThermoPhase::setState_TPX(double t, double p, const double* x)
 {
-    setMoleFractions(x);
+    setMoleFractions(span<const double>(x, nSpecies()));
     setState_TP(t,p);
 }
 
@@ -137,7 +137,7 @@ void ThermoPhase::setState_TPX(double t, double p, const string& x)
 
 void ThermoPhase::setState_TPY(double t, double p, const double* y)
 {
-    setMassFractions(y);
+    setMassFractions(span<const double>(y, nSpecies()));
     setState_TP(t,p);
 }
 
@@ -821,7 +821,7 @@ void ThermoPhase::setEquivalenceRatio(double phi, const double* fuelComp,
         y[k] = phi * fuelComp[k]/sum_f + AFR_st * oxComp[k]/sum_o;
     }
 
-    setMassFractions(y.data());
+    setMassFractions(y);
     setPressure(p);
 }
 
@@ -952,7 +952,7 @@ void ThermoPhase::setMixtureFraction(double mixFrac, const double* fuelComp,
         y[k] = mixFrac * fuelComp[k]/sum_yf + (1.0-mixFrac) * oxComp[k]/sum_yo;
     }
 
-    setMassFractions_NoNorm(y.data());
+    setMassFractions_NoNorm(y);
     setPressure(p);
 }
 
@@ -1293,7 +1293,7 @@ void ThermoPhase::getdlnActCoeffdlnN_numderiv(const size_t ld,
     vector<double> ActCoeff_Base(m_kk);
     getActivityCoefficients(ActCoeff_Base.data());
     vector<double> Xmol_Base(m_kk);
-    getMoleFractions(Xmol_Base.data());
+    getMoleFractions(Xmol_Base);
 
     // Make copies of ActCoeff and Xmol_ for use in taking differences
     vector<double> ActCoeff(m_kk);
@@ -1320,7 +1320,7 @@ void ThermoPhase::getdlnActCoeffdlnN_numderiv(const size_t ld,
         Xmol[j] = (moles_j_base + deltaMoles_j) / v_totalMoles;
 
         // Go get new values for the activity coefficients.
-        setMoleFractions(Xmol.data());
+        setMoleFractions(Xmol);
         setPressure(pres);
         getActivityCoefficients(ActCoeff.data());
 
@@ -1334,7 +1334,7 @@ void ThermoPhase::getdlnActCoeffdlnN_numderiv(const size_t ld,
         v_totalMoles = TMoles_base;
         Xmol = Xmol_Base;
     }
-    setMoleFractions(Xmol_Base.data());
+    setMoleFractions(Xmol_Base);
     setPressure(pres);
 }
 
@@ -1424,8 +1424,8 @@ string ThermoPhase::report(bool show_thermo, double threshold) const
         vector<double> x(m_kk);
         vector<double> y(m_kk);
         vector<double> mu(m_kk);
-        getMoleFractions(&x[0]);
-        getMassFractions(&y[0]);
+        getMoleFractions(x);
+        getMassFractions(y);
         getChemPotentials(&mu[0]);
         int nMinor = 0;
         double xMinor = 0.0;

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -699,6 +699,7 @@ void ThermoPhase::setState_SPorSV(double Starget, double p,
 
 double ThermoPhase::o2Required(span<const double> y) const
 {
+    checkArraySize("ThermoPhase::o2Required", y.size(), m_kk);
     // indices of fuel elements
     size_t iC = elementIndex("C", false);
     size_t iS = elementIndex("S", false);
@@ -728,6 +729,7 @@ double ThermoPhase::o2Required(span<const double> y) const
 
 double ThermoPhase::o2Present(span<const double> y) const
 {
+    checkArraySize("ThermoPhase::o2Present", y.size(), m_kk);
     size_t iO = elementIndex("O", true);
     double o2pres = 0.0;
     double sum = 0.0;
@@ -920,6 +922,8 @@ void ThermoPhase::setMixtureFraction(double mixFrac, const string& fuelComp,
 void ThermoPhase::setMixtureFraction(double mixFrac, span<const double> fuelComp,
                                      span<const double> oxComp, ThermoBasis basis)
 {
+    checkArraySize("ThermoPhase::setMixtureFraction", fuelComp.size(), m_kk);
+    checkArraySize("ThermoPhase::setMixtureFraction", oxComp.size(), m_kk);
     if (mixFrac < 0.0 || mixFrac > 1.0) {
         throw CanteraError("ThermoPhase::setMixtureFraction",
                            "Mixture fraction must be between 0 and 1");
@@ -978,6 +982,8 @@ double ThermoPhase::mixtureFraction(span<const double> fuelComp,
                                     span<const double> oxComp,
                                     ThermoBasis basis, const string& element) const
 {
+    checkArraySize("ThermoPhase::mixtureFraction", fuelComp.size(), m_kk);
+    checkArraySize("ThermoPhase::mixtureFraction", oxComp.size(), m_kk);
     vector<double> fuel, ox;
     if (basis == ThermoBasis::molar) { // convert input compositions to mass fractions
         fuel.resize(m_kk);
@@ -1276,6 +1282,7 @@ void ThermoPhase::equilibrate(const string& XY, const string& solver,
 
 void ThermoPhase::getdlnActCoeffdlnN(const size_t ld, span<double> dlnActCoeffdlnN)
 {
+    checkArraySize("ThermoPhase::getdlnActCoeffdlnN", dlnActCoeffdlnN.size(), ld*m_kk);
     for (size_t m = 0; m < m_kk; m++) {
         for (size_t k = 0; k < m_kk; k++) {
             dlnActCoeffdlnN[ld * k + m] = 0.0;
@@ -1287,6 +1294,8 @@ void ThermoPhase::getdlnActCoeffdlnN(const size_t ld, span<double> dlnActCoeffdl
 void ThermoPhase::getdlnActCoeffdlnN_numderiv(const size_t ld,
                                               span<double> dlnActCoeffdlnN)
 {
+    checkArraySize("ThermoPhase::getdlnActCoeffdlnN_numderiv",
+                   dlnActCoeffdlnN.size(), ld*m_kk);
     double deltaMoles_j = 0.0;
     double pres = pressure();
 

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -844,8 +844,8 @@ void ThermoPhase::setEquivalenceRatio(double phi, const Composition& fuelComp,
 
 double ThermoPhase::equivalenceRatio() const
 {
-    double o2_required = o2Required(massFractions());
-    double o2_present  = o2Present(massFractions());
+    double o2_required = o2Required(massFractions().data());
+    double o2_present  = o2Present(massFractions().data());
 
     if (o2_present == 0.0) { // pure fuel
         return std::numeric_limits<double>::infinity();
@@ -992,7 +992,8 @@ double ThermoPhase::mixtureFraction(const double* fuelComp, const double* oxComp
     {
         double o2_required_fuel = o2Required(fuelComp) - o2Present(fuelComp);
         double o2_required_ox   = o2Required(oxComp) - o2Present(oxComp);
-        double o2_required_mix  = o2Required(massFractions()) - o2Present(massFractions());
+        double o2_required_mix = o2Required(massFractions().data())
+            - o2Present(massFractions().data());
 
         if (o2_required_fuel < 0.0 || o2_required_ox > 0.0) {
             throw CanteraError("ThermoPhase::mixtureFraction",
@@ -1032,7 +1033,7 @@ double ThermoPhase::mixtureFraction(const double* fuelComp, const double* oxComp
         size_t m = elementIndex(element, true);
         double Z_m_fuel = elementalFraction(m, fuelComp)/sum_yf;
         double Z_m_ox   = elementalFraction(m, oxComp)/sum_yo;
-        double Z_m_mix  = elementalFraction(m, massFractions());
+        double Z_m_mix  = elementalFraction(m, massFractions().data());
 
         if (Z_m_fuel == Z_m_ox) {
             throw CanteraError("ThermoPhase::mixtureFraction",

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -156,12 +156,12 @@ void ThermoPhase::setState_TPY(double t, double p, const string& y)
 void ThermoPhase::setState_TP(double t, double p)
 {
     vector<double> state(partialStateSize());
-    savePartialState(state.size(), state.data());
+    savePartialState(state);
     try {
         setTemperature(t);
         setPressure(p);
     } catch (std::exception&) {
-        restorePartialState(state.size(), state.data());
+        restorePartialState(state);
         throw;
     }
 }
@@ -169,11 +169,11 @@ void ThermoPhase::setState_TP(double t, double p)
 void ThermoPhase::setState_HP(double Htarget, double p, double rtol)
 {
     vector<double> state(partialStateSize());
-    savePartialState(state.size(), state.data());
+    savePartialState(state);
     try {
         setState_HPorUV(Htarget, p, rtol, false);
     } catch (std::exception&) {
-        restorePartialState(state.size(), state.data());
+        restorePartialState(state);
         throw;
     }
 }
@@ -182,11 +182,11 @@ void ThermoPhase::setState_UV(double u, double v, double rtol)
 {
     assertCompressible("setState_UV");
     vector<double> state(partialStateSize());
-    savePartialState(state.size(), state.data());
+    savePartialState(state);
     try {
         setState_HPorUV(u, v, rtol, true);
     } catch (std::exception&) {
-        restorePartialState(state.size(), state.data());
+        restorePartialState(state);
         throw;
     }
 }
@@ -502,11 +502,11 @@ void ThermoPhase::setState_HPorUV(double Htarget, double p,
 void ThermoPhase::setState_SP(double Starget, double p, double rtol)
 {
     vector<double> state(partialStateSize());
-    savePartialState(state.size(), state.data());
+    savePartialState(state);
     try {
         setState_SPorSV(Starget, p, rtol, false);
     } catch (std::exception&) {
-        restorePartialState(state.size(), state.data());
+        restorePartialState(state);
         throw;
     }
 }
@@ -515,11 +515,11 @@ void ThermoPhase::setState_SV(double Starget, double v, double rtol)
 {
     assertCompressible("setState_SV");
     vector<double> state(partialStateSize());
-    savePartialState(state.size(), state.data());
+    savePartialState(state);
     try {
         setState_SPorSV(Starget, v, rtol, true);
     } catch (std::exception&) {
-        restorePartialState(state.size(), state.data());
+        restorePartialState(state);
         throw;
     }
 }
@@ -1232,7 +1232,7 @@ void ThermoPhase::equilibrate(const string& XY, const string& solver,
                               int estimate_equil, int log_level)
 {
     if (solver == "auto" || solver == "element_potential") {
-        vector<double> initial_state;
+        vector<double> initial_state(stateSize());
         saveState(initial_state);
         debuglog("Trying ChemEquil solver\n", log_level);
         try {

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -768,8 +768,8 @@ double ThermoPhase::stoichAirFuelRatio(const double* fuelComp,
     if (basis == ThermoBasis::molar) { // convert input compositions to mass fractions
         fuel.resize(m_kk);
         ox.resize(m_kk);
-        moleFractionsToMassFractions(fuelComp, fuel.data());
-        moleFractionsToMassFractions(oxComp, ox.data());
+        moleFractionsToMassFractions(span<const double>(fuelComp, m_kk), fuel);
+        moleFractionsToMassFractions(span<const double>(oxComp, m_kk), ox);
         fuelComp = fuel.data();
         oxComp = ox.data();
     }
@@ -805,8 +805,8 @@ void ThermoPhase::setEquivalenceRatio(double phi, const double* fuelComp,
     if (basis == ThermoBasis::molar) { // convert input compositions to mass fractions
         fuel.resize(m_kk);
         ox.resize(m_kk);
-        moleFractionsToMassFractions(fuelComp, fuel.data());
-        moleFractionsToMassFractions(oxComp, ox.data());
+        moleFractionsToMassFractions(span<const double>(fuelComp, m_kk), fuel);
+        moleFractionsToMassFractions(span<const double>(oxComp, m_kk), ox);
         fuelComp = fuel.data();
         oxComp = ox.data();
     }
@@ -890,8 +890,8 @@ double ThermoPhase::equivalenceRatio(const double* fuelComp,
     if (basis == ThermoBasis::molar) { // convert input compositions to mass fractions
         fuel.resize(m_kk);
         ox.resize(m_kk);
-        moleFractionsToMassFractions(fuelComp, fuel.data());
-        moleFractionsToMassFractions(oxComp, ox.data());
+        moleFractionsToMassFractions(span<const double>(fuelComp, m_kk), fuel);
+        moleFractionsToMassFractions(span<const double>(oxComp, m_kk), ox);
         fuelComp = fuel.data();
         oxComp = ox.data();
     }
@@ -930,8 +930,8 @@ void ThermoPhase::setMixtureFraction(double mixFrac, const double* fuelComp,
     if (basis == ThermoBasis::molar) { // convert input compositions to mass fractions
         fuel.resize(m_kk);
         ox.resize(m_kk);
-        moleFractionsToMassFractions(fuelComp, fuel.data());
-        moleFractionsToMassFractions(oxComp, ox.data());
+        moleFractionsToMassFractions(span<const double>(fuelComp, m_kk), fuel);
+        moleFractionsToMassFractions(span<const double>(oxComp, m_kk), ox);
         fuelComp = fuel.data();
         oxComp = ox.data();
     }
@@ -982,8 +982,8 @@ double ThermoPhase::mixtureFraction(const double* fuelComp, const double* oxComp
     if (basis == ThermoBasis::molar) { // convert input compositions to mass fractions
         fuel.resize(m_kk);
         ox.resize(m_kk);
-        moleFractionsToMassFractions(fuelComp, fuel.data());
-        moleFractionsToMassFractions(oxComp, ox.data());
+        moleFractionsToMassFractions(span<const double>(fuelComp, m_kk), fuel);
+        moleFractionsToMassFractions(span<const double>(oxComp, m_kk), ox);
         fuelComp = fuel.data();
         oxComp = ox.data();
     }

--- a/src/thermo/VPStandardStateTP.cpp
+++ b/src/thermo/VPStandardStateTP.cpp
@@ -45,24 +45,28 @@ void VPStandardStateTP::getStandardChemPotentials(span<double> g) const
 
 void VPStandardStateTP::getEnthalpy_RT(span<double> hrt) const
 {
+    checkArraySize("VPStandardStateTP::getEnthalpy_RT", hrt.size(), m_kk);
     updateStandardStateThermo();
     std::copy(m_hss_RT.begin(), m_hss_RT.end(), hrt.begin());
 }
 
 void VPStandardStateTP::getEntropy_R(span<double> sr) const
 {
+    checkArraySize("VPStandardStateTP::getEntropy_R", sr.size(), m_kk);
     updateStandardStateThermo();
     std::copy(m_sss_R.begin(), m_sss_R.end(), sr.begin());
 }
 
 void VPStandardStateTP::getGibbs_RT(span<double> grt) const
 {
+    checkArraySize("VPStandardStateTP::getGibbs_RT", grt.size(), m_kk);
     updateStandardStateThermo();
     std::copy(m_gss_RT.begin(), m_gss_RT.end(), grt.begin());
 }
 
 void VPStandardStateTP::getIntEnergy_RT(span<double> urt) const
 {
+    checkArraySize("VPStandardStateTP::getIntEnergy_RT", urt.size(), m_kk);
     updateStandardStateThermo();
     std::copy(m_hss_RT.begin(), m_hss_RT.end(), urt.begin());
     for (size_t k = 0; k < m_kk; k++) {
@@ -72,12 +76,14 @@ void VPStandardStateTP::getIntEnergy_RT(span<double> urt) const
 
 void VPStandardStateTP::getCp_R(span<double> cpr) const
 {
+    checkArraySize("VPStandardStateTP::getCp_R", cpr.size(), m_kk);
     updateStandardStateThermo();
     std::copy(m_cpss_R.begin(), m_cpss_R.end(), cpr.begin());
 }
 
 void VPStandardStateTP::getStandardVolumes(span<double> vol) const
 {
+    checkArraySize("VPStandardStateTP::getStandardVolumes", vol.size(), m_kk);
     updateStandardStateThermo();
     std::copy(m_Vss.begin(), m_Vss.end(), vol.begin());
 }
@@ -91,18 +97,21 @@ span<const double> VPStandardStateTP::getStandardVolumes() const
 
 void VPStandardStateTP::getEnthalpy_RT_ref(span<double> hrt) const
 {
+    checkArraySize("VPStandardStateTP::getEnthalpy_RT_ref", hrt.size(), m_kk);
     updateStandardStateThermo();
     std::copy(m_h0_RT.begin(), m_h0_RT.end(), hrt.begin());
 }
 
 void VPStandardStateTP::getGibbs_RT_ref(span<double> grt) const
 {
+    checkArraySize("VPStandardStateTP::getGibbs_RT_ref", grt.size(), m_kk);
     updateStandardStateThermo();
     std::copy(m_g0_RT.begin(), m_g0_RT.end(), grt.begin());
 }
 
 void VPStandardStateTP::getGibbs_ref(span<double> g) const
 {
+    checkArraySize("VPStandardStateTP::getGibbs_ref", g.size(), m_kk);
     updateStandardStateThermo();
     std::copy(m_g0_RT.begin(), m_g0_RT.end(), g.begin());
     scale(g.begin(), g.end(), g.begin(), RT());
@@ -110,18 +119,21 @@ void VPStandardStateTP::getGibbs_ref(span<double> g) const
 
 void VPStandardStateTP::getEntropy_R_ref(span<double> sr) const
 {
+    checkArraySize("VPStandardStateTP::getEntropy_R_ref", sr.size(), m_kk);
     updateStandardStateThermo();
     std::copy(m_s0_R.begin(), m_s0_R.end(), sr.begin());
 }
 
 void VPStandardStateTP::getCp_R_ref(span<double> cpr) const
 {
+    checkArraySize("VPStandardStateTP::getCp_R_ref", cpr.size(), m_kk);
     updateStandardStateThermo();
     std::copy(m_cp0_R.begin(), m_cp0_R.end(), cpr.begin());
 }
 
 void VPStandardStateTP::getStandardVolumes_ref(span<double> vol) const
 {
+    checkArraySize("VPStandardStateTP::getStandardVolumes_ref", vol.size(), m_kk);
     updateStandardStateThermo();
     std::copy(m_Vss.begin(), m_Vss.end(), vol.begin());
 }

--- a/src/thermo/VPStandardStateTP.cpp
+++ b/src/thermo/VPStandardStateTP.cpp
@@ -81,7 +81,7 @@ void VPStandardStateTP::getStandardVolumes(span<double> vol) const
     updateStandardStateThermo();
     std::copy(m_Vss.begin(), m_Vss.end(), vol.begin());
 }
-const vector<double>& VPStandardStateTP::getStandardVolumes() const
+span<const double> VPStandardStateTP::getStandardVolumes() const
 {
     updateStandardStateThermo();
     return m_Vss;

--- a/src/thermo/VPStandardStateTP.cpp
+++ b/src/thermo/VPStandardStateTP.cpp
@@ -35,7 +35,7 @@ int VPStandardStateTP::standardStateConvention() const
 
 // ----- Thermodynamic Values for the Species Standard States States ----
 
-void VPStandardStateTP::getStandardChemPotentials(double* g) const
+void VPStandardStateTP::getStandardChemPotentials(span<double> g) const
 {
     getGibbs_RT(g);
     for (size_t k = 0; k < m_kk; k++) {
@@ -43,43 +43,43 @@ void VPStandardStateTP::getStandardChemPotentials(double* g) const
     }
 }
 
-void VPStandardStateTP::getEnthalpy_RT(double* hrt) const
+void VPStandardStateTP::getEnthalpy_RT(span<double> hrt) const
 {
     updateStandardStateThermo();
-    std::copy(m_hss_RT.begin(), m_hss_RT.end(), hrt);
+    std::copy(m_hss_RT.begin(), m_hss_RT.end(), hrt.begin());
 }
 
-void VPStandardStateTP::getEntropy_R(double* sr) const
+void VPStandardStateTP::getEntropy_R(span<double> sr) const
 {
     updateStandardStateThermo();
-    std::copy(m_sss_R.begin(), m_sss_R.end(), sr);
+    std::copy(m_sss_R.begin(), m_sss_R.end(), sr.begin());
 }
 
-void VPStandardStateTP::getGibbs_RT(double* grt) const
+void VPStandardStateTP::getGibbs_RT(span<double> grt) const
 {
     updateStandardStateThermo();
-    std::copy(m_gss_RT.begin(), m_gss_RT.end(), grt);
+    std::copy(m_gss_RT.begin(), m_gss_RT.end(), grt.begin());
 }
 
-void VPStandardStateTP::getIntEnergy_RT(double* urt) const
+void VPStandardStateTP::getIntEnergy_RT(span<double> urt) const
 {
     updateStandardStateThermo();
-    std::copy(m_hss_RT.begin(), m_hss_RT.end(), urt);
+    std::copy(m_hss_RT.begin(), m_hss_RT.end(), urt.begin());
     for (size_t k = 0; k < m_kk; k++) {
         urt[k] -= m_Plast_ss / RT() * m_Vss[k];
     }
 }
 
-void VPStandardStateTP::getCp_R(double* cpr) const
+void VPStandardStateTP::getCp_R(span<double> cpr) const
 {
     updateStandardStateThermo();
-    std::copy(m_cpss_R.begin(), m_cpss_R.end(), cpr);
+    std::copy(m_cpss_R.begin(), m_cpss_R.end(), cpr.begin());
 }
 
-void VPStandardStateTP::getStandardVolumes(double* vol) const
+void VPStandardStateTP::getStandardVolumes(span<double> vol) const
 {
     updateStandardStateThermo();
-    std::copy(m_Vss.begin(), m_Vss.end(), vol);
+    std::copy(m_Vss.begin(), m_Vss.end(), vol.begin());
 }
 const vector<double>& VPStandardStateTP::getStandardVolumes() const
 {
@@ -89,41 +89,41 @@ const vector<double>& VPStandardStateTP::getStandardVolumes() const
 
 // ----- Thermodynamic Values for the Species Reference States ----
 
-void VPStandardStateTP::getEnthalpy_RT_ref(double* hrt) const
+void VPStandardStateTP::getEnthalpy_RT_ref(span<double> hrt) const
 {
     updateStandardStateThermo();
-    std::copy(m_h0_RT.begin(), m_h0_RT.end(), hrt);
+    std::copy(m_h0_RT.begin(), m_h0_RT.end(), hrt.begin());
 }
 
-void VPStandardStateTP::getGibbs_RT_ref(double* grt) const
+void VPStandardStateTP::getGibbs_RT_ref(span<double> grt) const
 {
     updateStandardStateThermo();
-    std::copy(m_g0_RT.begin(), m_g0_RT.end(), grt);
+    std::copy(m_g0_RT.begin(), m_g0_RT.end(), grt.begin());
 }
 
-void VPStandardStateTP::getGibbs_ref(double* g) const
+void VPStandardStateTP::getGibbs_ref(span<double> g) const
 {
     updateStandardStateThermo();
-    std::copy(m_g0_RT.begin(), m_g0_RT.end(), g);
-    scale(g, g+m_kk, g, RT());
+    std::copy(m_g0_RT.begin(), m_g0_RT.end(), g.begin());
+    scale(g.begin(), g.end(), g.begin(), RT());
 }
 
-void VPStandardStateTP::getEntropy_R_ref(double* sr) const
+void VPStandardStateTP::getEntropy_R_ref(span<double> sr) const
 {
     updateStandardStateThermo();
-    std::copy(m_s0_R.begin(), m_s0_R.end(), sr);
+    std::copy(m_s0_R.begin(), m_s0_R.end(), sr.begin());
 }
 
-void VPStandardStateTP::getCp_R_ref(double* cpr) const
+void VPStandardStateTP::getCp_R_ref(span<double> cpr) const
 {
     updateStandardStateThermo();
-    std::copy(m_cp0_R.begin(), m_cp0_R.end(), cpr);
+    std::copy(m_cp0_R.begin(), m_cp0_R.end(), cpr.begin());
 }
 
-void VPStandardStateTP::getStandardVolumes_ref(double* vol) const
+void VPStandardStateTP::getStandardVolumes_ref(span<double> vol) const
 {
     updateStandardStateThermo();
-    std::copy(m_Vss.begin(), m_Vss.end(), vol);
+    std::copy(m_Vss.begin(), m_Vss.end(), vol.begin());
 }
 
 void VPStandardStateTP::initThermo()
@@ -186,7 +186,7 @@ void VPStandardStateTP::setPressure(double p)
 
 void VPStandardStateTP::calcDensity()
 {
-    getPartialMolarVolumes(m_workS.data());
+    getPartialMolarVolumes(m_workS);
     double dd = meanMolecularWeight() / mean_X(m_workS);
     Phase::assignDensity(dd);
 }

--- a/src/thermo/WaterSSTP.cpp
+++ b/src/thermo/WaterSSTP.cpp
@@ -79,21 +79,25 @@ void WaterSSTP::initThermo()
 
 void WaterSSTP::getEnthalpy_RT(span<double> hrt) const
 {
+    checkArraySize("WaterSSTP::getEnthalpy_RT", hrt.size(), 1);
     hrt[0] = (m_sub.enthalpy_mass() * m_mw + EW_Offset) / RT();
 }
 
 void WaterSSTP::getIntEnergy_RT(span<double> ubar) const
 {
+    checkArraySize("WaterSSTP::getIntEnergy_RT", ubar.size(), 1);
     ubar[0] = (m_sub.intEnergy_mass() * m_mw + EW_Offset)/ RT();
 }
 
 void WaterSSTP::getEntropy_R(span<double> sr) const
 {
+    checkArraySize("WaterSSTP::getEntropy_R", sr.size(), 1);
     sr[0] = (m_sub.entropy_mass() * m_mw + SW_Offset) / GasConstant;
 }
 
 void WaterSSTP::getGibbs_RT(span<double> grt) const
 {
+    checkArraySize("WaterSSTP::getGibbs_RT", grt.size(), 1);
     grt[0] = (m_sub.gibbs_mass() * m_mw + EW_Offset) / RT()
              - SW_Offset / GasConstant;
     if (!m_ready) {
@@ -103,6 +107,7 @@ void WaterSSTP::getGibbs_RT(span<double> grt) const
 
 void WaterSSTP::getStandardChemPotentials(span<double> gss) const
 {
+    checkArraySize("WaterSSTP::getStandardChemPotentials", gss.size(), 1);
     gss[0] = (m_sub.gibbs_mass() * m_mw + EW_Offset - SW_Offset*temperature());
     if (!m_ready) {
         throw CanteraError("waterSSTP::getStandardChemPotentials",
@@ -112,6 +117,7 @@ void WaterSSTP::getStandardChemPotentials(span<double> gss) const
 
 void WaterSSTP::getCp_R(span<double> cpr) const
 {
+    checkArraySize("WaterSSTP::getCp_R", cpr.size(), 1);
     cpr[0] = m_sub.cp_mass() * m_mw / GasConstant;
 }
 
@@ -122,6 +128,7 @@ double WaterSSTP::cv_mole() const
 
 void WaterSSTP::getEnthalpy_RT_ref(span<double> hrt) const
 {
+    checkArraySize("WaterSSTP::getEnthalpy_RT_ref", hrt.size(), 1);
     double p = pressure();
     double T = temperature();
     double dens = density();
@@ -141,6 +148,7 @@ void WaterSSTP::getEnthalpy_RT_ref(span<double> hrt) const
 
 void WaterSSTP::getGibbs_RT_ref(span<double> grt) const
 {
+    checkArraySize("WaterSSTP::getGibbs_RT_ref", grt.size(), 1);
     double p = pressure();
     double T = temperature();
     double dens = density();
@@ -169,6 +177,7 @@ void WaterSSTP::getGibbs_ref(span<double> g) const
 
 void WaterSSTP::getEntropy_R_ref(span<double> sr) const
 {
+    checkArraySize("WaterSSTP::getEntropy_R_ref", sr.size(), 1);
     double p = pressure();
     double T = temperature();
     double dens = density();
@@ -191,6 +200,7 @@ void WaterSSTP::getEntropy_R_ref(span<double> sr) const
 
 void WaterSSTP::getCp_R_ref(span<double> cpr) const
 {
+    checkArraySize("WaterSSTP::getCp_R_ref", cpr.size(), 1);
     double p = pressure();
     double T = temperature();
     double dens = density();
@@ -211,6 +221,7 @@ void WaterSSTP::getCp_R_ref(span<double> cpr) const
 
 void WaterSSTP::getStandardVolumes_ref(span<double> vol) const
 {
+    checkArraySize("WaterSSTP::getStandardVolumes_ref", vol.size(), 1);
     double p = pressure();
     double T = temperature();
     double dens = density();

--- a/src/thermo/WaterSSTP.cpp
+++ b/src/thermo/WaterSSTP.cpp
@@ -77,40 +77,40 @@ void WaterSSTP::initThermo()
     m_ready = true;
 }
 
-void WaterSSTP::getEnthalpy_RT(double* hrt) const
+void WaterSSTP::getEnthalpy_RT(span<double> hrt) const
 {
-    *hrt = (m_sub.enthalpy_mass() * m_mw + EW_Offset) / RT();
+    hrt[0] = (m_sub.enthalpy_mass() * m_mw + EW_Offset) / RT();
 }
 
-void WaterSSTP::getIntEnergy_RT(double* ubar) const
+void WaterSSTP::getIntEnergy_RT(span<double> ubar) const
 {
-    *ubar = (m_sub.intEnergy_mass() * m_mw + EW_Offset)/ RT();
+    ubar[0] = (m_sub.intEnergy_mass() * m_mw + EW_Offset)/ RT();
 }
 
-void WaterSSTP::getEntropy_R(double* sr) const
+void WaterSSTP::getEntropy_R(span<double> sr) const
 {
     sr[0] = (m_sub.entropy_mass() * m_mw + SW_Offset) / GasConstant;
 }
 
-void WaterSSTP::getGibbs_RT(double* grt) const
+void WaterSSTP::getGibbs_RT(span<double> grt) const
 {
-    *grt = (m_sub.gibbs_mass() * m_mw + EW_Offset) / RT()
-           - SW_Offset / GasConstant;
+    grt[0] = (m_sub.gibbs_mass() * m_mw + EW_Offset) / RT()
+             - SW_Offset / GasConstant;
     if (!m_ready) {
         throw CanteraError("waterSSTP::getGibbs_RT", "Phase not ready");
     }
 }
 
-void WaterSSTP::getStandardChemPotentials(double* gss) const
+void WaterSSTP::getStandardChemPotentials(span<double> gss) const
 {
-    *gss = (m_sub.gibbs_mass() * m_mw + EW_Offset - SW_Offset*temperature());
+    gss[0] = (m_sub.gibbs_mass() * m_mw + EW_Offset - SW_Offset*temperature());
     if (!m_ready) {
         throw CanteraError("waterSSTP::getStandardChemPotentials",
                            "Phase not ready");
     }
 }
 
-void WaterSSTP::getCp_R(double* cpr) const
+void WaterSSTP::getCp_R(span<double> cpr) const
 {
     cpr[0] = m_sub.cp_mass() * m_mw / GasConstant;
 }
@@ -120,7 +120,7 @@ double WaterSSTP::cv_mole() const
     return m_sub.cv_mass() * m_mw;
 }
 
-void WaterSSTP::getEnthalpy_RT_ref(double* hrt) const
+void WaterSSTP::getEnthalpy_RT_ref(span<double> hrt) const
 {
     double p = pressure();
     double T = temperature();
@@ -135,11 +135,11 @@ void WaterSSTP::getEnthalpy_RT_ref(double* hrt) const
         throw CanteraError("WaterSSTP::getEnthalpy_RT_ref", "error");
     }
     double h = m_sub.enthalpy_mass() * m_mw;
-    *hrt = (h + EW_Offset) / RT();
+    hrt[0] = (h + EW_Offset) / RT();
     dd = m_sub.density(T, p, waterState, dens);
 }
 
-void WaterSSTP::getGibbs_RT_ref(double* grt) const
+void WaterSSTP::getGibbs_RT_ref(span<double> grt) const
 {
     double p = pressure();
     double T = temperature();
@@ -155,11 +155,11 @@ void WaterSSTP::getGibbs_RT_ref(double* grt) const
     }
     m_sub.setState_TD(T, dd);
     double g = m_sub.gibbs_mass() * m_mw;
-    *grt = (g + EW_Offset - SW_Offset*T)/ RT();
+    grt[0] = (g + EW_Offset - SW_Offset*T) / RT();
     dd = m_sub.density(T, p, waterState, dens);
 }
 
-void WaterSSTP::getGibbs_ref(double* g) const
+void WaterSSTP::getGibbs_ref(span<double> g) const
 {
     getGibbs_RT_ref(g);
     for (size_t k = 0; k < m_kk; k++) {
@@ -167,7 +167,7 @@ void WaterSSTP::getGibbs_ref(double* g) const
     }
 }
 
-void WaterSSTP::getEntropy_R_ref(double* sr) const
+void WaterSSTP::getEntropy_R_ref(span<double> sr) const
 {
     double p = pressure();
     double T = temperature();
@@ -185,11 +185,11 @@ void WaterSSTP::getEntropy_R_ref(double* sr) const
     m_sub.setState_TD(T, dd);
 
     double s = m_sub.entropy_mass() * m_mw;
-    *sr = (s + SW_Offset)/ GasConstant;
+    sr[0] = (s + SW_Offset) / GasConstant;
     dd = m_sub.density(T, p, waterState, dens);
 }
 
-void WaterSSTP::getCp_R_ref(double* cpr) const
+void WaterSSTP::getCp_R_ref(span<double> cpr) const
 {
     double p = pressure();
     double T = temperature();
@@ -205,11 +205,11 @@ void WaterSSTP::getCp_R_ref(double* cpr) const
         throw CanteraError("WaterSSTP::getCp_R_ref", "error");
     }
     double cp = m_sub.cp_mass() * m_mw;
-    *cpr = cp / GasConstant;
+    cpr[0] = cp / GasConstant;
     dd = m_sub.density(T, p, waterState, dens);
 }
 
-void WaterSSTP::getStandardVolumes_ref(double* vol) const
+void WaterSSTP::getStandardVolumes_ref(span<double> vol) const
 {
     double p = pressure();
     double T = temperature();
@@ -223,7 +223,7 @@ void WaterSSTP::getStandardVolumes_ref(double* vol) const
     if (dd <= 0.0) {
         throw CanteraError("WaterSSTP::getStandardVolumes_ref", "error");
     }
-    *vol = meanMolecularWeight() /dd;
+    vol[0] = meanMolecularWeight() / dd;
     dd = m_sub.density(T, p, waterState, dens);
 }
 

--- a/src/transport/DustyGasTransport.cpp
+++ b/src/transport/DustyGasTransport.cpp
@@ -32,7 +32,7 @@ void DustyGasTransport::initialize(shared_ptr<ThermoPhase> phase, Transport* gas
     m_dk.resize(m_nsp, 0.0);
 
     m_x.resize(m_nsp, 0.0);
-    m_thermo->getMoleFractions(m_x.data());
+    m_thermo->getMoleFractions(m_x);
 
     // set flags all false
     m_knudsen_ok = false;
@@ -187,7 +187,7 @@ void DustyGasTransport::updateTransport_T()
 
 void DustyGasTransport::updateTransport_C()
 {
-    m_thermo->getMoleFractions(m_x.data());
+    m_thermo->getMoleFractions(m_x);
 
     // add an offset to avoid a pure species condition
     // (check - this may be unnecessary)

--- a/src/transport/DustyGasTransport.cpp
+++ b/src/transport/DustyGasTransport.cpp
@@ -100,7 +100,7 @@ void DustyGasTransport::getMolarFluxes(const double* const state1,
                                        double* const fluxes)
 {
     // cbar will be the average concentration between the two points
-    double* const cbar = m_spwork.data();
+    span<double> cbar(m_spwork);
     double* const gradc = m_spwork2.data();
     const double t1 = state1[0];
     const double t2 = state2[0];
@@ -146,10 +146,10 @@ void DustyGasTransport::getMolarFluxes(const double* const state1,
         b = m_perm;
     }
     b *= gradp / m_gastran->viscosity();
-    scale(cbar, cbar + m_nsp, cbar, b);
+    scale(cbar.begin(), cbar.end(), cbar.begin(), b);
 
     // Multiply m_multidiff with cbar and add it to fluxes
-    increment(m_multidiff, cbar, fluxes);
+    increment(m_multidiff, cbar.data(), fluxes);
     scale(fluxes, fluxes + m_nsp, fluxes, -1.0);
 }
 

--- a/src/transport/DustyGasTransport.cpp
+++ b/src/transport/DustyGasTransport.cpp
@@ -25,7 +25,8 @@ void DustyGasTransport::initialize(shared_ptr<ThermoPhase> phase, Transport* gas
     }
 
     // make a local copy of the molecular weights
-    m_mw = m_thermo->molecularWeights();
+    m_mw.assign(m_thermo->molecularWeights().begin(),
+                m_thermo->molecularWeights().end());
 
     m_multidiff.resize(m_nsp, m_nsp);
     m_d.resize(m_nsp, m_nsp);

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -276,7 +276,8 @@ void GasTransport::init(shared_ptr<ThermoPhase> thermo, int mode)
     m_bdiff.resize(m_nsp, m_nsp);
 
     // make a local copy of the molecular weights
-    m_mw = m_thermo->molecularWeights();
+    m_mw.resize(m_nsp);
+    m_thermo->getMolecularWeights(m_mw.data());
 
     m_wratjk.resize(m_nsp, m_nsp, 0.0);
     m_wratkj1.resize(m_nsp, m_nsp, 0.0);
@@ -308,7 +309,7 @@ void GasTransport::setupCollisionParameters()
     m_disp.resize(m_nsp, 0.0);
     m_quad_polar.resize(m_nsp, 0.0);
 
-    const vector<double>& mw = m_thermo->molecularWeights();
+    auto mw = m_thermo->molecularWeights();
     getTransportData();
 
     for (size_t i = 0; i < m_nsp; i++) {
@@ -516,7 +517,7 @@ void GasTransport::fitProperties(MMCollisionInt& integrals)
     double visc, err, relerr,
                mxerr = 0.0, mxrelerr = 0.0, mxerr_cond = 0.0, mxrelerr_cond = 0.0;
     double T_save = m_thermo->temperature();
-    const vector<double>& mw = m_thermo->molecularWeights();
+    auto mw = m_thermo->molecularWeights();
     for (size_t k = 0; k < m_nsp; k++) {
         double tstar = Boltzmann * 298.0 / m_eps[k];
         // Scaling factor for temperature dependence of z_rot. [Kee2003] Eq.

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -277,7 +277,7 @@ void GasTransport::init(shared_ptr<ThermoPhase> thermo, int mode)
 
     // make a local copy of the molecular weights
     m_mw.resize(m_nsp);
-    m_thermo->getMolecularWeights(m_mw.data());
+    m_thermo->getMolecularWeights(m_mw);
 
     m_wratjk.resize(m_nsp, m_nsp, 0.0);
     m_wratkj1.resize(m_nsp, m_nsp, 0.0);

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -529,7 +529,7 @@ void GasTransport::fitProperties(MMCollisionInt& integrals)
             double t = m_thermo->minTemp() + dt*n;
             m_thermo->setTemperature(t);
             vector<double> cp_R_all(m_thermo->nSpecies());
-            m_thermo->getCp_R_ref(&cp_R_all[0]);
+            m_thermo->getCp_R_ref(cp_R_all);
             double cp_R = cp_R_all[k];
             tstar = Boltzmann * t / m_eps[k];
             double sqrt_T = sqrt(t);

--- a/src/transport/HighPressureGasTransport.cpp
+++ b/src/transport/HighPressureGasTransport.cpp
@@ -353,7 +353,7 @@ double HighPressureGasTransport::thermalConductivity()
     vector<double> molefracs(m_nsp);
     m_thermo->getMoleFractions(molefracs);
     vector<double> cp_0_R(m_nsp);
-    m_thermo->getCp_R_ref(&cp_0_R[0]); // Cp/R
+    m_thermo->getCp_R_ref(cp_0_R); // Cp/R
 
     // A model constant from the Euken correlation for polyatomic gases, described
     // below Equation 1 in ely-hanley1981 .
@@ -366,7 +366,7 @@ double HighPressureGasTransport::thermalConductivity()
     vector<double> h_i(m_nsp);
     vector<double> V_k(m_nsp);
 
-    m_thermo -> getPartialMolarVolumes(&V_k[0]);
+    m_thermo -> getPartialMolarVolumes(V_k);
     for (size_t i = 0; i < m_nsp; i++) {
         // Calculate variables for density-independent component, Equation 1,
         // the equation requires the pure-species viscosity estimate from

--- a/src/transport/HighPressureGasTransport.cpp
+++ b/src/transport/HighPressureGasTransport.cpp
@@ -136,13 +136,13 @@ void HighPressureGasTransportBase::initializeCriticalProperties()
     m_Zcrit.resize(nSpecies);
 
     vector<double> molefracs(nSpecies);
-    m_thermo->getMoleFractions(&molefracs[0]);
+    m_thermo->getMoleFractions(molefracs);
 
     vector<double> mf_temp(nSpecies, 0.0);
 
     for (size_t i = 0; i < nSpecies; ++i) {
         mf_temp[i] = 1.0;
-        m_thermo->setMoleFractions(&mf_temp[0]);
+        m_thermo->setMoleFractions(mf_temp);
 
         if (m_thermo->critTemperature() > 1e4) {
             throw CanteraError(
@@ -161,7 +161,7 @@ void HighPressureGasTransportBase::initializeCriticalProperties()
     }
 
     // Restore actual mole fractions
-    m_thermo->setMoleFractions(&molefracs[0]);
+    m_thermo->setMoleFractions(molefracs);
 }
 
 // Pure species critical properties - Tc, Pc, Vc, Zc:
@@ -351,7 +351,7 @@ double HighPressureGasTransport::thermalConductivity()
 {
     update_T();
     vector<double> molefracs(m_nsp);
-    m_thermo->getMoleFractions(&molefracs[0]);
+    m_thermo->getMoleFractions(molefracs);
     vector<double> cp_0_R(m_nsp);
     m_thermo->getCp_R_ref(&cp_0_R[0]); // Cp/R
 
@@ -594,7 +594,7 @@ void HighPressureGasTransport::computeMixtureParameters()
     double P_vap_mix = m_thermo->satPressure(tKelvin);
     size_t nsp = m_thermo->nSpecies();
     vector<double> molefracs(nsp);
-    m_thermo->getMoleFractions(&molefracs[0]);
+    m_thermo->getMoleFractions(molefracs);
 
     double x_H = molefracs[0]; // Holds the mole fraction of the heaviest species
     for (size_t i = 0; i < m_nsp; i++) {
@@ -945,7 +945,7 @@ void ChungHighPressureGasTransport::computeMixtureParameters()
     m_mu_r_mix = 0.0;
 
     vector<double> molefracs(m_nsp);
-    m_thermo->getMoleFractions(&molefracs[0]);
+    m_thermo->getMoleFractions(molefracs);
     for (size_t i = 0; i < m_nsp; i++) {
         for (size_t j = 0; j <m_nsp; j++){
             double sigma_ij = sqrt(m_sigma_i[i]*m_sigma_i[j]); // Equation 9-5.33

--- a/src/transport/IonGasTransport.cpp
+++ b/src/transport/IonGasTransport.cpp
@@ -80,7 +80,7 @@ void IonGasTransport::init(shared_ptr<ThermoPhase> thermo, int mode)
 
     // make a local copy of the molecular weights
     m_mw.resize(m_nsp);
-    m_thermo->getMolecularWeights(m_mw.data());
+    m_thermo->getMolecularWeights(m_mw);
 
     m_wratjk.resize(m_nsp, m_nsp, 0.0);
     m_wratkj1.resize(m_nsp, m_nsp, 0.0);

--- a/src/transport/IonGasTransport.cpp
+++ b/src/transport/IonGasTransport.cpp
@@ -79,7 +79,8 @@ void IonGasTransport::init(shared_ptr<ThermoPhase> thermo, int mode)
     m_cond.resize(m_nsp);
 
     // make a local copy of the molecular weights
-    m_mw = m_thermo->molecularWeights();
+    m_mw.resize(m_nsp);
+    m_thermo->getMolecularWeights(m_mw.data());
 
     m_wratjk.resize(m_nsp, m_nsp, 0.0);
     m_wratkj1.resize(m_nsp, m_nsp, 0.0);

--- a/src/transport/MixTransport.cpp
+++ b/src/transport/MixTransport.cpp
@@ -59,7 +59,7 @@ void MixTransport::getThermalDiffCoeffs(double* const dt)
         updateViscosity_T();
     }
 
-    const double* y = m_thermo->massFractions();
+    auto y = m_thermo->massFractions();
 
     vector<double>& a = m_spwork;
 
@@ -130,8 +130,8 @@ void MixTransport::getSpeciesFluxes(size_t ndim, const double* const grad_T,
     update_T();
     update_C();
     getMixDiffCoeffs(m_spwork.data());
-    const vector<double>& mw = m_thermo->molecularWeights();
-    const double* y = m_thermo->massFractions();
+    auto mw = m_thermo->molecularWeights();
+    auto y = m_thermo->massFractions();
     double rhon = m_thermo->molarDensity();
     vector<double> sum(ndim,0.0);
     for (size_t n = 0; n < ndim; n++) {

--- a/src/transport/MixTransport.cpp
+++ b/src/transport/MixTransport.cpp
@@ -167,7 +167,7 @@ void MixTransport::update_C()
     // before use, and update the local mole fractions.
     m_visc_ok = false;
     m_condmix_ok = false;
-    m_thermo->getMoleFractions(m_molefracs.data());
+    m_thermo->getMoleFractions(m_molefracs);
 
     // add an offset to avoid a pure species condition
     for (size_t k = 0; k < m_nsp; k++) {

--- a/src/transport/MultiTransport.cpp
+++ b/src/transport/MultiTransport.cpp
@@ -264,12 +264,12 @@ void MultiTransport::getMassFluxes(const double* state1, const double* state2,
     double* x2 = m_spwork2.data();
     double* x3 = m_spwork3.data();
     size_t nsp = m_thermo->nSpecies();
-    m_thermo->restoreState(nsp+2, state1);
+    m_thermo->restoreState(span<const double>(state1, nsp + 2));
     double p1 = m_thermo->pressure();
     double t1 = state1[0];
     m_thermo->getMoleFractions(span<double>(x1, nsp));
 
-    m_thermo->restoreState(nsp+2, state2);
+    m_thermo->restoreState(span<const double>(state2, nsp + 2));
     double p2 = m_thermo->pressure();
     double t2 = state2[0];
     m_thermo->getMoleFractions(span<double>(x2, nsp));

--- a/src/transport/MultiTransport.cpp
+++ b/src/transport/MultiTransport.cpp
@@ -260,19 +260,19 @@ void MultiTransport::getSpeciesFluxes(size_t ndim, const double* const grad_T,
 void MultiTransport::getMassFluxes(const double* state1, const double* state2,
                                    double delta, double* fluxes)
 {
-    double* x1 = m_spwork1.data();
-    double* x2 = m_spwork2.data();
-    double* x3 = m_spwork3.data();
+    span<double> x1(m_spwork1);
+    span<double> x2(m_spwork2);
+    span<double> x3(m_spwork3);
     size_t nsp = m_thermo->nSpecies();
     m_thermo->restoreState(span<const double>(state1, nsp + 2));
     double p1 = m_thermo->pressure();
     double t1 = state1[0];
-    m_thermo->getMoleFractions(span<double>(x1, nsp));
+    m_thermo->getMoleFractions(x1);
 
     m_thermo->restoreState(span<const double>(state2, nsp + 2));
     double p2 = m_thermo->pressure();
     double t2 = state2[0];
-    m_thermo->getMoleFractions(span<double>(x2, nsp));
+    m_thermo->getMoleFractions(x2);
 
     double p = 0.5*(p1 + p2);
     double t = 0.5*(state1[0] + state2[0]);
@@ -470,7 +470,7 @@ void MultiTransport::updateThermal_T()
      *       The original Dixon-Lewis paper subtracted 1.5 here.
      */
     vector<double> cp(m_thermo->nSpecies());
-    m_thermo->getCp_R_ref(&cp[0]);
+    m_thermo->getCp_R_ref(cp);
     for (size_t k = 0; k < m_nsp; k++) {
         m_cinternal[k] = cp[k] - 2.5;
     }

--- a/src/transport/MultiTransport.cpp
+++ b/src/transport/MultiTransport.cpp
@@ -267,12 +267,12 @@ void MultiTransport::getMassFluxes(const double* state1, const double* state2,
     m_thermo->restoreState(nsp+2, state1);
     double p1 = m_thermo->pressure();
     double t1 = state1[0];
-    m_thermo->getMoleFractions(x1);
+    m_thermo->getMoleFractions(span<double>(x1, nsp));
 
     m_thermo->restoreState(nsp+2, state2);
     double p2 = m_thermo->pressure();
     double t2 = state2[0];
-    m_thermo->getMoleFractions(x2);
+    m_thermo->getMoleFractions(span<double>(x2, nsp));
 
     double p = 0.5*(p1 + p2);
     double t = 0.5*(state1[0] + state2[0]);
@@ -281,7 +281,7 @@ void MultiTransport::getMassFluxes(const double* state1, const double* state2,
         x3[n] = 0.5*(x1[n] + x2[n]);
     }
     m_thermo->setState_TPX(t, p, x3);
-    m_thermo->getMoleFractions(m_molefracs.data());
+    m_thermo->getMoleFractions(m_molefracs);
 
     // update the binary diffusion coefficients if necessary
     update_T();
@@ -405,7 +405,7 @@ void MultiTransport::update_T()
 void MultiTransport::update_C()
 {
     // Update the local mole fraction array
-    m_thermo->getMoleFractions(m_molefracs.data());
+    m_thermo->getMoleFractions(m_molefracs);
 
     for (size_t k = 0; k < m_nsp; k++) {
         // add an offset to avoid a pure species condition

--- a/src/transport/MultiTransport.cpp
+++ b/src/transport/MultiTransport.cpp
@@ -191,7 +191,7 @@ void MultiTransport::getSpeciesFluxes(size_t ndim, const double* const grad_T,
         getThermalDiffCoeffs(m_spwork.data());
     }
 
-    const double* y = m_thermo->massFractions();
+    auto y = m_thermo->massFractions();
     double rho = m_thermo->density();
 
     for (size_t i = 0; i < m_nsp; i++) {
@@ -295,7 +295,7 @@ void MultiTransport::getMassFluxes(const double* state1, const double* state2,
         getThermalDiffCoeffs(m_spwork.data());
     }
 
-    const double* y = m_thermo->massFractions();
+    auto y = m_thermo->massFractions();
     double rho = m_thermo->density();
     for (size_t i = 0; i < m_nsp; i++) {
         double sum = 0.0;

--- a/src/transport/TransportFactory.cpp
+++ b/src/transport/TransportFactory.cpp
@@ -78,7 +78,7 @@ Transport* TransportFactory::newTransport(const string& transportModel,
             "new '{}' object", transportModel);
     }
 
-    vector<double> state;
+    vector<double> state(phase->stateSize());
     Transport* tr = 0;
     phase->saveState(state);
 

--- a/src/zeroD/ConstPressureMoleReactor.cpp
+++ b/src/zeroD/ConstPressureMoleReactor.cpp
@@ -61,7 +61,7 @@ void ConstPressureMoleReactor::eval(double time, double* LHS, double* RHS)
     evalWalls(time);
     updateSurfaceProductionRates();
 
-    const vector<double>& imw = m_thermo->inverseMolecularWeights();
+    auto imw = m_thermo->inverseMolecularWeights();
 
     if (m_chem) {
         m_kin->getNetProductionRates(&m_wdot[0]); // "omega dot"

--- a/src/zeroD/ConstPressureMoleReactor.cpp
+++ b/src/zeroD/ConstPressureMoleReactor.cpp
@@ -44,7 +44,7 @@ void ConstPressureMoleReactor::updateState(double* y)
     // moles of each species, and [K+1...] are the moles of surface
     // species on each wall.
     setMassFromMoles(y + m_sidx);
-    m_thermo->setMolesNoTruncate(y + m_sidx);
+    m_thermo->setMolesNoTruncate(span<const double>(y + m_sidx, m_nsp));
     if (m_energy) {
         m_thermo->setState_HP(y[0] / m_mass, m_pressure);
     } else {

--- a/src/zeroD/ConstPressureReactor.cpp
+++ b/src/zeroD/ConstPressureReactor.cpp
@@ -66,8 +66,8 @@ void ConstPressureReactor::eval(double time, double* LHS, double* RHS)
     evalWalls(time);
     updateSurfaceProductionRates();
 
-    const vector<double>& mw = m_thermo->molecularWeights();
-    const double* Y = m_thermo->massFractions();
+    auto mw = m_thermo->molecularWeights();
+    auto Y = m_thermo->massFractions();
     double mdot_surf = dot(m_sdot.begin(), m_sdot.end(), mw.begin());
     dmdt += mdot_surf;
 

--- a/src/zeroD/ConstPressureReactor.cpp
+++ b/src/zeroD/ConstPressureReactor.cpp
@@ -36,7 +36,7 @@ void ConstPressureReactor::getState(double* y)
     y[1] = m_thermo->enthalpy_mass() * m_thermo->density() * m_vol;
 
     // set components y+2 ... y+K+1 to the mass fractions Y_k of each species
-    m_thermo->getMassFractions(y+2);
+    m_thermo->getMassFractions(span<double>(y + 2, m_nsp));
 
 }
 
@@ -46,7 +46,7 @@ void ConstPressureReactor::updateState(double* y)
     // [2...K+2) are the mass fractions of each species, and [K+2...] are the
     // coverages of surface species on each wall.
     m_mass = y[0];
-    m_thermo->setMassFractions_NoNorm(y+2);
+    m_thermo->setMassFractions_NoNorm(span<const double>(y + 2, m_nsp));
     if (m_energy) {
         m_thermo->setState_HP(y[1]/m_mass, m_pressure);
     } else {

--- a/src/zeroD/FlowReactor.cpp
+++ b/src/zeroD/FlowReactor.cpp
@@ -34,7 +34,7 @@ FlowReactor::FlowReactor(shared_ptr<Solution> sol, bool clone, const string& nam
 
 void FlowReactor::getStateDae(double* y, double* ydot)
 {
-    m_thermo->getMassFractions(y+m_offset_Y);
+    m_thermo->getMassFractions(span<double>(y + m_offset_Y, m_nsp));
     const vector<double>& mw = m_thermo->molecularWeights();
 
     // set the first component to the initial density
@@ -152,7 +152,7 @@ void FlowReactor::updateState(double* y)
     // Set the mass fractions and density of the mixture.
     m_rho = y[0];
     m_u = y[1];
-    m_thermo->setMassFractions_NoNorm(y + m_offset_Y);
+    m_thermo->setMassFractions_NoNorm(span<const double>(y + m_offset_Y, m_nsp));
     m_thermo->setState_TP(y[3], y[2]);
 }
 

--- a/src/zeroD/FlowReactor.cpp
+++ b/src/zeroD/FlowReactor.cpp
@@ -128,7 +128,7 @@ void FlowReactor::getStateDae(double* y, double* ydot)
         //              h_mass = h_mole / Wk
         //       hence:
         //              h_mass * Wk = h_mol
-        m_thermo->getPartialMolarEnthalpies(m_hk.data());
+        m_thermo->getPartialMolarEnthalpies(m_hk);
         for (size_t i = 0; i < m_nsp; ++i) {
             ydot[3] -= m_hk[i] * (m_wdot[i] + m_sdot[i] / m_area);
         }
@@ -176,7 +176,7 @@ void FlowReactor::evalDae(double time, double* y, double* ydot, double* residual
     for (size_t i = 0; i < m_nsp; ++i) {
         sk_wk += m_sdot[i] * mw[i] / m_area;
     }
-    m_thermo->getPartialMolarEnthalpies(m_hk.data());
+    m_thermo->getPartialMolarEnthalpies(m_hk);
     // get net production
     if (m_chem) {
         m_kin->getNetProductionRates(m_wdot.data());

--- a/src/zeroD/FlowReactor.cpp
+++ b/src/zeroD/FlowReactor.cpp
@@ -35,7 +35,7 @@ FlowReactor::FlowReactor(shared_ptr<Solution> sol, bool clone, const string& nam
 void FlowReactor::getStateDae(double* y, double* ydot)
 {
     m_thermo->getMassFractions(span<double>(y + m_offset_Y, m_nsp));
-    const vector<double>& mw = m_thermo->molecularWeights();
+    auto mw = m_thermo->molecularWeights();
 
     // set the first component to the initial density
     y[0] = m_thermo->density();
@@ -171,7 +171,7 @@ void FlowReactor::setArea(double area) {
 void FlowReactor::evalDae(double time, double* y, double* ydot, double* residual)
 {
     updateSurfaceProductionRates();
-    const vector<double>& mw = m_thermo->molecularWeights();
+    auto mw = m_thermo->molecularWeights();
     double sk_wk = 0;
     for (size_t i = 0; i < m_nsp; ++i) {
         sk_wk += m_sdot[i] * mw[i] / m_area;

--- a/src/zeroD/IdealGasConstPressureMoleReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureMoleReactor.cpp
@@ -12,6 +12,7 @@
 #include "cantera/thermo/ThermoPhase.h"
 #include "cantera/thermo/SurfPhase.h"
 #include "cantera/base/utilities.h"
+#include "cantera/numerics/eigen_dense.h"
 #include <limits>
 
 namespace Cantera
@@ -46,7 +47,7 @@ void IdealGasConstPressureMoleReactor::updateState(double* y)
     m_thermo->setMolesNoTruncate(span<const double>(y + m_sidx, m_nsp));
     m_thermo->setState_TP(y[0], m_pressure);
     m_vol = m_mass / m_thermo->density();
-    m_thermo->getPartialMolarEnthalpies(m_hk.data());
+    m_thermo->getPartialMolarEnthalpies(m_hk);
     m_TotalCp = m_mass * m_thermo->cp_mass();
     updateConnected(false);
 }
@@ -158,8 +159,8 @@ void IdealGasConstPressureMoleReactor::getJacobianElements(
         Eigen::VectorXd enthalpy = Eigen::VectorXd::Zero(m_nsp);
         Eigen::VectorXd specificHeat = Eigen::VectorXd::Zero(m_nsp);
         // gas phase
-        m_thermo->getPartialMolarCp(specificHeat.data());
-        m_thermo->getPartialMolarEnthalpies(enthalpy.data());
+        m_thermo->getPartialMolarCp(asSpan(specificHeat));
+        m_thermo->getPartialMolarEnthalpies(asSpan(enthalpy));
         m_kin->getNetProductionRates(netProductionRates.data());
         // scale production rates by the volume for gas species
         for (size_t i = 0; i < m_nsp; i++) {

--- a/src/zeroD/IdealGasConstPressureMoleReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureMoleReactor.cpp
@@ -43,7 +43,7 @@ void IdealGasConstPressureMoleReactor::updateState(double* y)
     // moles of each species, and [K+1...] are the moles of surface
     // species on each wall.
     setMassFromMoles(y + m_sidx);
-    m_thermo->setMolesNoTruncate(y + m_sidx);
+    m_thermo->setMolesNoTruncate(span<const double>(y + m_sidx, m_nsp));
     m_thermo->setState_TP(y[0], m_pressure);
     m_vol = m_mass / m_thermo->density();
     m_thermo->getPartialMolarEnthalpies(m_hk.data());

--- a/src/zeroD/IdealGasConstPressureMoleReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureMoleReactor.cpp
@@ -58,7 +58,7 @@ void IdealGasConstPressureMoleReactor::eval(double time, double* LHS, double* RH
 
     evalWalls(time);
     updateSurfaceProductionRates();
-    const vector<double>& imw = m_thermo->inverseMolecularWeights();
+    auto imw = m_thermo->inverseMolecularWeights();
 
     if (m_chem) {
         m_kin->getNetProductionRates(&m_wdot[0]); // "omega dot"

--- a/src/zeroD/IdealGasConstPressureReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureReactor.cpp
@@ -64,7 +64,8 @@ void IdealGasConstPressureReactor::eval(double time, double* LHS, double* RHS)
     auto Y = m_thermo->massFractions();
     double mdot_surf = dot(m_sdot.begin(), m_sdot.end(), mw.begin());
     dmdt += mdot_surf;
-    m_thermo->getPartialMolarEnthalpies(&m_hk[0]);
+
+    m_thermo->getPartialMolarEnthalpies(m_hk);
 
     if (m_chem) {
         m_kin->getNetProductionRates(&m_wdot[0]); // "omega dot"

--- a/src/zeroD/IdealGasConstPressureReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureReactor.cpp
@@ -60,8 +60,8 @@ void IdealGasConstPressureReactor::eval(double time, double* LHS, double* RHS)
 
     evalWalls(time);
     updateSurfaceProductionRates();
-    const vector<double>& mw = m_thermo->molecularWeights();
-    const double* Y = m_thermo->massFractions();
+    auto mw = m_thermo->molecularWeights();
+    auto Y = m_thermo->massFractions();
     double mdot_surf = dot(m_sdot.begin(), m_sdot.end(), mw.begin());
     dmdt += mdot_surf;
     m_thermo->getPartialMolarEnthalpies(&m_hk[0]);

--- a/src/zeroD/IdealGasConstPressureReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureReactor.cpp
@@ -22,7 +22,7 @@ void IdealGasConstPressureReactor::getState(double* y)
     y[1] = m_thermo->temperature();
 
     // set components y+2 ... y+K+1 to the mass fractions Y_k of each species
-    m_thermo->getMassFractions(y+2);
+    m_thermo->getMassFractions(span<double>(y + 2, m_nsp));
 }
 
 void IdealGasConstPressureReactor::initialize(double t0)
@@ -43,7 +43,7 @@ void IdealGasConstPressureReactor::updateState(double* y)
     // [2...K+2) are the mass fractions of each species, and [K+2...] are the
     // coverages of surface species on each wall.
     m_mass = y[0];
-    m_thermo->setMassFractions_NoNorm(y+2);
+    m_thermo->setMassFractions_NoNorm(span<const double>(y + 2, m_nsp));
     m_thermo->setState_TP(y[1], m_pressure);
     m_vol = m_mass / m_thermo->density();
     updateConnected(false);

--- a/src/zeroD/IdealGasMoleReactor.cpp
+++ b/src/zeroD/IdealGasMoleReactor.cpp
@@ -104,7 +104,7 @@ void IdealGasMoleReactor::updateState(double* y)
     setMassFromMoles(y + m_sidx);
     m_vol = y[1];
     // set state
-    m_thermo->setMolesNoTruncate(y + m_sidx);
+    m_thermo->setMolesNoTruncate(span<const double>(y + m_sidx, m_nsp));
     m_thermo->setState_TD(y[0], m_mass / m_vol);
     m_thermo->getPartialMolarIntEnergies(m_uk.data());
     m_TotalCv = m_mass * m_thermo->cv_mass();

--- a/src/zeroD/IdealGasMoleReactor.cpp
+++ b/src/zeroD/IdealGasMoleReactor.cpp
@@ -118,7 +118,7 @@ void IdealGasMoleReactor::eval(double time, double* LHS, double* RHS)
 
     evalWalls(time);
     updateSurfaceProductionRates();
-    const vector<double>& imw = m_thermo->inverseMolecularWeights();
+    auto imw = m_thermo->inverseMolecularWeights();
 
     if (m_chem) {
         m_kin->getNetProductionRates(&m_wdot[0]); // "omega dot"

--- a/src/zeroD/IdealGasReactor.cpp
+++ b/src/zeroD/IdealGasReactor.cpp
@@ -61,7 +61,7 @@ void IdealGasReactor::eval(double time, double* LHS, double* RHS)
 
     evalWalls(time);
     updateSurfaceProductionRates();
-    m_thermo->getPartialMolarIntEnergies(&m_uk[0]);
+    m_thermo->getPartialMolarIntEnergies(m_uk);
     auto mw = m_thermo->molecularWeights();
     auto Y = m_thermo->massFractions();
 

--- a/src/zeroD/IdealGasReactor.cpp
+++ b/src/zeroD/IdealGasReactor.cpp
@@ -62,8 +62,8 @@ void IdealGasReactor::eval(double time, double* LHS, double* RHS)
     evalWalls(time);
     updateSurfaceProductionRates();
     m_thermo->getPartialMolarIntEnergies(&m_uk[0]);
-    const vector<double>& mw = m_thermo->molecularWeights();
-    const double* Y = m_thermo->massFractions();
+    auto mw = m_thermo->molecularWeights();
+    auto Y = m_thermo->massFractions();
 
     if (m_chem) {
         m_kin->getNetProductionRates(&m_wdot[0]); // "omega dot"

--- a/src/zeroD/IdealGasReactor.cpp
+++ b/src/zeroD/IdealGasReactor.cpp
@@ -26,7 +26,7 @@ void IdealGasReactor::getState(double* y)
     y[2] = m_thermo->temperature();
 
     // set components y+3 ... y+K+2 to the mass fractions of each species
-    m_thermo->getMassFractions(y+3);
+    m_thermo->getMassFractions(span<double>(y + 3, m_nsp));
 }
 
 void IdealGasReactor::initialize(double t0)
@@ -48,7 +48,7 @@ void IdealGasReactor::updateState(double* y)
     // and [K+3...] are the coverages of surface species on each wall.
     m_mass = y[0];
     m_vol = y[1];
-    m_thermo->setMassFractions_NoNorm(y+3);
+    m_thermo->setMassFractions_NoNorm(span<const double>(y + 3, m_nsp));
     m_thermo->setState_TD(y[2], m_mass / m_vol);
     updateConnected(true);
 }

--- a/src/zeroD/MoleReactor.cpp
+++ b/src/zeroD/MoleReactor.cpp
@@ -67,7 +67,7 @@ void MoleReactor::updateState(double* y)
     // of surface species on each wall.
     setMassFromMoles(y + m_sidx);
     m_vol = y[1];
-    m_thermo->setMolesNoTruncate(y + m_sidx);
+    m_thermo->setMolesNoTruncate(span<const double>(y + m_sidx, m_nsp));
     if (m_energy) {
         double U = y[0];
         // Residual function: error in internal energy as a function of T

--- a/src/zeroD/MoleReactor.cpp
+++ b/src/zeroD/MoleReactor.cpp
@@ -32,8 +32,8 @@ MoleReactor::MoleReactor(shared_ptr<Solution> sol, bool clone, const string& nam
 void MoleReactor::getMoles(double* y)
 {
     // Use inverse molecular weights to convert to moles
-    const double* Y = m_thermo->massFractions();
-    const vector<double>& imw = m_thermo->inverseMolecularWeights();
+    auto Y = m_thermo->massFractions();
+    auto imw = m_thermo->inverseMolecularWeights();
     for (size_t i = 0; i < m_nsp; i++) {
         y[i] = m_mass * imw[i] * Y[i];
     }
@@ -41,7 +41,7 @@ void MoleReactor::getMoles(double* y)
 
 void MoleReactor::setMassFromMoles(double* y)
 {
-    const vector<double>& mw = m_thermo->molecularWeights();
+    auto mw = m_thermo->molecularWeights();
     // calculate mass from moles
     m_mass = 0;
     for (size_t i = 0; i < m_nsp; i++) {
@@ -111,7 +111,7 @@ void MoleReactor::eval(double time, double* LHS, double* RHS)
     evalWalls(time);
     updateSurfaceProductionRates();
     // inverse molecular weights for conversion
-    const vector<double>& imw = m_thermo->inverseMolecularWeights();
+    auto imw = m_thermo->inverseMolecularWeights();
     // volume equation
     RHS[1] = m_vdot;
 

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -127,8 +127,8 @@ void Reactor::eval(double time, double* LHS, double* RHS)
 
     evalWalls(time);
     updateSurfaceProductionRates();
-    const vector<double>& mw = m_thermo->molecularWeights();
-    const double* Y = m_thermo->massFractions();
+    auto mw = m_thermo->molecularWeights();
+    auto Y = m_thermo->massFractions();
 
     // mass added to gas phase from surface reactions
     double mdot_surf = dot(m_sdot.begin(), m_sdot.end(), mw.begin());

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -56,7 +56,7 @@ void Reactor::getState(double* y)
     y[2] = m_thermo->intEnergy_mass() * m_mass;
 
     // set components y+3 ... y+K+2 to the mass fractions of each species
-    m_thermo->getMassFractions(y+3);
+    m_thermo->getMassFractions(span<double>(y + 3, m_nsp));
 }
 
 void Reactor::initialize(double t0)
@@ -80,7 +80,7 @@ void Reactor::updateState(double* y)
     // species, and [K+3...] are the coverages of surface species on each wall.
     m_mass = y[0];
     m_vol = y[1];
-    m_thermo->setMassFractions_NoNorm(y+3);
+    m_thermo->setMassFractions_NoNorm(span<const double>(y + 3, m_nsp));
 
     if (m_energy) {
         double U = y[2];

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -208,7 +208,7 @@ double ReactorBase::temperature() const
 
 const double* ReactorBase::massFractions() const
 {
-    return m_thermo->massFractions();
+    return m_thermo->massFractions().data();
 }
 
 double ReactorBase::massFraction(size_t k) const

--- a/test/equil/equil_gas.cpp
+++ b/test/equil/equil_gas.cpp
@@ -151,7 +151,7 @@ public:
         double mu_N = mu[gas.speciesIndex("N")];
         double mu_Ar = mu[gas.speciesIndex("AR")];
 
-        gas.getMoleFractions(&X[0]);
+        gas.getMoleFractions(X);
         for (size_t k = 0; k < gas.nSpecies(); k++) {
             if (X[k] < 1e-15) {
                 continue;

--- a/test/equil/equil_gas.cpp
+++ b/test/equil/equil_gas.cpp
@@ -40,7 +40,7 @@ TEST_F(OverconstrainedEquil, ChemEquil)
     EXPECT_NEAR(gas->moleFraction("C2H2"), 1.0, 1e-10);
     EXPECT_NEAR(gas->moleFraction("CH"), 0.0, 1e-10);
     vector<double> mu(2);
-    gas->getChemPotentials(&mu[0]);
+    gas->getChemPotentials(mu);
     EXPECT_NEAR(2*mu[0], mu[1], 1e-7*std::abs(mu[0]));
 }
 
@@ -51,7 +51,7 @@ TEST_F(OverconstrainedEquil, VcsNonideal)
     EXPECT_NEAR(gas->moleFraction("C2H2"), 1.0, 1e-10);
     EXPECT_NEAR(gas->moleFraction("CH"), 0.0, 1e-10);
     vector<double> mu(2);
-    gas->getChemPotentials(&mu[0]);
+    gas->getChemPotentials(mu);
     EXPECT_NEAR(2*mu[0], mu[1], 1e-7*std::abs(mu[0]));
 }
 
@@ -62,7 +62,7 @@ TEST_F(OverconstrainedEquil, DISABLED_MultiphaseEquil)
     EXPECT_NEAR(gas->moleFraction("C2H2"), 1.0, 1e-10);
     EXPECT_NEAR(gas->moleFraction("CH"), 0.0, 1e-10);
     vector<double> mu(2);
-    gas->getChemPotentials(&mu[0]);
+    gas->getChemPotentials(mu);
     EXPECT_NEAR(2*mu[0], mu[1], 1e-7*std::abs(mu[0]));
 }
 
@@ -144,7 +144,7 @@ public:
         }
 
         vector<double> mu(gas.nSpecies());
-        gas.getChemPotentials(&mu[0]);
+        gas.getChemPotentials(mu);
         double mu_C = mu[gas.speciesIndex("C")];
         double mu_H = mu[gas.speciesIndex("H")];
         double mu_O = mu[gas.speciesIndex("O")];

--- a/test/kinetics/rates.cpp
+++ b/test/kinetics/rates.cpp
@@ -101,7 +101,7 @@ TEST_F(FracCoeffTest, EquilibriumConstants)
     vector<double> mu0(therm->nSpecies(), 0.0);
 
     kin->getEquilibriumConstants(&Kc[0]);
-    therm->getGibbs_ref(&mu0[0]); // at pRef
+    therm->getGibbs_ref(mu0); // at pRef
 
     double deltaG0_0 = 1.4 * mu0[kH] + 0.6 * mu0[kOH] + 0.2 * mu0[kO2] - mu0[kH2O];
     double deltaG0_1 = mu0[kH2O] - 0.7 * mu0[kH2] - 0.6 * mu0[kOH] - 0.2 * mu0[kO2];

--- a/test/kinetics/rates.cpp
+++ b/test/kinetics/rates.cpp
@@ -63,7 +63,7 @@ TEST_F(FracCoeffTest, RatesOfProgress)
     vector<double> kf(kin->nReactions(), 0.0);
     vector<double> conc(therm->nSpecies(), 0.0);
     vector<double> ropf(kin->nReactions(), 0.0);
-    therm->getConcentrations(&conc[0]);
+    therm->getConcentrations(conc);
     kin->getFwdRateConstants(&kf[0]);
     kin->getFwdRatesOfProgress(&ropf[0]);
 

--- a/test/oneD/test_oneD.cpp
+++ b/test/oneD/test_oneD.cpp
@@ -25,12 +25,12 @@ TEST(onedim, freeflame)
     gas->setState_TPX(T, P, X);
     double rho_in = gas->density();
     vector<double> yin(nsp);
-    gas->getMassFractions(&yin[0]);
+    gas->getMassFractions(yin);
 
     // product estimate
     gas->equilibrate("HP");
     vector<double> yout(nsp);
-    gas->getMassFractions(&yout[0]);
+    gas->getMassFractions(yout);
     double rho_out = gas->density();
     double Tad = gas->temperature();
 

--- a/test/thermo/BinarySolutionTabulatedThermo_Test.cpp
+++ b/test/thermo/BinarySolutionTabulatedThermo_Test.cpp
@@ -16,7 +16,7 @@ public:
         vector<double> moleFracs(2);
         moleFracs[0] = x;
         moleFracs[1] = 1-x;
-        test_phase->setMoleFractions(&moleFracs[0]);
+        test_phase->setMoleFractions(moleFracs);
     }
 
     shared_ptr<ThermoPhase> test_phase;

--- a/test/thermo/BinarySolutionTabulatedThermo_Test.cpp
+++ b/test/thermo/BinarySolutionTabulatedThermo_Test.cpp
@@ -109,7 +109,7 @@ TEST_F(BinarySolutionTabulatedThermo_Test,chem_potentials)
     for (int i = 0; i < numSteps; ++i)
     {
         set_defect_X(xmin + i*dx);
-        test_phase->getChemPotentials(&chemPotentials[0]);
+        test_phase->getChemPotentials(chemPotentials);
         EXPECT_NEAR(expected_result[i], chemPotentials[0], 1.e-6);
     }
 }
@@ -139,7 +139,7 @@ TEST_F(BinarySolutionTabulatedThermo_Test,partialMolarEntropies)
     for (int i = 0; i < 9; ++i)
     {
         set_defect_X(xmin + i*dx);
-        test_phase->getPartialMolarEntropies(&partialMolarEntropies[0]);
+        test_phase->getPartialMolarEntropies(partialMolarEntropies);
         EXPECT_NEAR(expected_result[i], partialMolarEntropies[0], 1.e-6);
     }
 }
@@ -195,7 +195,7 @@ TEST_F(BinarySolutionTabulatedThermo_Test,partialMolarVolumes)
     for (int i = 0; i < 9; ++i)
     {
         set_defect_X(xmin + i*dx);
-        test_phase->getPartialMolarVolumes(&partialMolarVolumes[0]);
+        test_phase->getPartialMolarVolumes(partialMolarVolumes);
         EXPECT_NEAR(expected_result[i], partialMolarVolumes[0], 1.e-8);
     }
 }

--- a/test/thermo/CoverageDependentSurfPhase_Test.cpp
+++ b/test/thermo/CoverageDependentSurfPhase_Test.cpp
@@ -150,7 +150,7 @@ TEST_F(CoverageDependentSurfPhase_Test, standard_enthalpies_RT)
 
     // Get CoverageDependentSurfPhase standard enthalpy method value
     covdepsurf_phase->setTemperature(test_Ts[5]);
-    covdepsurf_phase->setCoverages(test_covs[0].data());
+    covdepsurf_phase->setCoverages(test_covs[0]);
     covdepsurf_phase->getEnthalpy_RT(enthalpies_RT);
     // Externally calculating value by adding coverage-dependent terms
     // to SurfPhase standard enthalpy method value
@@ -198,7 +198,7 @@ TEST_F(CoverageDependentSurfPhase_Test, standard_entropies_R)
 
     // Get CoverageDependentSurfPhase standard entropy method value
     covdepsurf_phase->setTemperature(test_Ts[3]);
-    covdepsurf_phase->setCoverages(test_covs[0].data());
+    covdepsurf_phase->setCoverages(test_covs[0]);
     covdepsurf_phase->getEntropy_R(entropies_R);
     // Externally calculate value by adding coverage-dependent terms
     // to SurfPhase standard entropy method value
@@ -231,7 +231,7 @@ TEST_F(CoverageDependentSurfPhase_Test, standard_cp_R)
 
     // Get CoverageDependentSurfPhase standard heat capacity method value
     covdepsurf_phase->setTemperature(test_Ts[4]);
-    covdepsurf_phase->setCoverages(test_covs[0].data());
+    covdepsurf_phase->setCoverages(test_covs[0]);
     covdepsurf_phase->getCp_R(cps_R);
     // Externally calculating value by adding coverage-dependent terms
     // to SurfPhase standard heat capacity method value

--- a/test/thermo/CoverageDependentSurfPhase_Test.cpp
+++ b/test/thermo/CoverageDependentSurfPhase_Test.cpp
@@ -51,10 +51,10 @@ TEST_F(CoverageDependentSurfPhase_Test, reference_enthalpies_RT)
     for (size_t i = 0; i < 10; i++) {
         covdepsurf_phase->setTemperature(test_Ts[i]);
         // Get CoverageDependentSurfPhase reference enthalpy method value
-        covdepsurf_phase->getEnthalpy_RT_ref(&enthalpies_RT_ref[0]);
+        covdepsurf_phase->getEnthalpy_RT_ref(enthalpies_RT_ref);
         idealsurf_phase->setTemperature(test_Ts[i]);
         // Get SurfPhase reference enthalpy method value
-        idealsurf_phase->getEnthalpy_RT_ref(&expected_result[0]);
+        idealsurf_phase->getEnthalpy_RT_ref(expected_result);
         for (size_t j = 0; j < 5; j++) {
             EXPECT_NEAR(enthalpies_RT_ref[j], expected_result[j], 1.e-6);
         }
@@ -71,10 +71,10 @@ TEST_F(CoverageDependentSurfPhase_Test, reference_entropies_R)
     for (size_t i = 0; i < 10; i++) {
         covdepsurf_phase->setTemperature(test_Ts[i]);
         // Get CoverageDependentSurfPhase reference entropy method value
-        covdepsurf_phase->getEntropy_R_ref(&entropies_R_ref[0]);
+        covdepsurf_phase->getEntropy_R_ref(entropies_R_ref);
         idealsurf_phase->setTemperature(test_Ts[i]);
         // Get SurfPhase reference entropy method value
-        idealsurf_phase->getEntropy_R_ref(&expected_result[0]);
+        idealsurf_phase->getEntropy_R_ref(expected_result);
         for (size_t j = 0; j < 5; j++) {
             EXPECT_NEAR(entropies_R_ref[j], expected_result[j], 1.e-6);
         }
@@ -91,10 +91,10 @@ TEST_F(CoverageDependentSurfPhase_Test, reference_cp_R)
     for (size_t i = 0; i < 10; i++) {
         covdepsurf_phase->setTemperature(test_Ts[i]);
         // Get CoverageDependentSurfPhase reference heat capacity method value
-        covdepsurf_phase->getCp_R_ref(&cps_R_ref[0]);
+        covdepsurf_phase->getCp_R_ref(cps_R_ref);
         idealsurf_phase->setTemperature(test_Ts[i]);
         // Get SurfPhase reference heat capacity method value
-        idealsurf_phase->getCp_R_ref(&expected_result[0]);
+        idealsurf_phase->getCp_R_ref(expected_result);
         for (size_t j = 0; j < 5; j++) {
             EXPECT_NEAR(cps_R_ref[j], expected_result[j], 1.e-6);
         }
@@ -111,10 +111,10 @@ TEST_F(CoverageDependentSurfPhase_Test, reference_gibbs_RT)
     for (size_t i = 0; i < 10; i++) {
         covdepsurf_phase->setTemperature(test_Ts[i]);
         // Get CoverageDependentSurfPhase reference gibbs free energy method value
-        covdepsurf_phase->getGibbs_RT_ref(&gibbs_RT_ref[0]);
+        covdepsurf_phase->getGibbs_RT_ref(gibbs_RT_ref);
         idealsurf_phase->setTemperature(test_Ts[i]);
         // Get SurfPhase reference gibbs free energy method value
-        idealsurf_phase->getGibbs_RT_ref(&expected_result[0]);
+        idealsurf_phase->getGibbs_RT_ref(expected_result);
         for (size_t j = 0; j < 5; j++) {
             EXPECT_NEAR(gibbs_RT_ref[j], expected_result[j], 1.e-6);
         }
@@ -151,11 +151,11 @@ TEST_F(CoverageDependentSurfPhase_Test, standard_enthalpies_RT)
     // Get CoverageDependentSurfPhase standard enthalpy method value
     covdepsurf_phase->setTemperature(test_Ts[5]);
     covdepsurf_phase->setCoverages(test_covs[0].data());
-    covdepsurf_phase->getEnthalpy_RT(&enthalpies_RT[0]);
+    covdepsurf_phase->getEnthalpy_RT(enthalpies_RT);
     // Externally calculating value by adding coverage-dependent terms
     // to SurfPhase standard enthalpy method value
     idealsurf_phase->setTemperature(test_Ts[5]);
-    idealsurf_phase->getEnthalpy_RT(&expected_result[0]);
+    idealsurf_phase->getEnthalpy_RT(expected_result);
     double RT = idealsurf_phase->RT();
     expected_result[1] += (h_slope * test_covs[0][1]) / RT;
     expected_result[1] += (h_low * 0.4) / RT;
@@ -199,11 +199,11 @@ TEST_F(CoverageDependentSurfPhase_Test, standard_entropies_R)
     // Get CoverageDependentSurfPhase standard entropy method value
     covdepsurf_phase->setTemperature(test_Ts[3]);
     covdepsurf_phase->setCoverages(test_covs[0].data());
-    covdepsurf_phase->getEntropy_R(&entropies_R[0]);
+    covdepsurf_phase->getEntropy_R(entropies_R);
     // Externally calculate value by adding coverage-dependent terms
     // to SurfPhase standard entropy method value
     idealsurf_phase->setTemperature(test_Ts[3]);
-    idealsurf_phase->getEntropy_R(&expected_result[0]);
+    idealsurf_phase->getEntropy_R(expected_result);
     expected_result[1] += (s_slope * test_covs[0][1]) / GasConstant;
     expected_result[1] += (s_low * 0.4) / GasConstant;
     expected_result[1] += (s_high * (test_covs[0][2] - 0.4)) / GasConstant;
@@ -232,11 +232,11 @@ TEST_F(CoverageDependentSurfPhase_Test, standard_cp_R)
     // Get CoverageDependentSurfPhase standard heat capacity method value
     covdepsurf_phase->setTemperature(test_Ts[4]);
     covdepsurf_phase->setCoverages(test_covs[0].data());
-    covdepsurf_phase->getCp_R(&cps_R[0]);
+    covdepsurf_phase->getCp_R(cps_R);
     // Externally calculating value by adding coverage-dependent terms
     // to SurfPhase standard heat capacity method value
     idealsurf_phase->setTemperature(test_Ts[4]);
-    idealsurf_phase->getCp_R(&expected_result[0]);
+    idealsurf_phase->getCp_R(expected_result);
     expected_result[1] += (cp_a * log(test_Ts[4]) + cp_b)
                            * test_covs[0][2] * test_covs[0][2] / GasConstant;
     EXPECT_NEAR(cps_R[1], expected_result[1], 1.e-6);

--- a/test/thermo/PengRobinson_Test.cpp
+++ b/test/thermo/PengRobinson_Test.cpp
@@ -52,7 +52,7 @@ TEST_F(PengRobinson_Test, chem_potentials)
     for(int i=0; i < numSteps; ++i)
     {
         set_r(xmin + i*dx);
-        test_phase->getChemPotentials(&chemPotentials[0]);
+        test_phase->getChemPotentials(chemPotentials);
         EXPECT_NEAR(expected_result[i], chemPotentials[0], 1.e-6);
     }
 }

--- a/test/thermo/PengRobinson_Test.cpp
+++ b/test/thermo/PengRobinson_Test.cpp
@@ -15,7 +15,7 @@ public:
 
     //vary the composition of a co2-h2 mixture:
     void set_r(const double r) {
-        vector<double> moleFracs(7);
+        vector<double> moleFracs(test_phase->nSpecies());
         moleFracs[0] = r;
         moleFracs[2] = 1-r;
         test_phase->setMoleFractions(moleFracs);
@@ -48,7 +48,7 @@ TEST_F(PengRobinson_Test, chem_potentials)
     double xmax = 0.9;
     int numSteps = 9;
     double dx = (xmax-xmin)/(numSteps-1);
-    vector<double> chemPotentials(7);
+    vector<double> chemPotentials(test_phase->nSpecies());
     for(int i=0; i < numSteps; ++i)
     {
         set_r(xmin + i*dx);

--- a/test/thermo/PengRobinson_Test.cpp
+++ b/test/thermo/PengRobinson_Test.cpp
@@ -18,7 +18,7 @@ public:
         vector<double> moleFracs(7);
         moleFracs[0] = r;
         moleFracs[2] = 1-r;
-        test_phase->setMoleFractions(&moleFracs[0]);
+        test_phase->setMoleFractions(moleFracs);
     }
 
     shared_ptr<ThermoPhase> test_phase;

--- a/test/thermo/RedlichKisterTest.cpp
+++ b/test/thermo/RedlichKisterTest.cpp
@@ -53,7 +53,7 @@ TEST_F(RedlichKister_Test, chem_potentials)
     for(int i=0; i < 9; ++i)
     {
         set_r(xmin + i*dx);
-        test_phase->getChemPotentials(&chemPotentials[0]);
+        test_phase->getChemPotentials(chemPotentials);
         EXPECT_NEAR(expected_chempot[i], chemPotentials[0], 1.e-6);
     }
 }
@@ -84,7 +84,7 @@ TEST_F(RedlichKister_Test, dlnActivities)
     {
         const double r = xmin + i*dx;
         set_r(r);
-        test_phase->getdlnActCoeffdlnX_diag(&dlnActCoeffdx[0]);
+        test_phase->getdlnActCoeffdlnX_diag(dlnActCoeffdx);
         EXPECT_NEAR(expected_result[i], dlnActCoeffdx[0], 1.e-6);
     }
 }
@@ -134,7 +134,7 @@ TEST_F(RedlichKister_Test, fromScratch)
     for(int i=0; i < 9; ++i)
     {
         set_r(xmin + i*(xmax-xmin)/(numSteps-1));
-        test_phase->getChemPotentials(&chemPotentials[0]);
+        test_phase->getChemPotentials(chemPotentials);
         EXPECT_NEAR(expected_chempot[i], chemPotentials[0], 1.e-6);
     }
 }

--- a/test/thermo/RedlichKisterTest.cpp
+++ b/test/thermo/RedlichKisterTest.cpp
@@ -6,6 +6,8 @@
 #include "cantera/base/stringUtils.h"
 #include "cantera/thermo/PDSS_ConstVol.h"
 
+#include <array>
+
 namespace Cantera
 {
 
@@ -118,12 +120,12 @@ TEST_F(RedlichKister_Test, fromScratch)
     auto ssVC6 = make_unique<PDSS_ConstVol>();
     rk.installPDSS(1, std::move(ssVC6));
 
-    double hcoeffs[] = {-3.268E6, 3.955E6, -4.573E6, 6.147E6, -3.339E6, 1.117E7,
+    std::array hcoeffs {-3.268E6, 3.955E6, -4.573E6, 6.147E6, -3.339E6, 1.117E7,
                         2.997E5, -4.866E7, 1.362E5, 1.373E8, -2.129E7, -1.722E8,
                         3.956E7, 9.302E7, -3.280E7};
-    double scoeffs[] = {0.0};
+    std::array scoeffs {0.0};
 
-    rk.addBinaryInteraction("Li(C6)", "V(C6)", hcoeffs, 15, scoeffs, 1);
+    rk.addBinaryInteraction("Li(C6)", "V(C6)", hcoeffs, scoeffs);
     rk.initThermo();
     rk.setState_TPX(298.15, 101325, "Li(C6):0.6,V(C6):0.4");
 

--- a/test/thermo/RedlichKisterTest.cpp
+++ b/test/thermo/RedlichKisterTest.cpp
@@ -34,7 +34,7 @@ public:
         vector<double> moleFracs(2);
         moleFracs[0] = r;
         moleFracs[1] = 1-r;
-        test_phase->setMoleFractions(&moleFracs[0]);
+        test_phase->setMoleFractions(moleFracs);
     }
 
     shared_ptr<ThermoPhase> test_phase;

--- a/test/thermo/RedlichKwongMFTP_Test.cpp
+++ b/test/thermo/RedlichKwongMFTP_Test.cpp
@@ -16,7 +16,7 @@ public:
 
     //vary the composition of a co2-h2 mixture:
     void set_r(const double r) {
-        vector<double> moleFracs(7);
+        vector<double> moleFracs(test_phase->nSpecies());
         moleFracs[0] = r;
         moleFracs[2] = 1-r;
         test_phase->setMoleFractions(moleFracs);

--- a/test/thermo/RedlichKwongMFTP_Test.cpp
+++ b/test/thermo/RedlichKwongMFTP_Test.cpp
@@ -19,7 +19,7 @@ public:
         vector<double> moleFracs(7);
         moleFracs[0] = r;
         moleFracs[2] = 1-r;
-        test_phase->setMoleFractions(&moleFracs[0]);
+        test_phase->setMoleFractions(moleFracs);
     }
 
     shared_ptr<ThermoPhase> test_phase;

--- a/test/thermo/RedlichKwongMFTP_Test.cpp
+++ b/test/thermo/RedlichKwongMFTP_Test.cpp
@@ -52,7 +52,7 @@ TEST_F(RedlichKwongMFTP_Test, chem_potentials)
     for(int i=0; i < 9; ++i)
     {
         set_r(xmin + i*dx);
-        test_phase->getChemPotentials(&chemPotentials[0]);
+        test_phase->getChemPotentials(chemPotentials);
         EXPECT_NEAR(expected_result[i], chemPotentials[0], 1.e-6);
     }
 }

--- a/test/thermo/ThermoPhase_Test.cpp
+++ b/test/thermo/ThermoPhase_Test.cpp
@@ -216,23 +216,23 @@ public:
         v_fuel[gas.speciesIndex("CH4")] = 10.0;
 
         if (oxidizer) {
-            gas.setState_TPX(300.0, 1e5, v_ox.data());
-            EXPECT_NEAR(gas.equivalenceRatio(v_fuel.data(), v_ox.data(), basis), phi, 1e-4);
+            gas.setState_TPX(300.0, 1e5, v_ox);
+            EXPECT_NEAR(gas.equivalenceRatio(v_fuel, v_ox, basis), phi, 1e-4);
             EXPECT_NEAR(gas.equivalenceRatio(), 0.0, 1e-4);
         } else {
-            gas.setState_TPX(300.0, 1e5, v_fuel.data());
-            ASSERT_EQ(gas.equivalenceRatio(v_fuel.data(), v_ox.data(), basis) > phi, true);
+            gas.setState_TPX(300.0, 1e5, v_fuel);
+            ASSERT_EQ(gas.equivalenceRatio(v_fuel, v_ox, basis) > phi, true);
             ASSERT_EQ(gas.equivalenceRatio() > phi, true);
         }
-        EXPECT_NEAR(gas.mixtureFraction(v_fuel.data(), v_ox.data(), basis, "Bilger"), mf, 1e-4);
-        EXPECT_NEAR(gas.mixtureFraction(v_fuel.data(), v_ox.data(), basis, "C"), mf, 1e-4);
+        EXPECT_NEAR(gas.mixtureFraction(v_fuel, v_ox, basis, "Bilger"), mf, 1e-4);
+        EXPECT_NEAR(gas.mixtureFraction(v_fuel, v_ox, basis, "C"), mf, 1e-4);
 
         double Ych4 = gas.massFraction(gas.speciesIndex("CH4"));
         gas.setState_TPX(300.0, 1e5, "N2:1");
-        gas.setMixtureFraction(mf, v_fuel.data(), v_ox.data(), basis);
+        gas.setMixtureFraction(mf, v_fuel, v_ox, basis);
         EXPECT_NEAR(gas.massFraction(gas.speciesIndex("CH4")), Ych4, 1e-4);
         gas.setState_TPX(300.0, 1e5, "N2:1");
-        gas.setEquivalenceRatio(phi, v_fuel.data(), v_ox.data(), basis);
+        gas.setEquivalenceRatio(phi, v_fuel, v_ox, basis);
         EXPECT_NEAR(gas.massFraction(gas.speciesIndex("CH4")), Ych4, 1e-4);
     }
 

--- a/test/thermo/ThermoPhase_Test.cpp
+++ b/test/thermo/ThermoPhase_Test.cpp
@@ -105,14 +105,14 @@ TEST_F(TestThermoMethods, setConcentrations)
         ctot += C0[k];
     }
 
-    thermo->setConcentrations(C0.data());
+    thermo->setConcentrations(C0);
     EXPECT_NEAR(thermo->molarDensity(), ctot, 1e-7 * ctot);
     EXPECT_DOUBLE_EQ(thermo->moleFraction(2), 0.0);
 
     for (size_t k = 0; k < thermo->nSpecies(); k++) {
         C0[k] *= 1.5;
     }
-    thermo->setConcentrationsNoNorm(C0.data());
+    thermo->setConcentrationsNoNorm(C0);
     EXPECT_NEAR(thermo->molarDensity(), 1.5 * ctot, 1e-7 * ctot);
     EXPECT_NEAR(thermo->moleFraction(2), -1e-8 / ctot, 1e-16);
 }

--- a/test/thermo/cubicSolver_Test.cpp
+++ b/test/thermo/cubicSolver_Test.cpp
@@ -17,7 +17,7 @@ public:
         vector<double> moleFracs(7);
         moleFracs[0] = r;
         moleFracs[2] = 1-r;
-        test_phase->setMoleFractions(&moleFracs[0]);
+        test_phase->setMoleFractions(moleFracs);
     }
 
     shared_ptr<ThermoPhase> test_phase;

--- a/test/thermo/nasapoly.cpp
+++ b/test/thermo/nasapoly.cpp
@@ -41,8 +41,8 @@ protected:
         double cp_R1, h_RT1, s_R1;
         double cp_R2, h_RT2, s_R2;
         double T = 481.99;
-        p.updatePropertiesTemp(T, &cp_R1, &h_RT1, &s_R1);
-        q.updatePropertiesTemp(T, &cp_R2, &h_RT2, &s_R2);
+        p.updatePropertiesTemp(T, cp_R1, h_RT1, s_R1);
+        q.updatePropertiesTemp(T, cp_R2, h_RT2, s_R2);
         EXPECT_DOUBLE_EQ(cp_R1, cp_R2);
         EXPECT_DOUBLE_EQ(h_RT1, h_RT2);
         EXPECT_DOUBLE_EQ(s_R1, s_R2);
@@ -66,13 +66,13 @@ TEST_F(NasaPoly1Test, updateProperties)
     // Reference values calculated using CHEMKIN II
     // Expect agreement to single-precision tolerance
     set_tpow(298.15);
-    poly.updateProperties(&tpow_[0], &cp_R, &h_RT, &s_R);
+    poly.updateProperties(span<const double>(tpow_), cp_R, h_RT, s_R);
     EXPECT_NEAR(4.46633496, cp_R, 1e-7);
     EXPECT_NEAR(-158.739244, h_RT, 1e-5);
     EXPECT_NEAR(25.7125777, s_R, 1e-6);
 
     set_tpow(876.54);
-    poly.updateProperties(&tpow_[0], &cp_R, &h_RT, &s_R);
+    poly.updateProperties(span<const double>(tpow_), cp_R, h_RT, s_R);
     EXPECT_NEAR(6.33029000, cp_R, 1e-7);
     EXPECT_NEAR(-50.3179924, h_RT, 1e-5);
     EXPECT_NEAR(31.5401226, s_R, 1e-6);
@@ -85,8 +85,8 @@ TEST_F(NasaPoly1Test, updatePropertiesTemp)
     double T = 481.99;
 
     set_tpow(T);
-    poly.updatePropertiesTemp(T, &cp_R1, &h_RT1, &s_R1);
-    poly.updateProperties(&tpow_[0], &cp_R2, &h_RT2, &s_R2);
+    poly.updatePropertiesTemp(T, cp_R1, h_RT1, s_R1);
+    poly.updateProperties(span<const double>(tpow_), cp_R2, h_RT2, s_R2);
 
     EXPECT_DOUBLE_EQ(cp_R1, cp_R2);
     EXPECT_DOUBLE_EQ(h_RT1, h_RT2);
@@ -111,10 +111,10 @@ TEST(Nasa9Test, Nasa9Thermo) {
     double abstol = 1e-7;
 
     for (size_t i = 0; i < 15; i++) {
-        g.setState_TPX(T0 + i*dT, pres, &Xset[0]);
-        g.getEntropy_R(&S_R[0]);
-        g.getCp_R(&cp_R[0]);
-        g.getEnthalpy_RT(&H_RT[0]);
+        g.setState_TPX(T0 + i*dT, pres, Xset);
+        g.getEntropy_R(S_R);
+        g.getCp_R(cp_R);
+        g.getEnthalpy_RT(H_RT);
 
         EXPECT_NEAR(cp_R[0], cp_R[1], abstol);
         EXPECT_NEAR(cp_R[0], cp_R[2], abstol);

--- a/test/thermo/phaseConstructors.cpp
+++ b/test/thermo/phaseConstructors.cpp
@@ -314,8 +314,8 @@ TEST(DebyeHuckel, fromScratch)
     EXPECT_NEAR(p.entropy_mass(), 4.01292e3, 2e-2);
     vector<double> actcoeff(p.nSpecies());
     vector<double> mu_ss(p.nSpecies());
-    p.getMolalityActivityCoefficients(actcoeff.data());
-    p.getStandardChemPotentials(mu_ss.data());
+    p.getMolalityActivityCoefficients(actcoeff);
+    p.getStandardChemPotentials(mu_ss);
     double act_ref[] = {1.21762, 0.538061, 0.472329, 0.717707, 0.507258, 1.0};
     double mu_ss_ref[] = {-3.06816e+08, -2.57956e+08, -1.84117e+08, 0.0,
         -2.26855e+08, -4.3292e+08};
@@ -440,11 +440,11 @@ TEST(HMWSoln, fromScratch)
 
     size_t N = p.nSpecies();
     vector<double> acMol(N), mf(N), activities(N), moll(N), mu0(N);
-    p.getMolalityActivityCoefficients(acMol.data());
+    p.getMolalityActivityCoefficients(acMol);
     p.getMoleFractions(mf);
-    p.getActivities(activities.data());
-    p.getMolalities(moll.data());
-    p.getStandardChemPotentials(mu0.data());
+    p.getActivities(activities);
+    p.getMolalities(moll);
+    p.getStandardChemPotentials(mu0);
 
     double acMolRef[] = {0.9341, 1.0191, 3.9637, 1.0191, 0.4660};
     double mfRef[] = {0.8198, 0.0901, 0.0000, 0.0901, 0.0000};
@@ -524,11 +524,11 @@ TEST(HMWSoln, fromScratch_HKFT)
 
     size_t N = p.nSpecies();
     vector<double> mv(N), h(N), mu(N), ac(N), acoeff(N);
-    p.getPartialMolarVolumes(mv.data());
-    p.getPartialMolarEnthalpies(h.data());
-    p.getChemPotentials(mu.data());
-    p.getActivities(ac.data());
-    p.getActivityCoefficients(acoeff.data());
+    p.getPartialMolarVolumes(mv);
+    p.getPartialMolarEnthalpies(h);
+    p.getChemPotentials(mu);
+    p.getActivities(ac);
+    p.getActivityCoefficients(acoeff);
 
     double mvRef[] = {0.01815196, 0.00157182, 0.01954605, 0.00173137, -0.0020266};
 

--- a/test/thermo/phaseConstructors.cpp
+++ b/test/thermo/phaseConstructors.cpp
@@ -23,7 +23,10 @@
 #include "cantera/thermo/IdealGasPhase.h"
 #include "cantera/thermo/Mu0Poly.h"
 #include "cantera/base/stringUtils.h"
+
 #include <fstream>
+#include <array>
+
 #include "thermo_data.h"
 
 namespace Cantera
@@ -372,35 +375,35 @@ TEST(IdealSolidSolnPhase, fromScratch)
 }
 
 static void set_hmw_interactions(HMWSoln& p) {
-    double beta0_nacl[] = {0.0765, 0.008946, -3.3158E-6, -777.03, -4.4706};
-    double beta1_nacl[] = {0.2664, 6.1608E-5, 1.0715E-6, 0.0, 0.0};
-    double beta2_nacl[] = {0.0, 0.0, 0.0, 0.0, 0.0};
-    double cphi_nacl[] = {0.00127, -4.655E-5, 0.0, 33.317, 0.09421};
-    p.setBinarySalt("Na+", "Cl-", 5, beta0_nacl, beta1_nacl, beta2_nacl,
+    std::array beta0_nacl{0.0765, 0.008946, -3.3158E-6, -777.03, -4.4706};
+    std::array beta1_nacl{0.2664, 6.1608E-5, 1.0715E-6, 0.0, 0.0};
+    std::array beta2_nacl{0.0, 0.0, 0.0, 0.0, 0.0};
+    std::array cphi_nacl{0.00127, -4.655E-5, 0.0, 33.317, 0.09421};
+    p.setBinarySalt("Na+", "Cl-", beta0_nacl, beta1_nacl, beta2_nacl,
         cphi_nacl, 2.0, 0.0);
 
-    double beta0_hcl[] = {0.1775, 0.0, 0.0, 0.0, 0.0};
-    double beta1_hcl[] = {0.2945, 0.0, 0.0, 0.0, 0.0};
-    double beta2_hcl[] = {0.0, 0.0, 0.0, 0.0, 0.0};
-    double cphi_hcl[] = {0.0008, 0.0, 0.0, 0.0, 0.0};
-    p.setBinarySalt("H+", "Cl-", 5, beta0_hcl, beta1_hcl, beta2_hcl,
+    std::array beta0_hcl{0.1775, 0.0, 0.0, 0.0, 0.0};
+    std::array beta1_hcl{0.2945, 0.0, 0.0, 0.0, 0.0};
+    std::array beta2_hcl{0.0, 0.0, 0.0, 0.0, 0.0};
+    std::array cphi_hcl{0.0008, 0.0, 0.0, 0.0, 0.0};
+    p.setBinarySalt("H+", "Cl-", beta0_hcl, beta1_hcl, beta2_hcl,
         cphi_hcl, 2.0, 0.0);
 
-    double beta0_naoh[] = {0.0864, 0.0, 0.0, 0.0, 0.0};
-    double beta1_naoh[] = {0.253, 0.0, 0.0, 0.0, 0.0};
-    double beta2_naoh[] = {0.0, 0.0, 0.0, 0.0, 0.0};
-    double cphi_naoh[] = {0.0044, 0.0, 0.0, 0.0, 0.0};
-    p.setBinarySalt("Na+", "OH-", 5, beta0_naoh, beta1_naoh, beta2_naoh,
+    std::array beta0_naoh{0.0864, 0.0, 0.0, 0.0, 0.0};
+    std::array beta1_naoh{0.253, 0.0, 0.0, 0.0, 0.0};
+    std::array beta2_naoh{0.0, 0.0, 0.0, 0.0, 0.0};
+    std::array cphi_naoh{0.0044, 0.0, 0.0, 0.0, 0.0};
+    p.setBinarySalt("Na+", "OH-", beta0_naoh, beta1_naoh, beta2_naoh,
         cphi_naoh, 2.0, 0.0);
 
-    double theta_cloh[] = {-0.05, 0.0, 0.0, 0.0, 0.0};
-    double psi_nacloh[] = {-0.006, 0.0, 0.0, 0.0, 0.0};
-    double theta_nah[] = {0.036, 0.0, 0.0, 0.0, 0.0};
-    double psi_clnah[] = {-0.004, 0.0, 0.0, 0.0, 0.0};
-    p.setTheta("Cl-", "OH-", 5, theta_cloh);
-    p.setPsi("Na+", "Cl-", "OH-", 5, psi_nacloh);
-    p.setTheta("Na+", "H+", 5, theta_nah);
-    p.setPsi("Cl-", "Na+", "H+", 5, psi_clnah);
+    std::array theta_cloh{-0.05, 0.0, 0.0, 0.0, 0.0};
+    std::array psi_nacloh{-0.006, 0.0, 0.0, 0.0, 0.0};
+    std::array theta_nah{0.036, 0.0, 0.0, 0.0, 0.0};
+    std::array psi_clnah{-0.004, 0.0, 0.0, 0.0, 0.0};
+    p.setTheta("Cl-", "OH-", theta_cloh);
+    p.setPsi("Na+", "Cl-", "OH-", psi_nacloh);
+    p.setTheta("Na+", "H+", theta_nah);
+    p.setPsi("Cl-", "Na+", "H+", psi_clnah);
 }
 
 TEST(HMWSoln, fromScratch)

--- a/test/thermo/phaseConstructors.cpp
+++ b/test/thermo/phaseConstructors.cpp
@@ -30,7 +30,7 @@ namespace Cantera
 {
 
 shared_ptr<Species> make_species(const string& name,
-     const string& composition, const double* nasa_coeffs)
+     const string& composition, span<const double> nasa_coeffs)
 {
     auto species = make_shared<Species>(name, parseCompString(composition));
     species->thermo = make_shared<NasaPoly2>(200, 3500, 101325, nasa_coeffs);
@@ -38,7 +38,7 @@ shared_ptr<Species> make_species(const string& name,
 }
 
 shared_ptr<Species> make_shomate_species(const string& name,
-     const string& composition, const double* shomate_coeffs)
+     const string& composition, span<const double> shomate_coeffs)
 {
     auto species = make_shared<Species>(name, parseCompString(composition));
     species->thermo = make_shared<ShomatePoly>(200, 3500, 101325, shomate_coeffs);
@@ -46,7 +46,7 @@ shared_ptr<Species> make_shomate_species(const string& name,
 }
 
 shared_ptr<Species> make_shomate2_species(const string& name,
-     const string& composition, const double* shomate_coeffs)
+     const string& composition, span<const double> shomate_coeffs)
 {
     auto species = make_shared<Species>(name, parseCompString(composition));
     species->thermo = make_shared<ShomatePoly2>(200, 3500, 101325, shomate_coeffs);

--- a/test/thermo/phaseConstructors.cpp
+++ b/test/thermo/phaseConstructors.cpp
@@ -441,7 +441,7 @@ TEST(HMWSoln, fromScratch)
     size_t N = p.nSpecies();
     vector<double> acMol(N), mf(N), activities(N), moll(N), mu0(N);
     p.getMolalityActivityCoefficients(acMol.data());
-    p.getMoleFractions(mf.data());
+    p.getMoleFractions(mf);
     p.getActivities(activities.data());
     p.getMolalities(moll.data());
     p.getStandardChemPotentials(mu0.data());

--- a/test/thermo/thermoFromYaml.cpp
+++ b/test/thermo/thermoFromYaml.cpp
@@ -88,7 +88,7 @@ TEST(ThermoFromYaml, SurfPhase)
     auto surf = std::dynamic_pointer_cast<SurfPhase>(thermo);
     EXPECT_DOUBLE_EQ(surf->siteDensity(), 2.7063e-8);
     vector<double> cov(surf->nSpecies());
-    surf->getCoverages(cov.data());
+    surf->getCoverages(cov);
     EXPECT_DOUBLE_EQ(cov[surf->speciesIndex("Pt(s)")], 0.5);
     EXPECT_DOUBLE_EQ(cov[surf->speciesIndex("H(s)")], 0.4);
 }

--- a/test/thermo/thermoFromYaml.cpp
+++ b/test/thermo/thermoFromYaml.cpp
@@ -142,7 +142,7 @@ TEST(ThermoFromYaml, IdealMolalSoln)
     size_t N = thermo->nSpecies();
     vector<double> mv(N);
     double mvRef[] = {1.5, 1.3, 0.1, 0.1};
-    thermo->getPartialMolarVolumes(mv.data());
+    thermo->getPartialMolarVolumes(mv);
     for (size_t k = 0; k < N; k++) {
         EXPECT_NEAR(mv[k], mvRef[k], 1e-8) << k;
     }
@@ -161,8 +161,8 @@ TEST(ThermoFromYaml, DebyeHuckel_bdot_ak)
     vector<double> actcoeff(thermo->nSpecies());
     vector<double> mu_ss(thermo->nSpecies());
     auto& molphase = dynamic_cast<MolalityVPSSTP&>(*thermo);
-    molphase.getMolalityActivityCoefficients(actcoeff.data());
-    thermo->getStandardChemPotentials(mu_ss.data());
+    molphase.getMolalityActivityCoefficients(actcoeff);
+    thermo->getStandardChemPotentials(mu_ss);
     double act_ref[] = {0.849231, 1.18392, 0.990068, 1.69245, 1.09349, 1.0};
     double mu_ss_ref[] = {-3.06816e+08, -2.57956e+08, -1.84117e+08, 0.0,
         -2.26855e+08, -4.3292e+08};
@@ -185,8 +185,8 @@ TEST(ThermoFromYaml, DebyeHuckel_beta_ij)
     vector<double> actcoeff(thermo->nSpecies());
     vector<double> mu_ss(thermo->nSpecies());
     auto& molphase = dynamic_cast<MolalityVPSSTP&>(*thermo);
-    molphase.getMolalityActivityCoefficients(actcoeff.data());
-    thermo->getStandardChemPotentials(mu_ss.data());
+    molphase.getMolalityActivityCoefficients(actcoeff);
+    thermo->getStandardChemPotentials(mu_ss);
     double act_ref[] = {0.959912, 1.16955, 1.16955, 2.40275, 0.681552, 1.0};
     double mu_ss_ref[] = {-3.06816e+08, -2.57956e+08, -1.84117e+08, 0,
         -2.26855e+08, -4.3292e+08};
@@ -218,14 +218,14 @@ TEST(ThermoFromYaml, RedlichKister)
     vector<double> dlnActCoeffdx(2);
     thermo->setState_TP(298.15, OneAtm);
     thermo->setMoleFractionsByName("Li(C6): 0.6375, V(C6): 0.3625");
-    thermo->getChemPotentials(chemPotentials.data());
-    thermo->getdlnActCoeffdlnX_diag(dlnActCoeffdx.data());
+    thermo->getChemPotentials(chemPotentials);
+    thermo->getdlnActCoeffdlnX_diag(dlnActCoeffdx);
     EXPECT_NEAR(chemPotentials[0], -1.2618554573674981e+007, 1e-6);
     EXPECT_NEAR(dlnActCoeffdx[0], 0.200612, 1e-6);
 
     thermo->setMoleFractionsByName("Li(C6): 0.8625, V(C6): 0.1375");
-    thermo->getChemPotentials(chemPotentials.data());
-    thermo->getdlnActCoeffdlnX_diag(dlnActCoeffdx.data());
+    thermo->getChemPotentials(chemPotentials);
+    thermo->getdlnActCoeffdlnX_diag(dlnActCoeffdx);
     EXPECT_NEAR(chemPotentials[0], -1.179299486233677e+07, 1e-6);
     EXPECT_NEAR(dlnActCoeffdx[0], -0.309379, 1e-6);
 }
@@ -237,10 +237,10 @@ TEST(ThermoFromYaml, HMWSoln)
     auto HMW = dynamic_cast<MolalityVPSSTP*>(thermo.get());
     vector<double> acMol(N), mf(N), activities(N), moll(N), mu0(N);
     thermo->getMoleFractions(mf);
-    HMW->getMolalities(moll.data());
-    HMW->getMolalityActivityCoefficients(acMol.data());
-    thermo->getActivities(activities.data());
-    thermo->getStandardChemPotentials(mu0.data());
+    HMW->getMolalities(moll);
+    HMW->getMolalityActivityCoefficients(acMol);
+    thermo->getActivities(activities);
+    thermo->getStandardChemPotentials(mu0);
 
     double acMolRef[] = {0.9341, 1.0191, 3.9637, 1.0191, 0.4660};
     double mfRef[] = {0.8198, 0.0901, 0.0000, 0.0901, 0.0000};
@@ -270,9 +270,9 @@ TEST(ThermoFromYaml, HMWSoln_HKFT)
     // Regression test based on HMWSoln.fromScratch_HKFT
     size_t N = thermo->nSpecies();
     vector<double> mv(N), h(N), acoeff(N);
-    thermo->getPartialMolarVolumes(mv.data());
-    thermo->getPartialMolarEnthalpies(h.data());
-    thermo->getActivityCoefficients(acoeff.data());
+    thermo->getPartialMolarVolumes(mv);
+    thermo->getPartialMolarEnthalpies(h);
+    thermo->getActivityCoefficients(acoeff);
     for (size_t k = 0; k < N; k++) {
         EXPECT_NEAR(mv[k], mvRef[k], 2e-8);
         EXPECT_NEAR(h[k], hRef[k], 2e0);
@@ -352,7 +352,7 @@ TEST(ThermoFromYaml, IdealSolidSolnPhase)
     vector<double> X_k(N);
     vector<double> h_k(N);
     thermo->getMoleFractions(X_k);
-    thermo->getPartialMolarEnthalpies(h_k.data());
+    thermo->getPartialMolarEnthalpies(h_k);
     for (size_t k = 0; k < N; k++) {
         h_avg += X_k[k]*h_k[k];
     }
@@ -360,7 +360,7 @@ TEST(ThermoFromYaml, IdealSolidSolnPhase)
 
     // Now test the pressure dependence, by repeating at 2 atm:
     thermo->setState_TP(298, 2*OneAtm);
-    thermo->getPartialMolarEnthalpies(h_k.data());
+    thermo->getPartialMolarEnthalpies(h_k);
     h_avg = 0;
     for (size_t k = 0; k < N; k++) {
         h_avg += X_k[k]*h_k[k];

--- a/test/thermo/thermoFromYaml.cpp
+++ b/test/thermo/thermoFromYaml.cpp
@@ -236,7 +236,7 @@ TEST(ThermoFromYaml, HMWSoln)
     size_t N = thermo->nSpecies();
     auto HMW = dynamic_cast<MolalityVPSSTP*>(thermo.get());
     vector<double> acMol(N), mf(N), activities(N), moll(N), mu0(N);
-    thermo->getMoleFractions(mf.data());
+    thermo->getMoleFractions(mf);
     HMW->getMolalities(moll.data());
     HMW->getMolalityActivityCoefficients(acMol.data());
     thermo->getActivities(activities.data());
@@ -351,7 +351,7 @@ TEST(ThermoFromYaml, IdealSolidSolnPhase)
     size_t N = thermo->nSpecies();
     vector<double> X_k(N);
     vector<double> h_k(N);
-    thermo->getMoleFractions(X_k.data());
+    thermo->getMoleFractions(X_k);
     thermo->getPartialMolarEnthalpies(h_k.data());
     for (size_t k = 0; k < N; k++) {
         h_avg += X_k[k]*h_k[k];

--- a/test/thermo/thermoParameterizations.cpp
+++ b/test/thermo/thermoParameterizations.cpp
@@ -126,11 +126,11 @@ TEST(Shomate, modifyOneHf298)
     double Htest = -400e6;
     S.modifyOneHf298(npos, Htest);
     double cp, h, s;
-    S.updatePropertiesTemp(298.15, &cp, &h, &s);
+    S.updatePropertiesTemp(298.15, cp, h, s);
     EXPECT_DOUBLE_EQ(Htest, h * 298.15 * GasConstant);
     EXPECT_DOUBLE_EQ(Htest, S.reportHf298());
     S.resetHf298();
-    S.updatePropertiesTemp(298.15, &cp, &h, &s);
+    S.updatePropertiesTemp(298.15, cp, h, s);
     EXPECT_DOUBLE_EQ(hf, h * 298.15 * GasConstant);
 }
 
@@ -147,7 +147,7 @@ TEST(SpeciesThermo, NasaPoly2FromYaml1) {
     double cp_R, h_RT, s_R;
     auto st = newSpeciesThermo(data);
     st->validate("NO2");
-    st->updatePropertiesTemp(300, &cp_R, &h_RT, &s_R);
+    st->updatePropertiesTemp(300, cp_R, h_RT, s_R);
     EXPECT_DOUBLE_EQ(st->refPressure(), OneAtm);
     EXPECT_DOUBLE_EQ(cp_R, 4.47823303484);
     EXPECT_DOUBLE_EQ(h_RT, 13.735827875868003);
@@ -167,7 +167,7 @@ TEST(SpeciesThermo, NasaPoly2FromYaml2) {
     auto st = newSpeciesThermo(data);
     st->validate("NO2");
     EXPECT_DOUBLE_EQ(st->refPressure(), OneAtm);
-    st->updatePropertiesTemp(300, &cp_R, &h_RT, &s_R);
+    st->updatePropertiesTemp(300, cp_R, h_RT, s_R);
     EXPECT_DOUBLE_EQ(st->maxTemp(), 1000);
     EXPECT_DOUBLE_EQ(cp_R, 4.47823303484);
     EXPECT_DOUBLE_EQ(h_RT, 13.735827875868003);
@@ -184,7 +184,7 @@ TEST(SpeciesThermo, Shomate2FromYaml1) {
     double cp_R, h_RT, s_R;
     auto st = newSpeciesThermo(data);
     st->validate("CO");
-    st->updatePropertiesTemp(1500, &cp_R, &h_RT, &s_R);
+    st->updatePropertiesTemp(1500, cp_R, h_RT, s_R);
     EXPECT_DOUBLE_EQ(st->refPressure(), OneAtm);
     EXPECT_DOUBLE_EQ(cp_R, 4.2365020788908732);
     EXPECT_DOUBLE_EQ(h_RT, -5.747000804338211);
@@ -209,7 +209,7 @@ TEST(SpeciesThermo, Nasa9PolyFromYaml) {
     double cp_R, h_RT, s_R;
     auto st = newSpeciesThermo(data);
     EXPECT_DOUBLE_EQ(st->refPressure(), 1e5);
-    st->updatePropertiesTemp(2000, &cp_R, &h_RT, &s_R);
+    st->updatePropertiesTemp(2000, cp_R, h_RT, s_R);
     EXPECT_DOUBLE_EQ(cp_R, 4.326181187976);
     EXPECT_DOUBLE_EQ(h_RT, 3.3757914517886856);
     EXPECT_DOUBLE_EQ(s_R, 30.31743870437559);
@@ -226,7 +226,7 @@ TEST(SpeciesThermo, ConstCpPolyFromYaml) {
         "T-max: 2000 K\n");
     double cp_R, h_RT, s_R;
     auto st = newSpeciesThermo(data);
-    st->updatePropertiesTemp(1100, &cp_R, &h_RT, &s_R);
+    st->updatePropertiesTemp(1100, cp_R, h_RT, s_R);
     EXPECT_DOUBLE_EQ(cp_R * GasConst_cal_mol_K, 5.95);
     EXPECT_DOUBLE_EQ(h_RT * GasConst_cal_mol_K * 1100, 9.22e3 + 100 * 5.95);
     EXPECT_DOUBLE_EQ(s_R * GasConst_cal_mol_K, -3.02 + 5.95 * log(1100.0/1000.0));
@@ -243,7 +243,7 @@ TEST(SpeciesThermo, Mu0PolyFromYaml) {
         " T-min: 273.15, T-max: 350 K}");
     auto st = newSpeciesThermo(data);
     double cp_R, h_RT, s_R;
-    st->updatePropertiesTemp(310, &cp_R, &h_RT, &s_R);
+    st->updatePropertiesTemp(310, cp_R, h_RT, s_R);
     EXPECT_DOUBLE_EQ(cp_R, -11226.315743743922);
     EXPECT_DOUBLE_EQ(h_RT, -774.43302435932878);
     EXPECT_DOUBLE_EQ(s_R, -433.36374417010006);
@@ -259,8 +259,8 @@ TEST(SpeciesThermo, NasaPoly2ToYaml) {
     auto duplicate = newSpeciesThermo(h2o_data2);
     double cp1, cp2, h1, h2, s1, s2;
     for (double T : {500, 900, 1300, 2100}) {
-        original->updatePropertiesTemp(T, &cp1, &h1, &s1);
-        duplicate->updatePropertiesTemp(T, &cp2, &h2, &s2);
+        original->updatePropertiesTemp(T, cp1, h1, s1);
+        duplicate->updatePropertiesTemp(T, cp2, h2, s2);
         EXPECT_DOUBLE_EQ(cp1, cp2);
         EXPECT_DOUBLE_EQ(h1, h2);
         EXPECT_DOUBLE_EQ(s1, s2);
@@ -276,8 +276,8 @@ TEST(SpeciesThermo, ShomatePolyToYaml) {
     auto duplicate = newSpeciesThermo(co2_data2);
     double cp1, cp2, h1, h2, s1, s2;
     for (double T : {500, 900, 1300, 2100}) {
-        original->updatePropertiesTemp(T, &cp1, &h1, &s1);
-        duplicate->updatePropertiesTemp(T, &cp2, &h2, &s2);
+        original->updatePropertiesTemp(T, cp1, h1, s1);
+        duplicate->updatePropertiesTemp(T, cp2, h2, s2);
         EXPECT_DOUBLE_EQ(cp1, cp2);
         EXPECT_DOUBLE_EQ(h1, h2);
         EXPECT_DOUBLE_EQ(s1, s2);
@@ -293,8 +293,8 @@ TEST(SpeciesThermo, ConstCpToYaml) {
     auto duplicate = newSpeciesThermo(h2o_data2);
     double cp1, cp2, h1, h2, s1, s2;
     for (double T : {300, 500, 900}) {
-        original->updatePropertiesTemp(T, &cp1, &h1, &s1);
-        duplicate->updatePropertiesTemp(T, &cp2, &h2, &s2);
+        original->updatePropertiesTemp(T, cp1, h1, s1);
+        duplicate->updatePropertiesTemp(T, cp2, h2, s2);
         EXPECT_DOUBLE_EQ(cp1, cp2);
         EXPECT_DOUBLE_EQ(h1, h2);
         EXPECT_DOUBLE_EQ(s1, s2);
@@ -310,8 +310,8 @@ TEST(SpeciesThermo, PiecewiseGibbsToYaml) {
     auto duplicate = newSpeciesThermo(AnyMap::fromYamlString(oh_data.toYamlString()));
     double cp1, cp2, h1, h2, s1, s2;
     for (double T : {274, 300, 330, 340}) {
-        original->updatePropertiesTemp(T, &cp1, &h1, &s1);
-        duplicate->updatePropertiesTemp(T, &cp2, &h2, &s2);
+        original->updatePropertiesTemp(T, cp1, h1, s1);
+        duplicate->updatePropertiesTemp(T, cp2, h2, s2);
         EXPECT_DOUBLE_EQ(cp1, cp2) << T;
         EXPECT_DOUBLE_EQ(h1, h2) << T;
         EXPECT_DOUBLE_EQ(s1, s2) << T;
@@ -327,8 +327,8 @@ TEST(SpeciesThermo, Nasa9PolyToYaml) {
     auto duplicate = newSpeciesThermo(n2p_data2);
     double cp1, cp2, h1, h2, s1, s2;
     for (double T : {300, 900, 1500, 7000}) {
-        original->updatePropertiesTemp(T, &cp1, &h1, &s1);
-        duplicate->updatePropertiesTemp(T, &cp2, &h2, &s2);
+        original->updatePropertiesTemp(T, cp1, h1, s1);
+        duplicate->updatePropertiesTemp(T, cp2, h2, s2);
         EXPECT_DOUBLE_EQ(cp1, cp2);
         EXPECT_DOUBLE_EQ(h1, h2);
         EXPECT_DOUBLE_EQ(s1, s2);

--- a/test/thermo/thermoToYaml.cpp
+++ b/test/thermo/thermoToYaml.cpp
@@ -521,8 +521,8 @@ TEST_F(ThermoYamlRoundTrip, IsotropicElectronEnergyPlasma)
     auto duplPlasma = std::dynamic_pointer_cast<PlasmaPhase>(duplicate);
     vector<double> origDist(origPlasma->nElectronEnergyLevels());
     vector<double> duplDist(duplPlasma->nElectronEnergyLevels());
-    origPlasma->getElectronEnergyLevels(origDist.data());
-    duplPlasma->getElectronEnergyLevels(duplDist.data());
+    origPlasma->getElectronEnergyLevels(origDist);
+    duplPlasma->getElectronEnergyLevels(duplDist);
     EXPECT_DOUBLE_EQ(origDist[2], duplDist[2]);
 }
 

--- a/test/thermo/thermoToYaml.cpp
+++ b/test/thermo/thermoToYaml.cpp
@@ -377,8 +377,8 @@ public:
 
         vector<double> Y1(kk), Y2(kk), h1(kk), h2(kk), s1(kk), s2(kk);
         vector<double> mu1(kk), mu2(kk), v1(kk), v2(kk), a1(kk), a2(kk);
-        original->getMassFractions(Y1.data());
-        duplicate->getMassFractions(Y2.data());
+        original->getMassFractions(Y1);
+        duplicate->getMassFractions(Y2);
         original->getPartialMolarEnthalpies(h1.data());
         duplicate->getPartialMolarEnthalpies(h2.data());
         original->getPartialMolarEntropies(s1.data());

--- a/test/thermo/thermoToYaml.cpp
+++ b/test/thermo/thermoToYaml.cpp
@@ -379,17 +379,17 @@ public:
         vector<double> mu1(kk), mu2(kk), v1(kk), v2(kk), a1(kk), a2(kk);
         original->getMassFractions(Y1);
         duplicate->getMassFractions(Y2);
-        original->getPartialMolarEnthalpies(h1.data());
-        duplicate->getPartialMolarEnthalpies(h2.data());
-        original->getPartialMolarEntropies(s1.data());
-        duplicate->getPartialMolarEntropies(s2.data());
-        original->getChemPotentials(mu1.data());
-        duplicate->getChemPotentials(mu2.data());
-        original->getPartialMolarVolumes(v1.data());
-        duplicate->getPartialMolarVolumes(v2.data());
+        original->getPartialMolarEnthalpies(h1);
+        duplicate->getPartialMolarEnthalpies(h2);
+        original->getPartialMolarEntropies(s1);
+        duplicate->getPartialMolarEntropies(s2);
+        original->getChemPotentials(mu1);
+        duplicate->getChemPotentials(mu2);
+        original->getPartialMolarVolumes(v1);
+        duplicate->getPartialMolarVolumes(v2);
         if (!skip_activities) {
-            original->getActivityCoefficients(a1.data());
-            duplicate->getActivityCoefficients(a2.data());
+            original->getActivityCoefficients(a1);
+            duplicate->getActivityCoefficients(a2);
         }
 
         for (size_t k = 0; k < kk; k++) {

--- a/test/thermo_consistency/consistency.cpp
+++ b/test/thermo_consistency/consistency.cpp
@@ -150,8 +150,8 @@ TEST_P(TestConsistency, h_eq_u_plus_Pv) {
     if (phase->type() == "plasma" && ke != npos) {
         // Two-temperature identity for PlasmaPhase:
         // h = u + p*v + X_e * R * (Te - T)
-        std::vector<double> X(nsp);
-        phase->getMoleFractions(X.data());
+        vector<double> X(nsp);
+        phase->getMoleFractions(X);
         double Xe = X[ke];
         EXPECT_NEAR(h, u + p * v + Xe * (RTe - RT), atol);
     } else {
@@ -591,7 +591,7 @@ TEST_P(TestConsistency, activity_coeffs) {
     try {
         phase->getActivities(a.data());
         phase->getActivityCoefficients(gamma.data());
-        phase->getMoleFractions(X.data());
+        phase->getMoleFractions(X);
     } catch (NotImplementedError& err) {
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
     }

--- a/test/thermo_consistency/consistency.cpp
+++ b/test/thermo_consistency/consistency.cpp
@@ -176,9 +176,9 @@ TEST_P(TestConsistency, hk_eq_uk_plus_P_vk)
 {
     vector<double> hk(nsp), uk(nsp), vk(nsp);
     try {
-        phase->getPartialMolarEnthalpies(hk.data());
-        phase->getPartialMolarIntEnergies(uk.data());
-        phase->getPartialMolarVolumes(vk.data());
+        phase->getPartialMolarEnthalpies(hk);
+        phase->getPartialMolarIntEnergies(uk);
+        phase->getPartialMolarVolumes(vk);
     } catch (NotImplementedError& err) {
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
     }
@@ -193,9 +193,9 @@ TEST_P(TestConsistency, gk_eq_hk_minus_T_sk)
 {
     vector<double> gk(nsp), hk(nsp), sk(nsp);
     try {
-        phase->getChemPotentials(gk.data());
-        phase->getPartialMolarEnthalpies(hk.data());
-        phase->getPartialMolarEntropies(sk.data());
+        phase->getChemPotentials(gk);
+        phase->getPartialMolarEnthalpies(hk);
+        phase->getPartialMolarEntropies(sk);
     } catch (NotImplementedError& err) {
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
     }
@@ -210,7 +210,7 @@ TEST_P(TestConsistency, h_eq_sum_hk_Xk)
 {
     vector<double> hk(nsp);
     try {
-        phase->getPartialMolarEnthalpies(hk.data());
+        phase->getPartialMolarEnthalpies(hk);
     } catch (NotImplementedError& err) {
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
     }
@@ -222,7 +222,7 @@ TEST_P(TestConsistency, u_eq_sum_uk_Xk)
     vector<double> uk(nsp);
     double u;
     try {
-        phase->getPartialMolarIntEnergies(uk.data());
+        phase->getPartialMolarIntEnergies(uk);
         u = phase->intEnergy_mole();
     } catch (NotImplementedError& err) {
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
@@ -235,7 +235,7 @@ TEST_P(TestConsistency, g_eq_sum_gk_Xk)
     vector<double> gk(nsp);
     double g;
     try {
-        phase->getChemPotentials(gk.data());
+        phase->getChemPotentials(gk);
         g = phase->gibbs_mole();
     } catch (NotImplementedError& err) {
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
@@ -248,7 +248,7 @@ TEST_P(TestConsistency, s_eq_sum_sk_Xk)
     vector<double> sk(nsp);
     double s;
     try {
-        phase->getPartialMolarEntropies(sk.data());
+        phase->getPartialMolarEntropies(sk);
         s = phase->entropy_mole();
     } catch (NotImplementedError& err) {
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
@@ -260,7 +260,7 @@ TEST_P(TestConsistency, v_eq_sum_vk_Xk)
 {
     vector<double> vk(nsp);
     try {
-        phase->getPartialMolarVolumes(vk.data());
+        phase->getPartialMolarVolumes(vk);
     } catch (NotImplementedError& err) {
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
     }
@@ -272,7 +272,7 @@ TEST_P(TestConsistency, cp_eq_sum_cpk_Xk)
     vector<double> cpk(nsp);
     double cp;
     try {
-        phase->getPartialMolarCp(cpk.data());
+        phase->getPartialMolarCp(cpk);
         cp = phase->cp_mole();
     } catch (NotImplementedError& err) {
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
@@ -497,9 +497,9 @@ TEST_P(TestConsistency, hk0_eq_uk0_plus_p_vk0)
 {
     vector<double> h0(nsp), u0(nsp), v0(nsp);
     try {
-        phase->getEnthalpy_RT(h0.data());
-        phase->getIntEnergy_RT(u0.data());
-        phase->getStandardVolumes(v0.data());
+        phase->getEnthalpy_RT(h0);
+        phase->getIntEnergy_RT(u0);
+        phase->getStandardVolumes(v0);
     } catch (NotImplementedError& err) {
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
     }
@@ -512,9 +512,9 @@ TEST_P(TestConsistency, gk0_eq_hk0_minus_T_sk0)
 {
     vector<double> g0(nsp), h0(nsp), s0(nsp);
     try {
-        phase->getEnthalpy_RT(h0.data());
-        phase->getGibbs_RT(g0.data());
-        phase->getEntropy_R(s0.data());
+        phase->getEnthalpy_RT(h0);
+        phase->getGibbs_RT(g0);
+        phase->getEntropy_R(s0);
     } catch (NotImplementedError& err) {
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
     }
@@ -528,16 +528,16 @@ TEST_P(TestConsistency, cpk0_eq_dhk0dT)
 {
     vector<double> h1(nsp), h2(nsp), cp1(nsp), cp2(nsp);
     try {
-        phase->getEnthalpy_RT(h1.data());
-        phase->getCp_R(cp1.data());
+        phase->getEnthalpy_RT(h1);
+        phase->getCp_R(cp1);
     } catch (NotImplementedError& err) {
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
     }
     double T1 = phase->temperature();
     double dT = 1e-5 * phase->temperature();
     phase->setState_TP(T1 + dT, phase->pressure());
-    phase->getEnthalpy_RT(h2.data());
-    phase->getCp_R(cp2.data());
+    phase->getEnthalpy_RT(h2);
+    phase->getCp_R(cp2);
     for (size_t k = 0; k < nsp; k++) {
         double cp_mid = 0.5 * (cp1[k] + cp2[k]) * GasConstant;
         double cp_fd = (h2[k] * (T1 + dT) - h1[k] * T1) / dT * GasConstant;
@@ -550,8 +550,8 @@ TEST_P(TestConsistency, standard_gibbs_nondim)
 {
     vector<double> g0_RT(nsp), mu0(nsp);
     try {
-        phase->getGibbs_RT(g0_RT.data());
-        phase->getStandardChemPotentials(mu0.data());
+        phase->getGibbs_RT(g0_RT);
+        phase->getStandardChemPotentials(mu0);
     } catch (NotImplementedError& err) {
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
     }
@@ -567,9 +567,9 @@ TEST_P(TestConsistency, standard_gibbs_nondim)
 TEST_P(TestConsistency, chem_potentials_to_activities) {
     vector<double> mu0(nsp), mu(nsp), a(nsp);
     try {
-        phase->getChemPotentials(mu.data());
-        phase->getStandardChemPotentials(mu0.data());
-        phase->getActivities(a.data());
+        phase->getChemPotentials(mu);
+        phase->getStandardChemPotentials(mu0);
+        phase->getActivities(a);
     } catch (NotImplementedError& err) {
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
     }
@@ -589,8 +589,8 @@ TEST_P(TestConsistency, chem_potentials_to_activities) {
 TEST_P(TestConsistency, activity_coeffs) {
     vector<double> a(nsp), gamma(nsp), X(nsp);
     try {
-        phase->getActivities(a.data());
-        phase->getActivityCoefficients(gamma.data());
+        phase->getActivities(a);
+        phase->getActivityCoefficients(gamma);
         phase->getMoleFractions(X);
     } catch (NotImplementedError& err) {
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
@@ -604,8 +604,8 @@ TEST_P(TestConsistency, activity_coeffs) {
 TEST_P(TestConsistency, activity_concentrations) {
     vector<double> a(nsp), Cact(nsp);
     try {
-        phase->getActivities(a.data());
-        phase->getActivityConcentrations(Cact.data());
+        phase->getActivities(a);
+        phase->getActivityConcentrations(Cact);
     } catch (NotImplementedError& err) {
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
     }
@@ -625,8 +625,8 @@ TEST_P(TestConsistency, log_standard_concentrations) {
 TEST_P(TestConsistency, log_activity_coeffs) {
     vector<double> gamma(nsp), log_gamma(nsp);
     try {
-        phase->getActivityCoefficients(gamma.data());
-        phase->getLnActivityCoefficients(log_gamma.data());
+        phase->getActivityCoefficients(gamma);
+        phase->getLnActivityCoefficients(log_gamma);
     } catch (NotImplementedError& err) {
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
     }
@@ -641,9 +641,9 @@ TEST_P(TestConsistency, hRef_eq_uRef_plus_P_vRef)
 {
     vector<double> hRef(nsp), uRef(nsp), vRef(nsp);
     try {
-        phase->getEnthalpy_RT_ref(hRef.data());
-        phase->getIntEnergy_RT_ref(uRef.data());
-        phase->getStandardVolumes_ref(vRef.data());
+        phase->getEnthalpy_RT_ref(hRef);
+        phase->getIntEnergy_RT_ref(uRef);
+        phase->getStandardVolumes_ref(vRef);
     } catch (NotImplementedError& err) {
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
     }
@@ -660,10 +660,10 @@ TEST_P(TestConsistency, gRef_eq_hRef_minus_T_sRef)
 {
     vector<double> hRef(nsp), gRef_RT(nsp), gRef(nsp), sRef(nsp);
     try {
-        phase->getEnthalpy_RT_ref(hRef.data());
-        phase->getGibbs_ref(gRef.data());
-        phase->getGibbs_RT_ref(gRef_RT.data());
-        phase->getEntropy_R_ref(sRef.data());
+        phase->getEnthalpy_RT_ref(hRef);
+        phase->getGibbs_ref(gRef);
+        phase->getGibbs_RT_ref(gRef_RT);
+        phase->getEntropy_R_ref(sRef);
     } catch (NotImplementedError& err) {
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
     }
@@ -684,16 +684,16 @@ TEST_P(TestConsistency, cpRef_eq_dhRefdT)
 {
     vector<double> h1(nsp), h2(nsp), cp1(nsp), cp2(nsp);
     try {
-        phase->getEnthalpy_RT_ref(h1.data());
-        phase->getCp_R_ref(cp1.data());
+        phase->getEnthalpy_RT_ref(h1);
+        phase->getCp_R_ref(cp1);
     } catch (NotImplementedError& err) {
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
     }
     double T1 = phase->temperature();
     double dT = 1e-5 * phase->temperature();
     phase->setState_TP(T1 + dT, phase->pressure());
-    phase->getEnthalpy_RT_ref(h2.data());
-    phase->getCp_R_ref(cp2.data());
+    phase->getEnthalpy_RT_ref(h2);
+    phase->getCp_R_ref(cp2);
     for (size_t k = 0; k < nsp; k++) {
         double cp_mid = 0.5 * (cp1[k] + cp2[k]) * GasConstant;
         double cp_fd = (h2[k] * (T1 + dT) - h1[k] * T1) / dT * GasConstant;

--- a/test/transport/gasTransportTest.cpp
+++ b/test/transport/gasTransportTest.cpp
@@ -14,7 +14,7 @@ class GasTransportTest : public testing::Test
 public:
     GasTransportTest() {
         nsp = s_thermo->nSpecies();
-        s_thermo->setState_TPX(T0, P0, X0.data());
+        s_thermo->setState_TPX(T0, P0, X0);
     }
 
     static void SetUpTestCase() {
@@ -294,7 +294,7 @@ TEST_F(GasTransportTest, getSpeciesFluxes_mix)
 
     auto [grad_T, grad_X] = SetUpFluxes();
     Array2D fluxes(nsp, 2, 0.0);
-    s_thermo->setState_TPX(T1, P0, X0.data());
+    s_thermo->setState_TPX(T1, P0, X0);
     s_mix->getSpeciesFluxes(2, grad_T.data(), nsp, &grad_X(0, 0), nsp, &fluxes(0, 0));
 
     double netFlux0 = 0.0, netFlux1 = 0.0;
@@ -342,7 +342,7 @@ TEST_F(GasTransportTest, getSpeciesFluxes_multi)
 
     auto [grad_T, grad_X] = SetUpFluxes();
     Array2D fluxes(nsp, 2, 0.0);
-    s_thermo->setState_TPX(T1, P0, X0.data());
+    s_thermo->setState_TPX(T1, P0, X0);
     s_multi->getSpeciesFluxes(2, grad_T.data(), nsp, &grad_X(0, 0), nsp, &fluxes(0, 0));
 
     double netFlux0 = 0.0, netFlux1 = 0.0;
@@ -388,7 +388,7 @@ TEST_F(GasTransportTest, multicomponentDiffusionCoefficients)
     };
 
     Array2D multiDiff(nsp, nsp);
-    s_thermo->setState_TPX(T1, P0, X0.data());
+    s_thermo->setState_TPX(T1, P0, X0);
     s_multi->getMultiDiffCoeffs(nsp, &multiDiff(0,0));
     size_t kH2 = s_thermo->speciesIndex("H2");
     for (size_t k = 0; k < nsp; k++) {
@@ -417,7 +417,7 @@ TEST_F(GasTransportTest, getFluxes_multi)
         grad_X[k] = (X3[k] - X2[k]) / dist;
     }
 
-    s_thermo->setState_TPX(0.5 * (T2 + T3), P0, X1.data());
+    s_thermo->setState_TPX(0.5 * (T2 + T3), P0, X1);
     s_multi->getSpeciesFluxes(1, &grad_T, nsp, grad_X.data(), nsp, fluxS.data());
     s_multi->getMassFluxes(state2.data(), state3.data(), dist, fluxMass.data());
     s_multi->getMolarFluxes(state2.data(), state3.data(), dist, fluxMole.data());

--- a/test/transport/gasTransportTest.cpp
+++ b/test/transport/gasTransportTest.cpp
@@ -406,10 +406,10 @@ TEST_F(GasTransportTest, getFluxes_multi)
     s_thermo->setState_TPX(T2, P0,
         "H2:0.25, H:0.0001, H2O:0.17, CO:0.15, CO2:0.05, NO:0.001, N2: 0.38");
     s_thermo->saveState(state2);
-    s_thermo->getMoleFractions(X2.data());
+    s_thermo->getMoleFractions(X2);
     s_thermo->setState_TPX(T3, P0, "H2:0.27, H2O:0.18, CO:0.13, CO2:0.04, N2: 0.38");
     s_thermo->saveState(state3);
-    s_thermo->getMoleFractions(X3.data());
+    s_thermo->getMoleFractions(X3);
     double grad_T = (T3 - T2) / dist;
     for (size_t k = 0; k < nsp; k++) {
         X1[k] = 0.5 * (X2[k] + X3[k]);

--- a/test/transport/gasTransportTest.cpp
+++ b/test/transport/gasTransportTest.cpp
@@ -400,7 +400,8 @@ TEST_F(GasTransportTest, multicomponentDiffusionCoefficients)
 TEST_F(GasTransportTest, getFluxes_multi)
 {
     vector<double> fluxS(nsp), fluxMass(nsp), fluxMole(nsp);
-    vector<double> state2, state3;
+    vector<double> state2(s_thermo->stateSize());
+    vector<double> state3(s_thermo->stateSize());
     vector<double> X1(nsp), X2(nsp), X3(nsp), grad_X(nsp);
 
     s_thermo->setState_TPX(T2, P0,

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -230,7 +230,7 @@ TEST(MoleReactorTestSet, test_mole_reactor_get_state)
     vector<double> state(reactor.neq());
     // test get state
     const ThermoPhase& thermo = *reactor.phase()->thermo();
-    const vector<double>& imw = thermo.inverseMolecularWeights();
+    auto imw = thermo.inverseMolecularWeights();
     // prescribed state
     double mass = reactor.volume() * thermo.density();
     size_t H2I = reactor.componentIndex("H2")-1;

--- a/test_problems/ChemEquil_ionizedGas/ionizedGasEquil.cpp
+++ b/test_problems/ChemEquil_ionizedGas/ionizedGasEquil.cpp
@@ -65,7 +65,7 @@ int main(int argc, char** argv)
                 cout << "heat capacity c_p = " << gas->cp_mass() << endl;
                 cout << "heat capacity c_v = " << gas->cv_mass() << endl << endl;
 
-                gas->getMoleFractions(Xmol.data());
+                gas->getMoleFractions(Xmol);
                 fprintf(FF,"%10.4g, %10.4g,", tkelvin, pres);
                 for (size_t k = 0; k < kk; k++) {
                     if (fabs(Xmol[k]) < 1.0E-130) {

--- a/test_problems/VCSnonideal/NaCl_equil/nacl_equil.cpp
+++ b/test_problems/VCSnonideal/NaCl_equil/nacl_equil.cpp
@@ -87,7 +87,7 @@ int main(int argc, char** argv)
         vector<double> Xmol(kk, 0.0);
         size_t iH2OL = hmw->speciesIndex("H2O(L)");
         Xmol[iH2OL] = 1.0;
-        hmw->setState_TPX(T, pres, Xmol.data());
+        hmw->setState_TPX(T, pres, Xmol);
 
         auto gas = newThermo("NaCl_gas.yaml");
 
@@ -98,7 +98,7 @@ int main(int argc, char** argv)
         }
         size_t iN2 = gas->speciesIndex("N2");
         Xmol[iN2] = 1.0;
-        gas->setState_TPX(T, pres, Xmol.data());
+        gas->setState_TPX(T, pres, Xmol);
 
 
         auto ss = make_unique<StoichSubstance>("NaCl_Solid.yaml");

--- a/test_problems/cathermo/DH_graph_1/DH_graph_1.cpp
+++ b/test_problems/cathermo/DH_graph_1/DH_graph_1.cpp
@@ -23,8 +23,8 @@ int main(int argc, char** argv)
         DebyeHuckel* DH = new DebyeHuckel(iFile, phaseName);
 
         size_t nsp = DH->nSpecies();
-        double acMol[100];
-        double moll[100];
+        vector<double> acMol(nsp);
+        vector<double> moll(nsp);
         string sName;
 
         DH->setState_TP(298.15, 1.01325E5);

--- a/test_problems/cathermo/DH_graph_1/DH_graph_1.cpp
+++ b/test_problems/cathermo/DH_graph_1/DH_graph_1.cpp
@@ -24,9 +24,7 @@ int main(int argc, char** argv)
 
         size_t nsp = DH->nSpecies();
         double acMol[100];
-        double mf[100];
         double moll[100];
-        DH->getMoleFractions(mf);
         string sName;
 
         DH->setState_TP(298.15, 1.01325E5);

--- a/test_problems/cathermo/HMW_graph_CpvT/HMW_graph_CpvT.cpp
+++ b/test_problems/cathermo/HMW_graph_CpvT/HMW_graph_CpvT.cpp
@@ -25,13 +25,7 @@ int main(int argc, char** argv)
         auto solid = newThermo("NaCl_Solid.yaml", "NaCl(S)");
 
         size_t nsp = HMW->nSpecies();
-        double mf[100];
         double moll[100];
-        for (i = 0; i < 100; i++) {
-            mf[i] = 0.0;
-        }
-
-        HMW->getMoleFractions(mf);
         string sName;
 
         TemperatureTable TTable(15, false, 273.15, 25., 0, 0);
@@ -60,7 +54,7 @@ int main(int argc, char** argv)
         moll[i1] = Is;
         moll[i2] = Is;
         HMW->setState_TPM(298.15, pres, moll);
-        double Xmol[30];
+        vector<double> Xmol(nsp);
         HMW->getMoleFractions(Xmol);
 
         /*

--- a/test_problems/cathermo/HMW_graph_CpvT/HMW_graph_CpvT.cpp
+++ b/test_problems/cathermo/HMW_graph_CpvT/HMW_graph_CpvT.cpp
@@ -19,13 +19,11 @@ int main(int argc, char** argv)
 
     try {
         string iFile = (argc > 1) ? argv[1] : "HMW_NaCl.yaml";
-        double Cp0_R[20], pmCp[20];
-
         HMWSoln* HMW = new HMWSoln(iFile, "NaCl_electrolyte");
         auto solid = newThermo("NaCl_Solid.yaml", "NaCl(S)");
 
         size_t nsp = HMW->nSpecies();
-        double moll[100];
+        vector<double> Cp0_R(nsp), pmCp(nsp), moll(nsp);
         string sName;
 
         TemperatureTable TTable(15, false, 273.15, 25., 0, 0);

--- a/test_problems/cathermo/HMW_graph_GvI/HMW_graph_GvI.cpp
+++ b/test_problems/cathermo/HMW_graph_GvI/HMW_graph_GvI.cpp
@@ -31,16 +31,9 @@ int main(int argc, char** argv)
         HMWSoln* HMW = new HMWSoln("HMW_NaCl.yaml", "NaCl_electrolyte_complex_shomate");
 
         size_t nsp = HMW->nSpecies();
-        double acMol[100];
-        double act[100];
-        double moll[100];
-
-        for (i = 0; i < 100; i++) {
-            acMol[i] = 1.0;
-            act[i] = 1.0;
-            moll[i] = 0.0;
-        }
-
+        vector<double> acMol(nsp, 1.0);
+        vector<double> act(nsp, 1.0);
+        vector<double> moll(nsp, 0.0);
         string sName;
         FILE* ff;
 

--- a/test_problems/cathermo/HMW_graph_GvI/HMW_graph_GvI.cpp
+++ b/test_problems/cathermo/HMW_graph_GvI/HMW_graph_GvI.cpp
@@ -33,17 +33,14 @@ int main(int argc, char** argv)
         size_t nsp = HMW->nSpecies();
         double acMol[100];
         double act[100];
-        double mf[100];
         double moll[100];
 
         for (i = 0; i < 100; i++) {
             acMol[i] = 1.0;
             act[i] = 1.0;
-            mf[i] = 0.0;
             moll[i] = 0.0;
         }
 
-        HMW->getMoleFractions(mf);
         string sName;
         FILE* ff;
 

--- a/test_problems/cathermo/HMW_graph_GvT/HMW_graph_GvT.cpp
+++ b/test_problems/cathermo/HMW_graph_GvT/HMW_graph_GvT.cpp
@@ -43,7 +43,7 @@ int main(int argc, char** argv)
             moll[i] = 0.0;
         }
 
-        HMW->getMoleFractions(mf);
+        HMW->getMoleFractions(span<double>(mf, nsp));
         string sName;
 
         TemperatureTable TTable(29, true, 293.15, 10., 0, 0);
@@ -72,7 +72,7 @@ int main(int argc, char** argv)
         moll[i2] = Is;
         HMW->setState_TPM(298.15, pres, moll);
         double Xmol[30];
-        HMW->getMoleFractions(Xmol);
+        HMW->getMoleFractions(span<double>(Xmol, nsp));
 
         printf("Fixed Concentration of the System:\n");
 

--- a/test_problems/cathermo/HMW_graph_GvT/HMW_graph_GvT.cpp
+++ b/test_problems/cathermo/HMW_graph_GvT/HMW_graph_GvT.cpp
@@ -32,18 +32,12 @@ int main(int argc, char** argv)
         auto solid = newThermo(nacl_s, id);
 
         size_t nsp = HMW->nSpecies();
-        double acMol[100];
-        double act[100];
-        double mf[100];
-        double moll[100];
-        for (i = 0; i < 100; i++) {
-            acMol[i] = 1.0;
-            act[i] = 1.0;
-            mf[i] = 0.0;
-            moll[i] = 0.0;
-        }
+        vector<double> acMol(nsp, 1.0);
+        vector<double> act(nsp, 1.0);
+        vector<double> mf(nsp, 0.0);
+        vector<double> moll(nsp, 0.0);
 
-        HMW->getMoleFractions(span<double>(mf, nsp));
+        HMW->getMoleFractions(mf);
         string sName;
 
         TemperatureTable TTable(29, true, 293.15, 10., 0, 0);
@@ -84,7 +78,7 @@ int main(int argc, char** argv)
         /*
          * ThermoUnknowns
          */
-        double mu0_RT[20], mu[20];
+        vector<double> mu0_RT(nsp), mu(nsp);
         double mu0_NaCl, mu0_Naplus, mu0_Clminus, Delta_G0;
         double mu_NaCl, mu_Naplus, mu_Clminus, Delta_G;
         double molarGibbs0, molarGibbs;

--- a/test_problems/cathermo/HMW_graph_HvT/HMW_graph_HvT.cpp
+++ b/test_problems/cathermo/HMW_graph_HvT/HMW_graph_HvT.cpp
@@ -19,19 +19,12 @@ int main(int argc, char** argv)
 
     try {
         string iFile = (argc > 1) ? argv[1] : "HMW_NaCl.yaml";
-        double Enth0_RT[20], pmEnth[20], molarEnth;
-
         HMWSoln* HMW = new HMWSoln(iFile, "NaCl_electrolyte");
-
-
-        /*
-         * Load in and initialize the
-         */
         auto solid = newThermo("NaCl_Solid.yaml","NaCl(S)");
 
-
         size_t nsp = HMW->nSpecies();
-        double moll[100];
+        vector<double> Enth0_RT(nsp), pmEnth(nsp);
+        vector<double> moll(nsp, 0.0);
 
         TemperatureTable TTable(15, false, 273.15, 25., 0, 0);
 
@@ -40,9 +33,6 @@ int main(int argc, char** argv)
 
         size_t i1 = HMW->speciesIndex("Na+");
         size_t i2 = HMW->speciesIndex("Cl-");
-        for (i = 1; i < nsp; i++) {
-            moll[i] = 0.0;
-        }
         HMW->setMolalities(moll);
 
         double Is = 0.0;
@@ -147,7 +137,7 @@ int main(int argc, char** argv)
             H_H2O     = pmEnth[0] * 1.0E-6;
             H_Naplus  = pmEnth[i1] * 1.0E-6;
             H_Clminus = pmEnth[i2] * 1.0E-6;
-            molarEnth = HMW->enthalpy_mole() * 1.0E-6;
+            double molarEnth = HMW->enthalpy_mole() * 1.0E-6;
 
             double Delta_Hs = (Xmol[0] * H_H2O +
                                Xmol[i1] * H_Naplus +

--- a/test_problems/cathermo/HMW_graph_HvT/HMW_graph_HvT.cpp
+++ b/test_problems/cathermo/HMW_graph_HvT/HMW_graph_HvT.cpp
@@ -31,14 +31,7 @@ int main(int argc, char** argv)
 
 
         size_t nsp = HMW->nSpecies();
-        double mf[100];
         double moll[100];
-        for (i = 0; i < 100; i++) {
-            mf[i] = 0.0;
-            moll[i] = 0.0;
-        }
-        HMW->getMoleFractions(mf);
-        string sName;
 
         TemperatureTable TTable(15, false, 273.15, 25., 0, 0);
 
@@ -66,7 +59,7 @@ int main(int argc, char** argv)
         moll[i1] = Is;
         moll[i2] = Is;
         HMW->setState_TPM(298.15, pres, moll);
-        double Xmol[30];
+        vector<double> Xmol(nsp);
         HMW->getMoleFractions(Xmol);
 
         /*

--- a/test_problems/cathermo/HMW_graph_VvT/HMW_graph_VvT.cpp
+++ b/test_problems/cathermo/HMW_graph_VvT/HMW_graph_VvT.cpp
@@ -19,19 +19,14 @@ int main(int argc, char** argv)
 
     try {
         string iFile = (argc > 1) ? argv[1] : "HMW_NaCl.yaml";
-        double V0[20], pmV[20];
 
         HMWSoln* HMW = new HMWSoln(iFile, "NaCl_electrolyte");
-
-
-        /*
-         * Load in and initialize the
-         */
         auto solid = newThermo("NaCl_Solid.yaml", "NaCl(S)");
 
 
         size_t nsp = HMW->nSpecies();
-        double moll[100];
+        vector<double> moll(nsp, 0.0);
+        vector<double> V0(nsp), pmV(nsp);
         string sName;
 
         TemperatureTable TTable(15, false, 273.15, 25., 0, 0);
@@ -41,9 +36,6 @@ int main(int argc, char** argv)
 
         size_t i1 = HMW->speciesIndex("Na+");
         size_t i2 = HMW->speciesIndex("Cl-");
-        for (i = 0; i < nsp; i++) {
-            moll[i] = 0.0;
-        }
         HMW->setMolalities(moll);
 
         /*

--- a/test_problems/cathermo/HMW_graph_VvT/HMW_graph_VvT.cpp
+++ b/test_problems/cathermo/HMW_graph_VvT/HMW_graph_VvT.cpp
@@ -31,9 +31,7 @@ int main(int argc, char** argv)
 
 
         size_t nsp = HMW->nSpecies();
-        double mf[100];
         double moll[100];
-        HMW->getMoleFractions(mf);
         string sName;
 
         TemperatureTable TTable(15, false, 273.15, 25., 0, 0);
@@ -60,7 +58,7 @@ int main(int argc, char** argv)
         moll[i1] = Is;
         moll[i2] = Is;
         HMW->setState_TPM(298.15, pres, moll);
-        double Xmol[30];
+        vector<double> Xmol(nsp);
         HMW->getMoleFractions(Xmol);
         double meanMW = HMW->meanMolecularWeight();
 

--- a/test_problems/cathermo/HMW_test_1/HMW_test_1.cpp
+++ b/test_problems/cathermo/HMW_test_1/HMW_test_1.cpp
@@ -15,7 +15,7 @@ void pAtable(HMWSoln* HMW)
     double moll[100];
 
     HMW->getMolalityActivityCoefficients(acMol);
-    HMW->getMoleFractions(mf);
+    HMW->getMoleFractions(span<double>(mf, nsp));
     HMW->getActivities(activities);
     HMW->getMolalities(moll);
     string sName;

--- a/test_problems/cathermo/HMW_test_1/HMW_test_1.cpp
+++ b/test_problems/cathermo/HMW_test_1/HMW_test_1.cpp
@@ -9,13 +9,13 @@ using namespace Cantera;
 void pAtable(HMWSoln* HMW)
 {
     size_t nsp = HMW->nSpecies();
-    double acMol[100];
-    double mf[100];
-    double activities[100];
-    double moll[100];
+    vector<double> acMol(nsp);
+    vector<double> mf(nsp);
+    vector<double> activities(nsp);
+    vector<double> moll(nsp);
 
     HMW->getMolalityActivityCoefficients(acMol);
-    HMW->getMoleFractions(span<double>(mf, nsp));
+    HMW->getMoleFractions(mf);
     HMW->getActivities(activities);
     HMW->getMolalities(moll);
     string sName;
@@ -40,8 +40,8 @@ int main(int argc, char** argv)
 
         size_t nsp = HMW->nSpecies();
 
-        double mu0[100];
-        double moll[100];
+        vector<double> mu0(nsp);
+        vector<double> moll(nsp);
         string sName;
 
         HMW->getMolalities(moll);

--- a/test_problems/cathermo/HMW_test_3/HMW_test_3.cpp
+++ b/test_problems/cathermo/HMW_test_3/HMW_test_3.cpp
@@ -9,13 +9,13 @@ using namespace Cantera;
 void pAtable(HMWSoln* HMW)
 {
     size_t nsp = HMW->nSpecies();
-    double acMol[100];
-    double mf[100];
-    double activities[100];
-    double moll[100];
+    vector<double> acMol(nsp);
+    vector<double> mf(nsp);
+    vector<double> activities(nsp);
+    vector<double> moll(nsp);
 
     HMW->getMolalityActivityCoefficients(acMol);
-    HMW->getMoleFractions(span<double>(mf, nsp));
+    HMW->getMoleFractions(mf);
     HMW->getActivities(activities);
     HMW->getMolalities(moll);
     string sName;
@@ -39,8 +39,8 @@ int main(int argc, char** argv)
 
         size_t nsp = HMW->nSpecies();
 
-        double mu0[100];
-        double moll[100];
+        vector<double> mu0(nsp);
+        vector<double> moll(nsp);
         string sName;
 
         HMW->getMolalities(moll);

--- a/test_problems/cathermo/HMW_test_3/HMW_test_3.cpp
+++ b/test_problems/cathermo/HMW_test_3/HMW_test_3.cpp
@@ -15,7 +15,7 @@ void pAtable(HMWSoln* HMW)
     double moll[100];
 
     HMW->getMolalityActivityCoefficients(acMol);
-    HMW->getMoleFractions(mf);
+    HMW->getMoleFractions(span<double>(mf, nsp));
     HMW->getActivities(activities);
     HMW->getMolalities(moll);
     string sName;

--- a/test_problems/cathermo/VPissp/ISSPTester.cpp
+++ b/test_problems/cathermo/VPissp/ISSPTester.cpp
@@ -55,7 +55,7 @@ int main(int argc, char** argv)
 
         size_t n = issp.nSpecies();
 
-        double HiSS[20], muiSS[20],SiSS[20], CpiSS[20], VoliSS[20];
+        vector<double> HiSS(n), muiSS(n),SiSS(n), CpiSS(n), VoliSS(n);
         double RT = GasConstant * Tkelvin;
         issp.getStandardChemPotentials(muiSS);
         issp.getEnthalpy_RT(HiSS);
@@ -79,9 +79,7 @@ int main(int argc, char** argv)
                    HiSS[i], SiSS[i], CpiSS[i], VoliSS[i]);
         }
 
-
-
-        double HiPM[20], mui[20],SiPM[20], CpiPM[20], VoliPM[20];
+        vector<double> HiPM(n), mui(n),SiPM(n), CpiPM(n), VoliPM(n);
 
         issp.getChemPotentials(mui);
         issp.getPartialMolarEnthalpies(HiPM);

--- a/test_problems/cathermo/ims/IMSTester.cpp
+++ b/test_problems/cathermo/ims/IMSTester.cpp
@@ -53,7 +53,7 @@ int main(int argc, char** argv)
 
         size_t n = ims.nSpecies();
 
-        double HiSS[20], muiSS[20],SiSS[20], CpiSS[20], VoliSS[20];
+        vector<double> HiSS(n), muiSS(n),SiSS(n), CpiSS(n), VoliSS(n);
         double RT = GasConstant * Tkelvin;
         ims.getStandardChemPotentials(muiSS);
         ims.getEnthalpy_RT(HiSS);
@@ -80,9 +80,7 @@ int main(int argc, char** argv)
                    HiSS[i], SiSS[i], CpiSS[i], VoliSS[i]);
         }
 
-
-
-        double HiPM[20], mui[20],SiPM[20], CpiPM[20], VoliPM[20];
+        vector<double> HiPM(n), mui(n),SiPM(n), CpiPM(n), VoliPM(n);
 
         ims.getChemPotentials(mui);
         ims.getPartialMolarEnthalpies(HiPM);

--- a/test_problems/cathermo/issp/ISSPTester.cpp
+++ b/test_problems/cathermo/issp/ISSPTester.cpp
@@ -54,7 +54,7 @@ int main(int argc, char** argv)
 
         size_t n = issp.nSpecies();
 
-        double HiSS[20], muiSS[20],SiSS[20], CpiSS[20], VoliSS[20];
+        vector<double> HiSS(n), muiSS(n),SiSS(n), CpiSS(n), VoliSS(n);
         double RT = GasConstant * Tkelvin;
         issp.getStandardChemPotentials(muiSS);
         issp.getEnthalpy_RT(HiSS);
@@ -78,9 +78,7 @@ int main(int argc, char** argv)
                    HiSS[i], SiSS[i], CpiSS[i], VoliSS[i]);
         }
 
-
-
-        double HiPM[20], mui[20],SiPM[20], CpiPM[20], VoliPM[20];
+        vector<double> HiPM(n), mui(n),SiPM(n), CpiPM(n), VoliPM(n);
 
         issp.getChemPotentials(mui);
         issp.getPartialMolarEnthalpies(HiPM);

--- a/test_problems/cathermo/stoichSub/stoichSub.cpp
+++ b/test_problems/cathermo/stoichSub/stoichSub.cpp
@@ -34,9 +34,9 @@ int main(int argc, char** argv)
         /*
          * ThermoUnknowns
          */
-        double mu0_RT[20], mu[20], cp_r[20];
-        double enth_RT[20];
-        double entrop_RT[20], intE_RT[20];
+        vector<double> mu0_RT(nsp), mu(nsp), cp_r(nsp);
+        vector<double> enth_RT(nsp);
+        vector<double> entrop_RT(nsp), intE_RT(nsp);
         double mu_NaCl, enth_NaCl, entrop_NaCl;
         double cp_NaCl;
         /*

--- a/test_problems/cathermo/testWaterTP/testWaterSSTP.cpp
+++ b/test_problems/cathermo/testWaterTP/testWaterSSTP.cpp
@@ -67,7 +67,7 @@ int main()
             delg0 = (g - h298)/temp + GasConstant * log(oneBar/presLow);
             Cp0 = w->cp_mole();
             {
-                w->getCp_R(&Cp0_ss);
+                w->getCp_R(span<double>(&Cp0_ss, 1));
                 Cp0_ss *= GasConstant;
                 if (fabs(Cp0_ss - Cp0) > 1.0E-5) {
                     printf("Inconsistency!\n");
@@ -159,13 +159,13 @@ int main()
                 press = psat*1.002;
             }
             w->setState_TP(temp, press);
-            w->getPartialMolarEnthalpies(&h);
+            w->getPartialMolarEnthalpies(span<double>(&h, 1));
             delh0 = tvalue(h - h298l, 1.0E-6);
-            w->getChemPotentials(&g);
+            w->getChemPotentials(span<double>(&g, 1));
             delg0 = (g - h298l)/temp;
-            w->getPartialMolarCp(&Cp0);
-            w->getPartialMolarEntropies(&s);
-            w->getPartialMolarVolumes(&vol);
+            w->getPartialMolarCp(span<double>(&Cp0, 1));
+            w->getPartialMolarEntropies(span<double>(&s, 1));
+            w->getPartialMolarVolumes(span<double>(&vol, 1));
             printf("%10g %10g %12g %13.4f %13.4f %13.4f %13.4f %13.4f\n", temp, press*1.0E-5,
                    psat*1.0E-5,
                    Cp0*1.0E-3, s*1.0E-3,
@@ -186,16 +186,16 @@ int main()
                 press = psat*1.002;
             }
             w->setState_TP(temp, press);
-            w->getEnthalpy_RT(&h);
+            w->getEnthalpy_RT(span<double>(&h, 1));
             h *= temp * GasConstant;
             delh0 = tvalue(h - h298l, 1.0E-6);
-            w->getStandardChemPotentials(&g);
+            w->getStandardChemPotentials(span<double>(&g, 1));
             delg0 = (g - h298l)/temp;
-            w->getCp_R(&Cp0);
+            w->getCp_R(span<double>(&Cp0, 1));
             Cp0 *= GasConstant;
-            w->getEntropy_R(&s);
+            w->getEntropy_R(span<double>(&s, 1));
             s *= GasConstant;
-            w->getStandardVolumes(&vol);
+            w->getStandardVolumes(span<double>(&vol, 1));
             printf("%10g %10g %12g %13.4f %13.4f %13.4f %13.4f %13.4f\n", temp, press*1.0E-5,
                    psat*1.0E-5,
                    Cp0*1.0E-3, s*1.0E-3,
@@ -216,16 +216,16 @@ int main()
                 press = psat*1.002;
             }
             w->setState_TP(temp, press);
-            w->getEnthalpy_RT_ref(&h);
+            w->getEnthalpy_RT_ref(span<double>(&h, 1));
             h *= temp * GasConstant;
             delh0 = tvalue(h - h298l, 1.0E-6);
-            w->getGibbs_ref(&g);
+            w->getGibbs_ref(span<double>(&g, 1));
             delg0 = (g - h298l)/temp;
-            w->getCp_R_ref(&Cp0);
+            w->getCp_R_ref(span<double>(&Cp0, 1));
             Cp0 *= GasConstant;
-            w->getEntropy_R_ref(&s);
+            w->getEntropy_R_ref(span<double>(&s, 1));
             s *= GasConstant;
-            w->getStandardVolumes_ref(&vol);
+            w->getStandardVolumes_ref(span<double>(&vol, 1));
             printf("%10g %10g %12g %13.4f %13.4f %13.4f %13.4f %13.4f\n", temp, press*1.0E-5,
                    psat*1.0E-5,
                    Cp0*1.0E-3, s*1.0E-3,
@@ -243,16 +243,16 @@ int main()
             double psat = w->satPressure(temp);
             double press = OneAtm;
             w->setState_TP(temp, press);
-            w->getEnthalpy_RT(&h);
+            w->getEnthalpy_RT(span<double>(&h, 1));
             h *= temp * GasConstant;
             delh0 = tvalue(h - h298l, 1.0E-6);
-            w->getStandardChemPotentials(&g);
+            w->getStandardChemPotentials(span<double>(&g, 1));
             delg0 = (g - h298l)/temp;
-            w->getCp_R(&Cp0);
+            w->getCp_R(span<double>(&Cp0, 1));
             Cp0 *= GasConstant;
-            w->getEntropy_R(&s);
+            w->getEntropy_R(span<double>(&s, 1));
             s *= GasConstant;
-            w->getStandardVolumes(&vol);
+            w->getStandardVolumes(span<double>(&vol, 1));
             printf("%10g %10g %12g %13.4f %13.4f %13.4f %13.4f %13.4f\n", temp, press*1.0E-5,
                    psat*1.0E-5,
                    Cp0*1.0E-3, s*1.0E-3,

--- a/test_problems/diamondSurf/runDiamond.cpp
+++ b/test_problems/diamondSurf/runDiamond.cpp
@@ -34,10 +34,7 @@ int main(int argc, char** argv)
         size_t nr = ikin->nReactions();
         cout << "Number of reactions = " << nr << endl;
 
-        double x[20];
-        for (i = 0; i < 20; i++) {
-            x[i] = 0.0;
-        }
+        vector<double> x(nsp);
         x[0] = 0.0010;
         x[1] = 0.9888;
         x[2] = 0.0002;
@@ -46,9 +43,7 @@ int main(int argc, char** argv)
 
         gas->setState_TPX(1200., p, x);
 
-        for (i = 0; i < 20; i++) {
-            x[i] = 0.0;
-        }
+        x.assign(nsp_d100, 0.0);
         size_t i0 = diamond100->speciesIndex("c6H*");
         x[i0] = 0.1;
         size_t i1 = diamond100->speciesIndex("c6HH");
@@ -56,9 +51,7 @@ int main(int argc, char** argv)
         diamond100->setMoleFractions(x);
         diamond100->setTemperature(1200.);
 
-        for (i = 0; i < 20; i++) {
-            x[i] = 0.0;
-        }
+        x.assign(nsp_d100, 0.0);
         x[0] = 1.0;
         diamond100->setState_TP(1200., p);
 
@@ -67,7 +60,7 @@ int main(int argc, char** argv)
         // Throw some asserts in here to test that they compile
         AssertTrace(p == p);
         AssertThrow(p == p, "main");
-        AssertThrowMsg(i == 20, "main", "are you kidding");
+        AssertThrowMsg(p == p, "main", "are you kidding");
 
         double src[20];
         for (i = 0; i < 20; i++) {

--- a/test_problems/dustyGasTransport/dustyGasTransportTest.cpp
+++ b/test_problems/dustyGasTransport/dustyGasTransportTest.cpp
@@ -34,10 +34,10 @@ int main(int argc, char** argv)
             printf("\n");
         }
 
-        vector<double> state1;
+        vector<double> state1(g->stateSize());
         g->saveState(state1);
         g->setState_TP(T, 1.2 * OneAtm);
-        vector<double> state2;
+        vector<double> state2(g->stateSize());
         g->saveState(state2);
         double delta = 0.001;
         vector<double> fluxes;

--- a/test_problems/stoichSolidKinetics/stoichSolidKinetics.cpp
+++ b/test_problems/stoichSolidKinetics/stoichSolidKinetics.cpp
@@ -76,29 +76,29 @@ void testProblem()
         iKin.getDeltaGibbs(&work[0]);
         printValue("   deltaG        = ", work[0]);
 
-        gasTP->getChemPotentials(&work[0]);
+        gasTP->getChemPotentials(work);
         double mu_CO2 = work[igco2];
         printValue("   mu_CO2(g)     = ", mu_CO2);
 
-        cao_s->getGibbs_RT(&work[0]);
+        cao_s->getGibbs_RT(work);
         double mu_cao = work[0] * GasConstant * Temp;
         printValue("   mu_cao(s)     = ", mu_cao);
 
-        caco3_s->getChemPotentials(&work[0]);
+        caco3_s->getChemPotentials(work);
         double mu_caco3  = work[0];
         printValue("   mu_caco3      = ", mu_caco3);
 
         double deltaG_calc =  mu_CO2 +  mu_cao - mu_caco3;
         printValue("   deltaG_calc   = ", deltaG_calc);
 
-        gasTP->getActivities(&work[0]);
+        gasTP->getActivities(work);
         double act_CO2 = work[igco2];
         printValue("   act_CO2       = ", act_CO2);
 
-        cao_s->getActivities(&work[0]);
+        cao_s->getActivities(work);
         printValue("   act_cao(s)    = ", work[0]);
 
-        caco3_s->getActivities(&work[0]);
+        caco3_s->getActivities(work);
         printValue("   act_caco3(s)  = ", work[0]);
 
         cout << "*** Base problem assuming that all phases exist:" << endl;

--- a/test_problems/surfSolverTest/surfaceSolver.cpp
+++ b/test_problems/surfSolverTest/surfaceSolver.cpp
@@ -22,7 +22,7 @@ void printGas(ostream& oooo, ThermoPhase* gasTP, InterfaceKinetics* iKin_ptr, do
     double C[MSSIZE];
     oooo.precision(3);
     string gasPhaseName = gasTP->name();
-    gasTP->getMoleFractions(x);
+    gasTP->getMoleFractions(span<double>(x, gasTP->nSpecies()));
     gasTP->getConcentrations(C);
     double Temp = gasTP->temperature();
     double p = gasTP->pressure();
@@ -55,7 +55,7 @@ void printBulk(ostream& oooo,
     double C[MSSIZE];
     oooo.precision(3);
     string bulkParticlePhaseName = bulkPhaseTP->name();
-    bulkPhaseTP->getMoleFractions(x);
+    bulkPhaseTP->getMoleFractions(span<double>(x, bulkPhaseTP->nSpecies()));
     bulkPhaseTP->getConcentrations(C);
     size_t iPhase = iKin_ptr->phaseIndex(bulkParticlePhaseName);
     size_t kstart = iKin_ptr->kineticsSpeciesIndex(0, iPhase);
@@ -99,7 +99,7 @@ void printSurf(ostream& oooo,
 {
     double x[MSSIZE];
     string surfParticlePhaseName = surfPhaseTP->name();
-    surfPhaseTP->getMoleFractions(x);
+    surfPhaseTP->getMoleFractions(span<double>(x, surfPhaseTP->nSpecies()));
     size_t iPhase = iKin_ptr->phaseIndex(surfParticlePhaseName);
     size_t kstart = iKin_ptr->kineticsSpeciesIndex(0, iPhase);
     oooo << "Surface Phase:  " << surfParticlePhaseName
@@ -184,11 +184,11 @@ int main(int argc, char** argv)
          * -> note that the states are set in the input file too
          */
         double pres = gasTP->pressure();
-        gasTP->getMoleFractions(x);
+        gasTP->getMoleFractions(span<double>(x, gasTP->nSpecies()));
         double tmp = 0.3 * std::min(x[0], x[1]);
         x[0] += tmp;
         x[1] -= tmp;
-        gasTP->setMoleFractions(x);
+        gasTP->setMoleFractions(span<const double>(x, gasTP->nSpecies()));
         gasTP->setPressure(pres);
 
         iKin_ptr->solvePseudoSteadyStateProblem(ioflag);

--- a/test_problems/surfSolverTest/surfaceSolver.cpp
+++ b/test_problems/surfSolverTest/surfaceSolver.cpp
@@ -18,11 +18,11 @@ using namespace Cantera;
 
 void printGas(ostream& oooo, ThermoPhase* gasTP, InterfaceKinetics* iKin_ptr, double* src)
 {
-    double x[MSSIZE];
-    double C[MSSIZE];
+    vector<double> x(gasTP->nSpecies());
+    vector<double> C(gasTP->nSpecies());
     oooo.precision(3);
     string gasPhaseName = gasTP->name();
-    gasTP->getMoleFractions(span<double>(x, gasTP->nSpecies()));
+    gasTP->getMoleFractions(x);
     gasTP->getConcentrations(C);
     double Temp = gasTP->temperature();
     double p = gasTP->pressure();
@@ -51,11 +51,11 @@ void printGas(ostream& oooo, ThermoPhase* gasTP, InterfaceKinetics* iKin_ptr, do
 void printBulk(ostream& oooo,
                ThermoPhase* bulkPhaseTP, InterfaceKinetics* iKin_ptr, double* src)
 {
-    double x[MSSIZE];
-    double C[MSSIZE];
+    vector<double> x(bulkPhaseTP->nSpecies());
+    vector<double> C(bulkPhaseTP->nSpecies());
     oooo.precision(3);
     string bulkParticlePhaseName = bulkPhaseTP->name();
-    bulkPhaseTP->getMoleFractions(span<double>(x, bulkPhaseTP->nSpecies()));
+    bulkPhaseTP->getMoleFractions(x);
     bulkPhaseTP->getConcentrations(C);
     size_t iPhase = iKin_ptr->phaseIndex(bulkParticlePhaseName);
     size_t kstart = iKin_ptr->kineticsSpeciesIndex(0, iPhase);
@@ -97,9 +97,9 @@ void printBulk(ostream& oooo,
 void printSurf(ostream& oooo,
                ThermoPhase* surfPhaseTP, InterfaceKinetics* iKin_ptr, double* src)
 {
-    double x[MSSIZE];
+    vector<double> x(surfPhaseTP->nSpecies());
     string surfParticlePhaseName = surfPhaseTP->name();
-    surfPhaseTP->getMoleFractions(span<double>(x, surfPhaseTP->nSpecies()));
+    surfPhaseTP->getMoleFractions(x);
     size_t iPhase = iKin_ptr->phaseIndex(surfParticlePhaseName);
     size_t kstart = iKin_ptr->kineticsSpeciesIndex(0, iPhase);
     oooo << "Surface Phase:  " << surfParticlePhaseName
@@ -153,7 +153,7 @@ int main(int argc, char** argv)
         size_t nr = iKin_ptr->nReactions();
         cout << "Number of reactions = " << nr << endl;
 
-        double x[MSSIZE];
+        vector<double> x(nspGas);
 
         ofstream ofile("results.txt");
 
@@ -184,11 +184,11 @@ int main(int argc, char** argv)
          * -> note that the states are set in the input file too
          */
         double pres = gasTP->pressure();
-        gasTP->getMoleFractions(span<double>(x, gasTP->nSpecies()));
+        gasTP->getMoleFractions(x);
         double tmp = 0.3 * std::min(x[0], x[1]);
         x[0] += tmp;
         x[1] -= tmp;
-        gasTP->setMoleFractions(span<const double>(x, gasTP->nSpecies()));
+        gasTP->setMoleFractions(x);
         gasTP->setPressure(pres);
 
         iKin_ptr->solvePseudoSteadyStateProblem(ioflag);

--- a/test_problems/surfSolverTest/surfaceSolver.cpp
+++ b/test_problems/surfSolverTest/surfaceSolver.cpp
@@ -72,7 +72,7 @@ void printBulk(ostream& oooo,
          << "   (kmol/m^3)                   (kmol/m^2/s) " << endl;
     double sum = 0.0;
     double Wsum = 0.0;
-    const vector<double>& molecW = bulkPhaseTP->molecularWeights();
+    auto molecW = bulkPhaseTP->molecularWeights();
     size_t nspBulk = bulkPhaseTP->nSpecies();
     for (size_t k = 0; k < nspBulk; k++) {
         kstart = iKin_ptr->kineticsSpeciesIndex(k, iPhase);


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Replace `double*` arguments with `span<double>` and `const double*` arguments with `span<const double>`
- Replace methods that return `const vector<double>&` with `span<const double>`
- Remove extraneous arguments used to carry array sizes
- Modify a couple methods in `SpeciesThermoInterpType` that used `double*` to output scalars to use `double&` or to eliminate redundant output.
- Add checks in methods operating on `std::span` to require that provided arrays are of sufficient size

**If applicable, fill in the issue number this pull request is fixing**

This is the first step in implementing the transition to `std::span`, as proposed in https://github.com/Cantera/enhancements/issues/237.

**AI Statement (required)**
- **Extensive use of generative AI.**
  Significant portions of code or documentation were generated with AI, including
  logic and implementation decisions. All generated code and documentation were
  reviewed and understood by the contributor. Examples: Output from agentic coding
  tools and/or substantial refactoring by LLMs (web-based or local).

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
