### PR TITLE
Correct basis parameter description for mole fraction basis

### DIFF
--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -1504,7 +1504,7 @@ cdef class Sim1D:
         :param compression:
             Compression level (0-9); optional (default=0; HDF only)
         :param basis:
-            Output mass (``Y``/``mass``) or mole (``Y``/``mass``) fractions;
+            Output mass (``Y``/``mass``) or mole (``X``/``mole``) fractions;
             if not specified (`None`), the native basis of the underlying `ThermoPhase`
             manager is used.
 

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -1278,7 +1278,7 @@ class SolutionArray(SolutionArrayBase):
         :param compression:
             Compression level (0-9); optional (default=0; HDF only)
         :param basis:
-            Output mass (``Y``/``mass``) or mole (``Y``/``mass``) fractions;
+            Output mass (``Y``/``mass``) or mole (``X``/``mole``) fractions;
             if not specified (`None`), the native basis of the underlying `ThermoPhase`
             manager is used.
 


### PR DESCRIPTION
**Changes proposed in this pull request**

- Correct description of the mole fraction version of the basis argument in the docstring of the save() method of Sim1D
  - Here is where I found the error: https://cantera.org/dev/python/onedim.html
  - Original docstring: "Output mass (``Y``/``mass``) or mole (``Y``/``mass``) fractions"
  - Corrected docstring: "Output mass (``Y``/``mass``) or mole (``X``/``mole``) fractions"

**AI Statement (required)**

- **No generative AI was used.** This contribution was written entirely without AI
  assistance.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
