### PR TITLE
Support setting the energy levels with yaml input file for electron-energy-distribution type: Boltzmann-two-term

### DIFF
--- a/src/thermo/PlasmaPhase.cpp
+++ b/src/thermo/PlasmaPhase.cpp
@@ -60,6 +60,10 @@ void PlasmaPhase::updateElectronEnergyDistribution()
     } else if (m_distributionType == "isotropic") {
         setIsotropicElectronEnergyDistribution();
     } else if (m_distributionType == "Boltzmann-two-term") {
+        if (!nCollisions()) {
+            // EEDF solver requires collision data; skip if none are defined.
+            return;
+        }
         auto ierr = m_eedfSolver->calculateDistributionFunction();
         if (ierr == 0) {
             auto y = m_eedfSolver->getEEDFEdge();
@@ -324,6 +328,11 @@ void PlasmaPhase::setParameters(const AnyMap& phaseNode, const AnyMap& rootNode)
             auto distribution = eedf["distribution"].asVector<double>(levels.size());
             setDiscretizedElectronEnergyDist(levels.data(), distribution.data(),
                                              levels.size());
+        } else if (m_distributionType == "Boltzmann-two-term") {
+            if (eedf.hasKey("energy-levels")) {
+                auto levels = eedf["energy-levels"].asVector<double>();
+                setElectronEnergyLevels(levels.data(), levels.size());
+            }
         }
     }
 

--- a/test/data/air-plasma.yaml
+++ b/test/data/air-plasma.yaml
@@ -16,6 +16,15 @@ phases:
     energy-levels: [0.0, 2.0, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 22.0,
       24.0, 26.0, 28.0, 30.0, 32.0, 34.0, 36.0, 38.0, 40.0]
 
+- name: air-plasma-default-ELs
+  thermo: plasma
+  kinetics: gas
+  species:
+  - nasa_gas.yaml/species: [Electron, O2, N2, O2+, N2+, O, O2-]
+  state: {T: 300.0, P: 1 atm, X: {O2: 0.21, N2: 0.79}}
+  electron-energy-distribution:
+    type: Boltzmann-two-term
+
 reactions:
 - equation: O2 + Electron => Electron + Electron + O2+
   type: electron-collision-plasma

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -1328,7 +1328,7 @@ class TestPlasmaPhase:
 
     def test_eedf_solver(self):
 
-        phase = ct.Solution('air-plasma.yaml')
+        phase = ct.Solution('air-plasma.yaml','air-plasma-Phelps')
         phase.TPX = 300., 101325., 'N2:0.79, O2:0.21, N2+:1E-10, Electron:1E-10'
         phase.reduced_electric_field = 200.0 * 1e-21  # Reduced electric field [V.m^2]
         phase.update_electron_energy_distribution()
@@ -1336,20 +1336,13 @@ class TestPlasmaPhase:
         grid = phase.electron_energy_levels
         eedf = phase.electron_energy_distribution
 
-        reference_grid = np.logspace(-1, np.log10(60))
-
         reference_eedf = np.array([
-            9.1027381e-02, 9.1026393e-02, 9.1025267e-02, 9.1023985e-02, 9.1022523e-02,
-            9.1020858e-02, 9.1015025e-02, 9.1006713e-02, 9.0997242e-02, 9.0986450e-02,
-            9.0974154e-02, 9.0954654e-02, 9.0923885e-02, 9.0888824e-02, 9.0842837e-02,
-            9.0775447e-02, 9.0695937e-02, 9.0578309e-02, 9.0398980e-02, 9.0118320e-02,
-            8.9293838e-02, 8.7498617e-02, 8.3767419e-02, 7.5765714e-02, 6.4856820e-02,
-            5.5592157e-02, 4.9309310e-02, 4.5268611e-02, 4.2261381e-02, 3.9440745e-02,
-            3.6437762e-02, 3.3181527e-02, 2.9616717e-02, 2.5795007e-02, 2.1676205e-02,
-            1.7347058e-02, 1.3022044e-02, 8.9705614e-03, 5.5251937e-03, 3.1894295e-03,
-            1.7301525e-03, 8.4647152e-04, 3.6030983e-04, 1.2894755e-04, 3.7416645e-05,
-            8.4693678e-06, 1.4299900e-06, 1.7026957e-07, 1.3992350e-08, 1.5340110e-09
-        ])
+            0.09103376, 0.09103349, 0.09103313, 0.09103262, 0.09103193,
+            0.09103097, 0.09102965, 0.09102784, 0.09102534, 0.0910219,
+            0.09100814, 0.09098309, 0.09093237, 0.0908309, 0.09062281,
+            0.09005469, 0.08573433, 0.06499493, 0.0473475, 0.0,
+            0.0])
+        reference_grid = np.logspace(-1, np.log10(60), reference_eedf.size)
 
         interp = np.interp(reference_grid, grid, eedf, left=0.0, right=0.0)
 

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -193,7 +193,7 @@ TEST(zerodim, test_individual_reactor_initialization)
 
 TEST(zerodim, plasma_reactor_energy)
 {
-    auto sol = newSolution("air-plasma.yaml", "air-plasma-Phelps", "none");
+    auto sol = newSolution("air-plasma.yaml", "air-plasma-default-ELs", "none");
     auto thermo = sol->thermo();
     auto* plasma = dynamic_cast<PlasmaPhase*>(thermo.get());
     ASSERT_NE(plasma, nullptr);


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

As the title, the energy levels can be set with the yaml file for type Boltzmann-two-term. Setting the energy levels had no effect before in yaml file, and PlasmaPhase used only the default energy-levels. (The EEDF solver still use the default energy levels regardless.). One issue was that the initiation of the EEDF solver was not completed (it requires the collision cross-sections) at setting the energy levels. The update energy distribution function was triggered by setting the energy levels, and the EEDF solver failed. Therefore, the update energy distribution function cannot run when EEDF solver is not ready. One way is to check the number of collisions to know if the collisions have been loaded. Alternative is to add a function in EEDF solver to signal if it is ready.

Note that the example data is also being updated accordingly, https://github.com/Cantera/cantera-example-data/pull/7. We can first merge this and the example nanosecond_pulse_discharge.py should pass. (The example should also pass without the source code change as the energy-levels data is not used at all.)

@speth @mquiram 


<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Add code to setParameters to read the energy levels.
- Add the guard to prevent update energy distribution for Boltzmann-two-term wihtout collision data.
- Update the test file.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->


**AI Statement (required)**
Limited use of generative AI
Mostly on the test data and comments.
<!-- Please include one of the following options in your PR description:

- **Limited use of generative AI.**
  Standard or boilerplate code snippets were generated with AI and manually reviewed;
  all design, logic, and implementation decisions were made by the contributor.
  Examples: IDE code-completions or brief LLM queries for common patterns.


For additional information on Cantera's AI policy, see
https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md#restrictions-on-generative-ai-usage -->


**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
