### PR TITLE
Convert kinetics & equilibrium code to use std::span

### DIFF
--- a/doc/sphinx/userguide/kinetics_transport.cpp
+++ b/doc/sphinx/userguide/kinetics_transport.cpp
@@ -20,7 +20,7 @@ void simple_demo2()
 
     // Get the net reaction rates.
     vector<double> wdot(kin->nReactions());
-    kin->getNetRatesOfProgress(wdot.data());
+    kin->getNetRatesOfProgress(wdot);
 
     writelog("Net reaction rates for reactions involving CO2\n");
     size_t kCO2 = gas->speciesIndex("CO2");

--- a/include/cantera/cython/funcWrapper.h
+++ b/include/cantera/cython/funcWrapper.h
@@ -219,6 +219,8 @@ inline int translate_exception()
         PyErr_SetString(PyExc_IndexError, exn.what());
     } catch (const Cantera::NotImplementedError& exn) {
         PyErr_SetString(PyExc_NotImplementedError, exn.what());
+    } catch (const Cantera::ArraySizeError& exn) {
+        PyErr_SetString(PyExc_ValueError, exn.what());
     } catch (const Cantera::CanteraError& exn) {
         PyErr_SetString(pyCanteraError, exn.what());
     } catch (const std::exception& exn) {

--- a/include/cantera/cython/kinetics_utils.h
+++ b/include/cantera/cython/kinetics_utils.h
@@ -53,7 +53,9 @@ inline void sparseCscData(const Eigen::SparseMatrix<double>& mat,
     }
 }
 
-#define KIN_1D(FUNC_NAME) ARRAY_FUNC(kin, Kinetics, FUNC_NAME)
+#define KIN_1D(FUNC_NAME) \
+    inline void kin_ ## FUNC_NAME(Cantera::Kinetics* object, std::span<double> data) \
+    { object->FUNC_NAME(data); }
 
 KIN_1D(getFwdRatesOfProgress)
 KIN_1D(getRevRatesOfProgress)

--- a/include/cantera/equil/ChemEquil.h
+++ b/include/cantera/equil/ChemEquil.h
@@ -117,7 +117,7 @@ public:
      *     Unsuccessful returns are indicated by a return value of -1 for lack
      *     of convergence or -3 for a singular Jacobian.
      */
-    int equilibrate(ThermoPhase& s, const char* XY, vector<double>& elMoles,
+    int equilibrate(ThermoPhase& s, const char* XY, span<double> elMoles,
                     int loglevel = 0);
 
     /**
@@ -155,16 +155,15 @@ protected:
      * @f[ \lambda_m/RT @f].
      * @param t temperature in K.
      */
-    void setToEquilState(ThermoPhase& s,
-                         const vector<double>& x, double t);
+    void setToEquilState(ThermoPhase& s, span<const double> x, double t);
 
     //! Estimate the initial mole numbers. This version borrows from the
     //! MultiPhaseEquil solver.
-    int setInitialMoles(ThermoPhase& s, vector<double>& elMoleGoal, int loglevel = 0);
+    int setInitialMoles(ThermoPhase& s, span<double> elMoleGoal, int loglevel = 0);
 
     //! Generate a starting estimate for the element potentials.
-    int estimateElementPotentials(ThermoPhase& s, vector<double>& lambda,
-                                  vector<double>& elMolesGoal, int loglevel = 0);
+    int estimateElementPotentials(ThermoPhase& s, span<double> lambda,
+                                  span<double> elMolesGoal, int loglevel = 0);
 
     /**
      * Do a calculation of the element potentials using the Brinkley method,
@@ -199,7 +198,7 @@ protected:
      *
      * NOTE: update for activity coefficients.
      */
-    int estimateEP_Brinkley(ThermoPhase& s, vector<double>& lambda, vector<double>& elMoles);
+    int estimateEP_Brinkley(ThermoPhase& s, span<double> lambda, span<double> elMoles);
 
     //! Find an acceptable step size and take it.
     /*!
@@ -214,22 +213,22 @@ protected:
      * limited to a factor of 2 jump in the values from this method. Near
      * convergence, the delta damping gets out of the way.
      */
-    int dampStep(ThermoPhase& s, vector<double>& oldx,
-                 double oldf, vector<double>& grad, vector<double>& step, vector<double>& x,
-                 double& f, vector<double>& elmols, double xval, double yval);
+    int dampStep(ThermoPhase& s, span<double> oldx, double oldf, span<double> grad,
+                 span<double> step, span<double> x, double& f, span<double> elmols,
+                 double xval, double yval);
 
     /**
      *  Evaluates the residual vector F, of length #m_mm
      */
-    void equilResidual(ThermoPhase& s, const vector<double>& x,
-                       const vector<double>& elmtotal, vector<double>& resid,
+    void equilResidual(ThermoPhase& s, span<const double> x,
+                       span<const double> elmtotal, span<double> resid,
                        double xval, double yval, int loglevel = 0);
 
-    void equilJacobian(ThermoPhase& s, vector<double>& x,
-                       const vector<double>& elmols, DenseMatrix& jac,
+    void equilJacobian(ThermoPhase& s, span<double> x,
+                       span<const double> elmols, DenseMatrix& jac,
                        double xval, double yval, int loglevel = 0);
 
-    void adjustEloc(ThermoPhase& s, vector<double>& elMolesGoal);
+    void adjustEloc(ThermoPhase& s, span<double> elMolesGoal);
 
     //! Update internally stored state information.
     void update(const ThermoPhase& s);
@@ -243,10 +242,9 @@ protected:
      * @param[in] Xmol_i_calc Mole fractions of the species
      * @param[in] pressureConst Pressure
      */
-    double calcEmoles(ThermoPhase& s, vector<double>& x,
-                      const double& n_t, const vector<double>& Xmol_i_calc,
-                      vector<double>& eMolesCalc, vector<double>& n_i_calc,
-                      double pressureConst);
+    double calcEmoles(ThermoPhase& s, span<double> x, const double& n_t,
+                      span<const double> Xmol_i_calc, span<double> eMolesCalc,
+                      span<double> n_i_calc, double pressureConst);
 
     size_t m_mm; //!< number of elements in the phase
     size_t m_kk; //!< number of species in the phase

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -79,7 +79,7 @@ public:
      *   @param phases Vector of pointers to phases
      *   @param phaseMoles Vector of mole numbers in each phase (kmol)
      */
-    void addPhases(vector<ThermoPhase*>& phases, const vector<double>& phaseMoles);
+    void addPhases(span<ThermoPhase*> phases, span<const double> phaseMoles);
 
     //! Add all phases present in 'mix' to this mixture.
     /*!
@@ -174,7 +174,7 @@ public:
      *
      *    @param x  vector of mole fractions. Length = number of global species.
      */
-    void getMoleFractions(double* const x) const;
+    void getMoleFractions(span<double> x) const;
 
     //! Process phases and build atomic composition array.
     /*!
@@ -342,7 +342,7 @@ public:
      *                  potentials are returned instead of the composition-
      *                  dependent chemical potentials.
      */
-    void getValidChemPotentials(double not_mu, double* mu,
+    void getValidChemPotentials(double not_mu, span<double> mu,
                                 bool standard = false) const;
 
     //! Temperature [K].
@@ -403,7 +403,7 @@ public:
      * @param Moles  Vector of mole numbers of all the species in all the phases
      *               (kmol)
      */
-    void setState_TPMoles(const double T, const double Pres, const double* Moles);
+    void setState_TPMoles(const double T, const double Pres, span<const double> Moles);
 
     //! Pressure [Pa].
     double pressure() const {
@@ -475,7 +475,7 @@ public:
      * @param n    index of the phase
      * @param x    Vector of input mole fractions.
      */
-    void setPhaseMoleFractions(const size_t n, const double* const x);
+    void setPhaseMoleFractions(const size_t n, span<const double> x);
 
     //! Set the number of moles of species in the mixture
     /*!
@@ -500,7 +500,7 @@ public:
      * @param[out] molNum Vector of doubles of length nSpecies() containing the
      *               global mole numbers (kmol).
      */
-    void getMoles(double* molNum) const;
+    void getMoles(span<double> molNum) const;
 
     //! Sets all of the global species mole numbers
     /*!
@@ -510,7 +510,7 @@ public:
      * @param n    Vector of doubles of length nSpecies() containing the global
      *             mole numbers (kmol).
      */
-    void setMoles(const double* n);
+    void setMoles(span<const double> n);
 
     //! Adds moles of a certain species to the mixture
     /*!
@@ -525,7 +525,7 @@ public:
      * Length = number of elements in the MultiPhase object.
      * Index is the global element index. Units is in kmol.
      */
-    void getElemAbundances(double* elemAbundances) const;
+    void getElemAbundances(span<double> elemAbundances) const;
 
     //! Return true if the phase @e p has valid thermo data for the current
     //! temperature.
@@ -723,10 +723,9 @@ std::ostream& operator<<(std::ostream& s, MultiPhase& x);
  *
  * @ingroup equilGroup
  */
-size_t BasisOptimize(int* usedZeroedSpecies, bool doFormRxn,
-                     MultiPhase* mphase, vector<size_t>& orderVectorSpecies,
-                     vector<size_t>& orderVectorElements,
-                     vector<double>& formRxnMatrix);
+size_t BasisOptimize(int* usedZeroedSpecies, bool doFormRxn, MultiPhase* mphase,
+                     span<size_t> orderVectorSpecies, span<size_t> orderVectorElements,
+                     span<double> formRxnMatrix);
 
 //! Handles the potential rearrangement of the constraint equations
 //! represented by the Formula Matrix.
@@ -766,10 +765,9 @@ size_t BasisOptimize(int* usedZeroedSpecies, bool doFormRxn,
  *
  * @ingroup equilGroup
  */
-void ElemRearrange(size_t nComponents, const vector<double>& elementAbundances,
-                   MultiPhase* mphase,
-                   vector<size_t>& orderVectorSpecies,
-                   vector<size_t>& orderVectorElements);
+void ElemRearrange(size_t nComponents, span<const double> elementAbundances,
+                   MultiPhase* mphase, span<size_t> orderVectorSpecies,
+                   span<size_t> orderVectorElements);
 
 //! External int that is used to turn on debug printing for the
 //! BasisOptimize program.

--- a/include/cantera/equil/MultiPhaseEquil.h
+++ b/include/cantera/equil/MultiPhaseEquil.h
@@ -51,8 +51,9 @@ public:
         }
     }
 
-    void getStoichVector(size_t rxn, vector<double>& nu) {
-        nu.resize(m_nsp, 0.0);
+    void getStoichVector(size_t rxn, span<double> nu) {
+        checkArraySize("MultiPhaseEquil::getStoichVector", nu.size(), m_nsp);
+        fill(nu.begin(), nu.end(), 0.0);
         if (rxn > nFree()) {
             return;
         }
@@ -104,7 +105,7 @@ protected:
     //!     have length = nSpecies(), then the species will be considered as
     //!     candidates to be components in declaration order, beginning with
     //!     the first phase added.
-    void getComponents(const vector<size_t>& order);
+    void getComponents(span<const size_t> order);
 
     //! Estimate the initial mole numbers. This is done by running each
     //! reaction as far forward or backward as possible, subject to the
@@ -124,12 +125,12 @@ protected:
 
     //! Re-arrange a vector of species properties in sorted form
     //! (components first) into unsorted, sequential form.
-    void unsort(vector<double>& x);
+    void unsort(span<double> x);
 
-    void step(double omega, vector<double>& deltaN, int loglevel = 0);
+    void step(double omega, span<double> deltaN, int loglevel = 0);
 
     //! Compute the change in extent of reaction for each reaction.
-    double computeReactionSteps(vector<double>& dxi);
+    double computeReactionSteps(span<double> dxi);
 
     void updateMixMoles();
 

--- a/include/cantera/equil/vcs_VolPhase.h
+++ b/include/cantera/equil/vcs_VolPhase.h
@@ -72,7 +72,7 @@ public:
      * @param moleFracVec      Vector of input mole fractions
      * @param vcsStateStatus   Status flag for this update
      */
-    void setMoleFractionsState(const double molNum, const double* const moleFracVec,
+    void setMoleFractionsState(const double molNum, span<const double> moleFracVec,
                                const int vcsStateStatus);
 
     //! Set the moles within the phase
@@ -88,7 +88,7 @@ public:
      *     to gather the species into the local contiguous vector format.
      */
     void setMolesFromVCS(const int stateCalc,
-                         const double* molesSpeciesVCS = 0);
+                         span<const double> molesSpeciesVCS = {});
 
     //! Set the moles within the phase
     /*!
@@ -108,8 +108,8 @@ public:
      * @param TPhMoles  VCS's array containing the number of moles in each phase.
      */
     void setMolesFromVCSCheck(const int vcsStateStatus,
-                              const double* molesSpeciesVCS,
-                              const double* const TPhMoles);
+                              span<const double> molesSpeciesVCS,
+                              span<const double> TPhMoles);
 
     //! Update the moles within the phase, if necessary
     /*!
@@ -134,7 +134,7 @@ public:
      *     of the phases in a VCS problem. Only the entries for the current
      *     phase are filled in.
      */
-    void sendToVCS_ActCoeff(const int stateCalc, double* const AC);
+    void sendToVCS_ActCoeff(const int stateCalc, span<double> AC);
 
     //! set the electric potential of the phase
     /*!
@@ -176,7 +176,7 @@ public:
      *     all of the phases in a VCS problem. Only the entries for the current
      *     phase are filled in.
      */
-    double sendToVCS_VolPM(double* const VolPM) const;
+    double sendToVCS_VolPM(span<double> VolPM) const;
 
     //! Fill in the standard state Gibbs free energy vector for VCS
     /*!
@@ -188,7 +188,7 @@ public:
      *     species in all of the phases in a VCS problem. Only the entries for the
      *     current phase are filled in.
      */
-    void sendToVCS_GStar(double* const gstar) const;
+    void sendToVCS_GStar(span<double> gstar) const;
 
     //! Sets the temperature and pressure in this object and underlying
     //! ThermoPhase objects
@@ -250,11 +250,11 @@ private:
      * @param xmol Value of the mole fractions for the species in the phase.
      *             These are contiguous.
      */
-    void setMoleFractions(const double* const xmol);
+    void setMoleFractions(span<const double> xmol);
 
 public:
     //! Return a const reference to the mole fractions stored in the object.
-    const vector<double> & moleFractions() const;
+    span<const double> moleFractions() const;
 
     double moleFraction(size_t klocal) const;
 
@@ -263,13 +263,14 @@ public:
      * @param n_k Pointer to a vector of n_k's
      * @param creationGlobalRxnNumbers  Vector of global creation reaction numbers
      */
-    void setCreationMoleNumbers(const double* const n_k, const vector<size_t> &creationGlobalRxnNumbers);
+    void setCreationMoleNumbers(span<const double> n_k,
+                                span<const size_t> creationGlobalRxnNumbers);
 
     //! Return a const reference to the creationMoleNumbers stored in the object.
     /*!
      * @returns a const reference to the vector of creationMoleNumbers
      */
-    const vector<double> & creationMoleNumbers(vector<size_t> &creationGlobalRxnNumbers) const;
+    span<const double> creationMoleNumbers(span<size_t> creationGlobalRxnNumbers) const;
 
     //! Returns whether the phase is an ideal solution phase
     bool isIdealSoln() const;

--- a/include/cantera/equil/vcs_internal.h
+++ b/include/cantera/equil/vcs_internal.h
@@ -51,7 +51,7 @@ public:
  * @param vec vector of doubles
  * @returns   the l2 norm of the vector
  */
-double vcs_l2norm(const vector<double>& vec);
+double vcs_l2norm(span<const double> vec);
 
 //! Returns a const char string representing the type of the species given by
 //! the first argument

--- a/include/cantera/equil/vcs_solve.h
+++ b/include/cantera/equil/vcs_solve.h
@@ -493,7 +493,7 @@ public:
      *
      * NOTE: This routine needs to be regulated.
      */
-    void vcs_CalcLnActCoeffJac(const double* const moleSpeciesVCS);
+    void vcs_CalcLnActCoeffJac(span<const double> moleSpeciesVCS);
 
     //! Print out a report on the state of the equilibrium problem to
     //! standard output.
@@ -589,7 +589,8 @@ public:
     /*!
      * Note, for this algorithm this function should be monotonically decreasing.
      */
-    double vcs_Total_Gibbs(double* w, double* fe, double* tPhMoles);
+    double vcs_Total_Gibbs(span<const double> w, span<const double> fe,
+                           span<const double> tPhMoles);
 
     //! Fully specify the problem to be solved
     void vcs_prob_specifyFully();
@@ -646,14 +647,13 @@ private:
      * Make sure to conserve elements and keep track of the total kmoles in
      * all phases.
      *
-     * @param kspec The species index
-     * @param delta_ptr   pointer to the delta for the species. This may
-     *                     change during the calculation
+     * @param kspec  The species index
+     * @param delta  The delta for the species. This may change during the calculation.
      * @return
      *     1: succeeded without change of dx
      *     0: Had to adjust dx, perhaps to zero, in order to do the delta.
      */
-    int delta_species(const size_t kspec, double* const delta_ptr);
+    int delta_species(const size_t kspec, double& delta);
 
     //! Provide an estimate for the deleted species in phases that are not
     //! zeroed out
@@ -751,7 +751,8 @@ private:
      */
     double l2normdg(double dg[]) const;
 
-    void checkDelta1(double* const ds, double* const delTPhMoles, size_t kspec);
+    void checkDelta1(span<const double> ds, span<const double> delTPhMoles,
+                     size_t kspec);
 
     //! Calculate the status of single species phases.
     void vcs_SSPhase();

--- a/include/cantera/kinetics/BulkKinetics.h
+++ b/include/cantera/kinetics/BulkKinetics.h
@@ -85,7 +85,7 @@ public:
     void updateROP() override;
 
     void getThirdBodyConcentrations(span<double> concm) override;
-    const vector<double>& thirdBodyConcentrations() const override {
+    span<const double> thirdBodyConcentrations() const override {
         return m_concm;
     }
 

--- a/include/cantera/kinetics/BulkKinetics.h
+++ b/include/cantera/kinetics/BulkKinetics.h
@@ -42,35 +42,35 @@ public:
 
     //! @name Reaction rate constants, rates of progress, and thermodynamic properties
     //! @{
-    void getFwdRateConstants(double* kfwd) override;
-    void getEquilibriumConstants(double* kc) override;
-    void getRevRateConstants(double* krev, bool doIrreversible=false) override;
+    void getFwdRateConstants(span<double> kfwd) override;
+    void getEquilibriumConstants(span<double> kc) override;
+    void getRevRateConstants(span<double> krev, bool doIrreversible=false) override;
 
-    void getDeltaGibbs(double* deltaG) override;
-    void getDeltaEnthalpy(double* deltaH) override;
-    void getDeltaEntropy(double* deltaS) override;
+    void getDeltaGibbs(span<double> deltaG) override;
+    void getDeltaEnthalpy(span<double> deltaH) override;
+    void getDeltaEntropy(span<double> deltaS) override;
 
-    void getDeltaSSGibbs(double* deltaG) override;
-    void getDeltaSSEnthalpy(double* deltaH) override;
-    void getDeltaSSEntropy(double* deltaS) override;
+    void getDeltaSSGibbs(span<double> deltaG) override;
+    void getDeltaSSEnthalpy(span<double> deltaH) override;
+    void getDeltaSSEntropy(span<double> deltaS) override;
     //! @}
 
     //! @name Derivatives of rate constants and rates of progress
     //! @{
     void getDerivativeSettings(AnyMap& settings) const override;
     void setDerivativeSettings(const AnyMap& settings) override;
-    void getFwdRateConstants_ddT(double* dkfwd) override;
-    void getFwdRatesOfProgress_ddT(double* drop) override;
-    void getRevRatesOfProgress_ddT(double* drop) override;
-    void getNetRatesOfProgress_ddT(double* drop) override;
-    void getFwdRateConstants_ddP(double* dkfwd) override;
-    void getFwdRatesOfProgress_ddP(double* drop) override;
-    void getRevRatesOfProgress_ddP(double* drop) override;
-    void getNetRatesOfProgress_ddP(double* drop) override;
-    void getFwdRateConstants_ddC(double* dkfwd) override;
-    void getFwdRatesOfProgress_ddC(double* drop) override;
-    void getRevRatesOfProgress_ddC(double* drop) override;
-    void getNetRatesOfProgress_ddC(double* drop) override;
+    void getFwdRateConstants_ddT(span<double> dkfwd) override;
+    void getFwdRatesOfProgress_ddT(span<double> drop) override;
+    void getRevRatesOfProgress_ddT(span<double> drop) override;
+    void getNetRatesOfProgress_ddT(span<double> drop) override;
+    void getFwdRateConstants_ddP(span<double> dkfwd) override;
+    void getFwdRatesOfProgress_ddP(span<double> drop) override;
+    void getRevRatesOfProgress_ddP(span<double> drop) override;
+    void getNetRatesOfProgress_ddP(span<double> drop) override;
+    void getFwdRateConstants_ddC(span<double> dkfwd) override;
+    void getFwdRatesOfProgress_ddC(span<double> drop) override;
+    void getRevRatesOfProgress_ddC(span<double> drop) override;
+    void getNetRatesOfProgress_ddC(span<double> drop) override;
     Eigen::SparseMatrix<double> fwdRatesOfProgress_ddX() override;
     Eigen::SparseMatrix<double> revRatesOfProgress_ddX() override;
     Eigen::SparseMatrix<double> netRatesOfProgress_ddX() override;
@@ -84,7 +84,7 @@ public:
 
     void updateROP() override;
 
-    void getThirdBodyConcentrations(double* concm) override;
+    void getThirdBodyConcentrations(span<double> concm) override;
     const vector<double>& thirdBodyConcentrations() const override {
         return m_concm;
     }
@@ -100,35 +100,35 @@ protected:
     //! @{
 
     //! Multiply rate with third-body collider concentrations
-    void processThirdBodies(double* rop);
+    void processThirdBodies(span<double> rop);
 
     //! Multiply rate with inverse equilibrium constant
-    void applyEquilibriumConstants(double* rop);
+    void applyEquilibriumConstants(span<double> rop);
 
     //! Multiply rate with scaled temperature derivatives of the inverse
     //! equilibrium constant
     /*!
      *  This (scaled) derivative is handled by a finite difference.
      */
-    void applyEquilibriumConstants_ddT(double* drkcn);
+    void applyEquilibriumConstants_ddT(span<double> drkcn);
 
     //! Process temperature derivative
     //! @param in  rate expression used for the derivative calculation
     //! @param drop  pointer to output buffer
-    void process_ddT(const vector<double>& in, double* drop);
+    void process_ddT(const span<const double> in, span<double> drop);
 
     //! Process pressure derivative
     //! @param in  rate expression used for the derivative calculation
     //! @param drop  pointer to output buffer
-    void process_ddP(const vector<double>& in, double* drop);
+    void process_ddP(const span<const double> in, span<double> drop);
 
     //! Process concentration (molar density) derivative
     //! @param stoich  stoichiometry manager
     //! @param in  rate expression used for the derivative calculation
     //! @param drop  pointer to output buffer
     //! @param mass_action  boolean indicating whether law of mass action applies
-    void process_ddC(StoichManagerN& stoich, const vector<double>& in,
-                     double* drop, bool mass_action=true);
+    void process_ddC(StoichManagerN& stoich, span<const double> in,
+                     span<double> drop, bool mass_action=true);
 
     //! Process derivatives
     //! @param stoich  stoichiometry manager
@@ -137,7 +137,7 @@ protected:
     //! @return a sparse matrix of derivative contributions for each reaction of
     //! dimensions nTotalReactions by nTotalSpecies
     Eigen::SparseMatrix<double> calculateCompositionDerivatives(
-        StoichManagerN& stoich, const vector<double>& in, bool ddX=true);
+        StoichManagerN& stoich, span<const double> in, bool ddX=true);
 
     //! Helper function ensuring that all rate derivatives can be calculated
     //! @param name  method name used for error output

--- a/include/cantera/kinetics/ElectronCollisionPlasmaRate.h
+++ b/include/cantera/kinetics/ElectronCollisionPlasmaRate.h
@@ -194,22 +194,22 @@ public:
     }
 
     //! The value of #m_energyLevels [eV]
-    const vector<double>& energyLevels() const {
+    span<const double> energyLevels() const {
         return m_energyLevels;
     }
 
     //! The value of #m_crossSections [m2]
-    const vector<double>& crossSections() const {
+    span<const double> crossSections() const {
         return m_crossSections;
     }
 
     //! The value of #m_crossSectionsInterpolated [m2]
-    const vector<double>& crossSectionInterpolated() const {
+    span<const double> crossSectionInterpolated() const {
         return m_crossSectionsInterpolated;
     }
 
     //! Update the value of #m_crossSectionsInterpolated [m2]
-    void updateInterpolatedCrossSection(const vector<double>&);
+    void updateInterpolatedCrossSection(span<const double>);
 
 private:
     //! The name of the kind of electron collision

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -104,7 +104,7 @@ public:
      * @param T Temperature [K].
      * @param work storage space for intermediate results.
      */
-    virtual void updateTemp(double T, double* work) const {}
+    virtual void updateTemp(double T, span<double> work) const {}
 
     /**
      * The falloff function.
@@ -115,19 +115,19 @@ public:
      *             to updateTemp.
      * @returns the value of the falloff function @f$ F @f$ defined above
      */
-    virtual double F(double pr, const double* work) const {
+    virtual double F(double pr, span<const double> work) const {
         return 1.0;
     }
 
     //! Evaluate falloff function at current conditions
     double evalF(double T, double conc3b) {
-        updateTemp(T, m_work.data());
+        updateTemp(T, m_work);
         double logT = std::log(T);
         double recipT = 1. / T;
         m_rc_low = m_lowRate.evalRate(logT, recipT);
         m_rc_high = m_highRate.evalRate(logT, recipT);
         double pr = conc3b * m_rc_low / (m_rc_high + SmallNumber);
-        return F(pr, m_work.data());
+        return F(pr, m_work);
     }
 
     const string type() const override {
@@ -150,7 +150,7 @@ public:
     //! Evaluate reaction rate
     //! @param shared_data  data shared by all reactions of a given type
     double evalFromStruct(const FalloffData& shared_data) {
-        updateTemp(shared_data.temperature, m_work.data());
+        updateTemp(shared_data.temperature, m_work);
         m_rc_low = m_lowRate.evalRate(shared_data.logT, shared_data.recipT);
         m_rc_high = m_highRate.evalRate(shared_data.logT, shared_data.recipT);
         double thirdBodyConcentration;
@@ -164,12 +164,12 @@ public:
         // Apply falloff function
         if (m_chemicallyActivated) {
             // 1 / (1 + Pr) * F
-            pr = F(pr, m_work.data()) / (1.0 + pr);
+            pr = F(pr, m_work) / (1.0 + pr);
             return pr * m_rc_low;
         }
 
         // Pr / (1 + Pr) * F
-        pr *= F(pr, m_work.data()) / (1.0 + pr);
+        pr *= F(pr, m_work) / (1.0 + pr);
         return pr * m_rc_high;
     }
 
@@ -336,9 +336,9 @@ public:
      *   @param work      Vector of working space, length 1, representing the
      *                    temperature-dependent part of the parameterization.
      */
-    void updateTemp(double T, double* work) const override;
+    void updateTemp(double T, span<double> work) const override;
 
-    double F(double pr, const double* work) const override;
+    double F(double pr, span<const double> work) const override;
 
     const string subType() const override {
         return "Troe";
@@ -437,9 +437,9 @@ public:
      *   @param work      Vector of working space, length 2, representing the
      *                    temperature-dependent part of the parameterization.
      */
-    void updateTemp(double T, double* work) const override;
+    void updateTemp(double T, span<double> work) const override;
 
-    double F(double pr, const double* work) const override;
+    double F(double pr, span<const double> work) const override;
 
     const string subType() const override {
         return "SRI";
@@ -530,9 +530,9 @@ public:
      *   @param work      Vector of working space, length 1, representing the
      *                    temperature-dependent part of the parameterization.
      */
-    void updateTemp(double T, double* work) const override;
+    void updateTemp(double T, span<double> work) const override;
 
-    double F(double pr, const double* work) const override;
+    double F(double pr, span<const double> work) const override;
 
     const string subType() const override {
         return "Tsang";

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -87,15 +87,17 @@ public:
      * @param c Vector of coefficients of the parameterization. The number and
      *     meaning of these coefficients is subclass-dependent.
      */
-    virtual void setFalloffCoeffs(const vector<double>& c);
+    virtual void setFalloffCoeffs(span<const double> c);
 
     /**
      * Retrieve coefficients of the falloff parameterization.
      *
-     * @param c Vector of coefficients of the parameterization. The number and
-     *     meaning of these coefficients is subclass-dependent.
+     * @param c Vector of coefficients of the parameterization. The number (obtained
+     *     with the nParameters() method) and meaning of these coefficients is
+     *     subclass-dependent.
      */
-    virtual void getFalloffCoeffs(vector<double>& c) const;
+    virtual void getFalloffCoeffs(span<double> c) const {};
+
 
     /**
      * Update the temperature-dependent portions of the falloff function, if
@@ -251,7 +253,7 @@ public:
     LindemannRate(const AnyMap& node, const UnitStack& rate_units={});
 
     LindemannRate(const ArrheniusRate& low, const ArrheniusRate& high,
-                  const vector<double>& c);
+                  span<const double> c);
 
     unique_ptr<MultiRateBase> newMultiRate() const override{
         return make_unique<MultiRate<LindemannRate, FalloffData>>();
@@ -315,7 +317,7 @@ public:
 
     TroeRate(const AnyMap& node, const UnitStack& rate_units={});
     TroeRate(const ArrheniusRate& low, const ArrheniusRate& high,
-             const vector<double>& c);
+             span<const double> c);
 
     unique_ptr<MultiRateBase> newMultiRate() const override {
         return make_unique<MultiRate<TroeRate, FalloffData>>();
@@ -326,9 +328,9 @@ public:
      * @param c Vector of three or four doubles: The doubles are the parameters,
      *          a, T_3, T_1, and (optionally) T_2 of the Troe parameterization
      */
-    void setFalloffCoeffs(const vector<double>& c) override;
+    void setFalloffCoeffs(span<const double> c) override;
 
-    void getFalloffCoeffs(vector<double>& c) const override;
+    void getFalloffCoeffs(span<double> c) const override;
 
     //! Update the temperature parameters in the representation
     /*!
@@ -409,7 +411,7 @@ public:
 
     SriRate(const AnyMap& node, const UnitStack& rate_units={});
 
-    SriRate(const ArrheniusRate& low, const ArrheniusRate& high, const vector<double>& c)
+    SriRate(const ArrheniusRate& low, const ArrheniusRate& high, span<const double> c)
         : SriRate()
     {
         m_lowRate = low;
@@ -427,9 +429,9 @@ public:
      *          a, b, c, d (optional; default 1.0), and e (optional; default
      *          0.0) of the SRI parameterization
      */
-    void setFalloffCoeffs(const vector<double>& c) override;
+    void setFalloffCoeffs(span<const double> c) override;
 
-    void getFalloffCoeffs(vector<double>& c) const override;
+    void getFalloffCoeffs(span<double> c) const override;
 
     //! Update the temperature parameters in the representation
     /*!
@@ -503,7 +505,7 @@ public:
 
     TsangRate(const AnyMap& node, const UnitStack& rate_units={});
 
-    TsangRate(const ArrheniusRate& low, const ArrheniusRate& high, const vector<double>& c)
+    TsangRate(const ArrheniusRate& low, const ArrheniusRate& high, span<const double> c)
         : TsangRate()
     {
         m_lowRate = low;
@@ -520,9 +522,9 @@ public:
      * @param c Vector of one or two doubles: The doubles are the parameters,
      *          a and (optionally) b of the Tsang F_cent parameterization
      */
-    void setFalloffCoeffs(const vector<double>& c) override;
+    void setFalloffCoeffs(span<const double> c) override;
 
-    void getFalloffCoeffs(vector<double>& c) const override;
+    void getFalloffCoeffs(span<double> c) const override;
 
     //! Update the temperature parameters in the representation
     /*!

--- a/include/cantera/kinetics/Group.h
+++ b/include/cantera/kinetics/Group.h
@@ -24,12 +24,16 @@ public:
     Group(size_t n) : m_sign(0) {
         m_comp.resize(n,0);
     }
-    Group(const vector<int>& elnumbers) :
-        m_comp(elnumbers), m_sign(0) {
+    Group(span<const int> elnumbers)
+        : m_comp(elnumbers.begin()
+        , elnumbers.end())
+        , m_sign(0)
+    {
         validate();
     }
-    Group(const vector<size_t>& elnumbers) :
-        m_comp(elnumbers.size()), m_sign(0) {
+    Group(span<const size_t> elnumbers) :
+        m_comp(elnumbers.size()), m_sign(0)
+    {
         for (size_t i = 0; i < elnumbers.size(); i++) {
             m_comp[i] = int(elnumbers[i]);
         }
@@ -125,7 +129,7 @@ public:
         return m_comp[m];
     }
 
-    std::ostream& fmt(std::ostream& s, const vector<string>& esymbols) const;
+    std::ostream& fmt(std::ostream& s, span<const string> esymbols) const;
 
 private:
     vector<int> m_comp;

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -81,24 +81,24 @@ public:
      *   where deltaG is the electrochemical potential difference between
      *   products minus reactants.
      */
-    void getEquilibriumConstants(double* kc) override;
+    void getEquilibriumConstants(span<double> kc) override;
 
-    void getDeltaGibbs(double* deltaG) override;
+    void getDeltaGibbs(span<double> deltaG) override;
 
-    void getDeltaElectrochemPotentials(double* deltaM) override;
-    void getDeltaEnthalpy(double* deltaH) override;
-    void getDeltaEntropy(double* deltaS) override;
+    void getDeltaElectrochemPotentials(span<double> deltaM) override;
+    void getDeltaEnthalpy(span<double> deltaH) override;
+    void getDeltaEntropy(span<double> deltaS) override;
 
-    void getDeltaSSGibbs(double* deltaG) override;
-    void getDeltaSSEnthalpy(double* deltaH) override;
-    void getDeltaSSEntropy(double* deltaS) override;
+    void getDeltaSSGibbs(span<double> deltaG) override;
+    void getDeltaSSEnthalpy(span<double> deltaH) override;
+    void getDeltaSSEntropy(span<double> deltaS) override;
 
     //! @}
     //! @name Reaction Mechanism Informational Query Routines
     //! @{
 
-    void getFwdRateConstants(double* kfwd) override;
-    void getRevRateConstants(double* krev, bool doIrreversible=false) override;
+    void getFwdRateConstants(span<double> kfwd) override;
+    void getRevRateConstants(span<double> krev, bool doIrreversible=false) override;
 
     //! @}
     //! @name Reaction Mechanism Construction
@@ -286,7 +286,7 @@ protected:
 
 
     //! Multiply rate with inverse equilibrium constant
-    void applyEquilibriumConstants(double* rop);
+    void applyEquilibriumConstants(span<double> rop);
 
     //! Process mole fraction derivative
     //! @param stoich  stoichiometry manager

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -293,8 +293,8 @@ protected:
     //! @param in  rate expression used for the derivative calculation
     //! @return a sparse matrix of derivative contributions for each reaction of
     //! dimensions nTotalReactions by nTotalSpecies
-    Eigen::SparseMatrix<double> calculateCompositionDerivatives(StoichManagerN& stoich,
-                                            const vector<double>& in);
+    Eigen::SparseMatrix<double> calculateCompositionDerivatives(
+        StoichManagerN& stoich, span<const double> in);
 
     //! Helper function ensuring that all rate derivatives can be calculated
     //! @param name  method name used for error output

--- a/include/cantera/kinetics/InterfaceRate.h
+++ b/include/cantera/kinetics/InterfaceRate.h
@@ -31,7 +31,7 @@ struct InterfaceData : public BlowersMaselData
     InterfaceData() = default;
     bool update(const ThermoPhase& bulk, const Kinetics& kin) override;
     void update(double T) override;
-    void update(double T, const vector<double>& values) override;
+    void update(double T, span<const double> values) override;
     using BlowersMaselData::update;
     virtual void perturbTemperature(double deltaT);
     void resize(Kinetics& kin) override;

--- a/include/cantera/kinetics/InterfaceRate.h
+++ b/include/cantera/kinetics/InterfaceRate.h
@@ -103,7 +103,7 @@ public:
     //! *a*, power-law exponent *m*, and activation energy dependence *e*,
     //! where *e* is in Kelvin, that is, energy divided by the molar gas constant.
     virtual void addCoverageDependence(const string& sp, double a, double m,
-                                       const vector<double>& e);
+                                       span<const double> e);
 
     //! Boolean indicating whether rate uses exchange current density formulation
     bool exchangeCurrentDensityFormulation() {
@@ -117,7 +117,7 @@ public:
 
     //! Set association with an ordered list of all species associated with a given
     //! `Kinetics` object.
-    void setSpecies(const vector<string>& species);
+    void setSpecies(span<const string> species);
 
     //! Update reaction rate parameters
     //! @param shared_data  data shared by all reactions of a given type
@@ -426,7 +426,7 @@ public:
     }
 
     void addCoverageDependence(const string& sp, double a, double m,
-                               const vector<double>& e) override
+                               span<const double> e) override
     {
         InterfaceRateBase::addCoverageDependence(sp, a, m, e);
         RateType::setCompositionDependence(true);

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -529,10 +529,11 @@ public:
      * Provide direct access to current third-body concentration values.
      * @see getThirdBodyConcentrations.
      */
-    virtual const vector<double>& thirdBodyConcentrations() const {
+    virtual span<const double> thirdBodyConcentrations() const {
         throw NotImplementedError("Kinetics::thirdBodyConcentrations",
             "Not applicable/implemented for Kinetics object of type '{}'",
             kineticsType());
+        return {};
     }
 
     //! @}

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -93,8 +93,8 @@ class AnyMap;
 //! phase 'a', another bulk phase 'b', and the surface phase 'a:b' at the a/b
 //! interface. Phase 'a' contains 12 species, phase 'b' contains 3, and at the
 //! interface there are 5 adsorbed species defined in phase 'a:b'. Then methods
-//! like getNetProductionRates(double* net) will write and output array of
-//! length 20, beginning at the location pointed to by 'net'. The first 12
+//! like getNetProductionRates(span<double> net) will write and output array of
+//! length 20, beginning at the start of the span. The first 12
 //! values will be the net production rates for all 12 species of phase 'a'
 //! (even if some do not participate in the reactions), the next 3 will be for
 //! phase 'b', and finally the net production rates for the surface species will
@@ -347,7 +347,7 @@ public:
      * @param fwdROP  Output vector containing forward rates
      *                of progress of the reactions. Length: nReactions().
      */
-    virtual void getFwdRatesOfProgress(double* fwdROP);
+    virtual void getFwdRatesOfProgress(span<double> fwdROP);
 
     //!  Return the Reverse rates of progress of the reactions
     /*!
@@ -357,7 +357,7 @@ public:
      * @param revROP  Output vector containing reverse rates
      *                of progress of the reactions. Length: nReactions().
      */
-    virtual void getRevRatesOfProgress(double* revROP);
+    virtual void getRevRatesOfProgress(span<double> revROP);
 
     /**
      * Net rates of progress. Return the net (forward - reverse) rates of
@@ -366,7 +366,7 @@ public:
      *
      * @param netROP  Output vector of the net ROP. Length: nReactions().
      */
-    virtual void getNetRatesOfProgress(double* netROP);
+    virtual void getNetRatesOfProgress(span<double> netROP);
 
     //! Return a vector of Equilibrium constants.
     /*!
@@ -381,7 +381,7 @@ public:
      * @param kc   Output vector containing the equilibrium constants.
      *             Length: nReactions().
      */
-    virtual void getEquilibriumConstants(double* kc) {
+    virtual void getEquilibriumConstants(span<double> kc) {
         throw NotImplementedError("Kinetics::getEquilibriumConstants");
     }
 
@@ -399,7 +399,8 @@ public:
      * @param property Input vector of property value. Length: #m_kk.
      * @param deltaProperty Output vector of deltaRxn. Length: nReactions().
      */
-    virtual void getReactionDelta(const double* property, double* deltaProperty) const;
+    virtual void getReactionDelta(span<const double> property,
+                                  span<double> deltaProperty) const;
 
     /**
      * Given an array of species properties 'g', return in array 'dg' the
@@ -411,7 +412,7 @@ public:
      * primarily designed for use in calculating reverse rate coefficients
      * from thermochemistry for reversible reactions.
      */
-    virtual void getRevReactionDelta(const double* g, double* dg) const;
+    virtual void getRevReactionDelta(span<const double> g, span<double> dg) const;
 
     //! Return the vector of values for the reaction Gibbs free energy change.
     /*!
@@ -423,7 +424,7 @@ public:
      * @param deltaG  Output vector of deltaG's for reactions Length:
      *     nReactions().
      */
-    virtual void getDeltaGibbs(double* deltaG) {
+    virtual void getDeltaGibbs(span<double> deltaG) {
         throw NotImplementedError("Kinetics::getDeltaGibbs");
     }
 
@@ -438,7 +439,7 @@ public:
      * @param deltaM  Output vector of deltaM's for reactions Length:
      *     nReactions().
      */
-    virtual void getDeltaElectrochemPotentials(double* deltaM) {
+    virtual void getDeltaElectrochemPotentials(span<double> deltaM) {
         throw NotImplementedError("Kinetics::getDeltaElectrochemPotentials");
     }
 
@@ -451,7 +452,7 @@ public:
      * @param deltaH  Output vector of deltaH's for reactions Length:
      *     nReactions().
      */
-    virtual void getDeltaEnthalpy(double* deltaH) {
+    virtual void getDeltaEnthalpy(span<double> deltaH) {
         throw NotImplementedError("Kinetics::getDeltaEnthalpy");
     }
 
@@ -464,7 +465,7 @@ public:
      * @param deltaS  Output vector of deltaS's for reactions Length:
      *     nReactions().
      */
-    virtual void getDeltaEntropy(double* deltaS) {
+    virtual void getDeltaEntropy(span<double> deltaS) {
         throw NotImplementedError("Kinetics::getDeltaEntropy");
     }
 
@@ -478,7 +479,7 @@ public:
      * @param deltaG  Output vector of ss deltaG's for reactions Length:
      *     nReactions().
      */
-    virtual void getDeltaSSGibbs(double* deltaG) {
+    virtual void getDeltaSSGibbs(span<double> deltaG) {
         throw NotImplementedError("Kinetics::getDeltaSSGibbs");
     }
 
@@ -492,7 +493,7 @@ public:
      * @param deltaH  Output vector of ss deltaH's for reactions Length:
      *     nReactions().
      */
-    virtual void getDeltaSSEnthalpy(double* deltaH) {
+    virtual void getDeltaSSEnthalpy(span<double> deltaH) {
         throw NotImplementedError("Kinetics::getDeltaSSEnthalpy");
     }
 
@@ -506,7 +507,7 @@ public:
      * @param deltaS  Output vector of ss deltaS's for reactions Length:
      *     nReactions().
      */
-    virtual void getDeltaSSEntropy(double* deltaS) {
+    virtual void getDeltaSSEntropy(span<double> deltaS) {
         throw NotImplementedError("Kinetics::getDeltaSSEntropy");
     }
 
@@ -518,7 +519,7 @@ public:
      * @param concm  Output vector of effective third-body concentrations.
      *      Length: nReactions().
      */
-    virtual void getThirdBodyConcentrations(double* concm) {
+    virtual void getThirdBodyConcentrations(span<double> concm) {
         throw NotImplementedError("Kinetics::getThirdBodyConcentrations",
             "Not applicable/implemented for Kinetics object of type '{}'",
             kineticsType());
@@ -545,7 +546,7 @@ public:
      *
      * @param cdot   Output vector of creation rates. Length: #m_kk.
      */
-    virtual void getCreationRates(double* cdot);
+    virtual void getCreationRates(span<double> cdot);
 
     /**
      * Species destruction rates [kmol/m^3/s or kmol/m^2/s]. Return the species
@@ -554,7 +555,7 @@ public:
      *
      * @param ddot   Output vector of destruction rates. Length: #m_kk.
      */
-    virtual void getDestructionRates(double* ddot);
+    virtual void getDestructionRates(span<double> ddot);
 
     /**
      * Species net production rates [kmol/m^3/s or kmol/m^2/s]. Return the
@@ -564,7 +565,7 @@ public:
      *
      * @param wdot   Output vector of net production rates. Length: #m_kk.
      */
-    virtual void getNetProductionRates(double* wdot);
+    virtual void getNetProductionRates(span<double> wdot);
 
     //! @}
 
@@ -714,7 +715,7 @@ public:
      * at constant pressure, molar concentration and mole fractions
      * @param[out] dkfwd  Output vector of derivatives. Length: nReactions().
      */
-    virtual void getFwdRateConstants_ddT(double* dkfwd)
+    virtual void getFwdRateConstants_ddT(span<double> dkfwd)
     {
         throw NotImplementedError("Kinetics::getFwdRateConstants_ddT",
             "Not implemented for kinetics type '{}'.", kineticsType());
@@ -725,7 +726,7 @@ public:
      * at constant temperature, molar concentration and mole fractions.
      * @param[out] dkfwd  Output vector of derivatives. Length: nReactions().
      */
-    virtual void getFwdRateConstants_ddP(double* dkfwd)
+    virtual void getFwdRateConstants_ddP(span<double> dkfwd)
     {
         throw NotImplementedError("Kinetics::getFwdRateConstants_ddP",
             "Not implemented for kinetics type '{}'.", kineticsType());
@@ -739,7 +740,7 @@ public:
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
      */
-    virtual void getFwdRateConstants_ddC(double* dkfwd)
+    virtual void getFwdRateConstants_ddC(span<double> dkfwd)
     {
         throw NotImplementedError("Kinetics::getFwdRateConstants_ddC",
             "Not implemented for kinetics type '{}'.", kineticsType());
@@ -750,7 +751,7 @@ public:
      * at constant pressure, molar concentration and mole fractions.
      * @param[out] drop  Output vector of derivatives. Length: nReactions().
      */
-    virtual void getFwdRatesOfProgress_ddT(double* drop)
+    virtual void getFwdRatesOfProgress_ddT(span<double> drop)
     {
         throw NotImplementedError("Kinetics::getFwdRatesOfProgress_ddT",
             "Not implemented for kinetics type '{}'.", kineticsType());
@@ -761,7 +762,7 @@ public:
      * at constant temperature, molar concentration and mole fractions.
      * @param[out] drop  Output vector of derivatives. Length: nReactions().
      */
-    virtual void getFwdRatesOfProgress_ddP(double* drop)
+    virtual void getFwdRatesOfProgress_ddP(span<double> drop)
     {
         throw NotImplementedError("Kinetics::getFwdRatesOfProgress_ddP",
             "Not implemented for kinetics type '{}'.", kineticsType());
@@ -775,7 +776,7 @@ public:
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
      */
-    virtual void getFwdRatesOfProgress_ddC(double* drop)
+    virtual void getFwdRatesOfProgress_ddC(span<double> drop)
     {
         throw NotImplementedError("Kinetics::getFwdRatesOfProgress_ddC",
             "Not implemented for kinetics type '{}'.", kineticsType());
@@ -823,7 +824,7 @@ public:
      * at constant pressure, molar concentration and mole fractions.
      * @param[out] drop  Output vector of derivatives. Length: nReactions().
      */
-    virtual void getRevRatesOfProgress_ddT(double* drop)
+    virtual void getRevRatesOfProgress_ddT(span<double> drop)
     {
         throw NotImplementedError("Kinetics::getRevRatesOfProgress_ddT",
             "Not implemented for kinetics type '{}'.", kineticsType());
@@ -834,7 +835,7 @@ public:
      * at constant temperature, molar concentration and mole fractions.
      * @param[out] drop  Output vector of derivatives. Length: nReactions().
      */
-    virtual void getRevRatesOfProgress_ddP(double* drop)
+    virtual void getRevRatesOfProgress_ddP(span<double> drop)
     {
         throw NotImplementedError("Kinetics::getRevRatesOfProgress_ddP",
             "Not implemented for kinetics type '{}'.", kineticsType());
@@ -848,7 +849,7 @@ public:
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
      */
-    virtual void getRevRatesOfProgress_ddC(double* drop)
+    virtual void getRevRatesOfProgress_ddC(span<double> drop)
     {
         throw NotImplementedError("Kinetics::getRevRatesOfProgress_ddC",
             "Not implemented for kinetics type '{}'.", kineticsType());
@@ -896,7 +897,7 @@ public:
      * at constant pressure, molar concentration and mole fractions.
      * @param[out] drop  Output vector of derivatives. Length: nReactions().
      */
-    virtual void getNetRatesOfProgress_ddT(double* drop)
+    virtual void getNetRatesOfProgress_ddT(span<double> drop)
     {
         throw NotImplementedError("Kinetics::getNetRatesOfProgress_ddT",
             "Not implemented for kinetics type '{}'.", kineticsType());
@@ -907,7 +908,7 @@ public:
      * at constant temperature, molar concentration and mole fractions.
      * @param[out] drop  Output vector of derivatives. Length: nReactions().
      */
-    virtual void getNetRatesOfProgress_ddP(double* drop)
+    virtual void getNetRatesOfProgress_ddP(span<double> drop)
     {
         throw NotImplementedError("Kinetics::getNetRatesOfProgress_ddP",
             "Not implemented for kinetics type '{}'.", kineticsType());
@@ -921,7 +922,7 @@ public:
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
      */
-    virtual void getNetRatesOfProgress_ddC(double* drop)
+    virtual void getNetRatesOfProgress_ddC(span<double> drop)
     {
         throw NotImplementedError("Kinetics::getNetRatesOfProgress_ddC",
             "Not implemented for kinetics type '{}'.", kineticsType());
@@ -969,14 +970,14 @@ public:
      * at constant pressure, molar concentration and mole fractions.
      * @param[out] dwdot  Output vector of derivatives. Length: #m_kk.
      */
-    void getCreationRates_ddT(double* dwdot);
+    void getCreationRates_ddT(span<double> dwdot);
 
     /**
      * Calculate derivatives for species creation rates with respect to pressure
      * at constant temperature, molar concentration and mole fractions.
      * @param[out] dwdot  Output vector of derivatives. Length: #m_kk.
      */
-    void getCreationRates_ddP(double* dwdot);
+    void getCreationRates_ddP(span<double> dwdot);
 
     /**
      * Calculate derivatives for species creation rates with respect to molar
@@ -986,7 +987,7 @@ public:
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
      */
-    void getCreationRates_ddC(double* dwdot);
+    void getCreationRates_ddC(span<double> dwdot);
 
     /**
      * Calculate derivatives for species creation rates with respect to species
@@ -1022,14 +1023,14 @@ public:
      * at constant pressure, molar concentration and mole fractions.
      * @param[out] dwdot  Output vector of derivatives. Length: #m_kk.
      */
-    void getDestructionRates_ddT(double* dwdot);
+    void getDestructionRates_ddT(span<double> dwdot);
 
     /**
      * Calculate derivatives for species destruction rates with respect to pressure
      * at constant temperature, molar concentration and mole fractions.
      * @param[out] dwdot  Output vector of derivatives. Length: #m_kk.
      */
-    void getDestructionRates_ddP(double* dwdot);
+    void getDestructionRates_ddP(span<double> dwdot);
 
     /**
      * Calculate derivatives for species destruction rates with respect to molar
@@ -1039,7 +1040,7 @@ public:
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
      */
-    void getDestructionRates_ddC(double* dwdot);
+    void getDestructionRates_ddC(span<double> dwdot);
 
     /**
      * Calculate derivatives for species destruction rates with respect to species
@@ -1075,14 +1076,14 @@ public:
      * temperature at constant pressure, molar concentration and mole fractions.
      * @param[out] dwdot  Output vector of derivatives. Length: #m_kk.
      */
-    void getNetProductionRates_ddT(double* dwdot);
+    void getNetProductionRates_ddT(span<double> dwdot);
 
     /**
      * Calculate derivatives for species net production rates with respect to pressure
      * at constant temperature, molar concentration and mole fractions.
      * @param[out] dwdot  Output vector of derivatives. Length: #m_kk.
      */
-    void getNetProductionRates_ddP(double* dwdot);
+    void getNetProductionRates_ddP(span<double> dwdot);
 
     /**
      * Calculate derivatives for species net production rates with respect to molar
@@ -1092,7 +1093,7 @@ public:
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
      */
-    void getNetProductionRates_ddC(double* dwdot);
+    void getNetProductionRates_ddC(span<double> dwdot);
 
     /**
      * Calculate derivatives for species net production rates with respect to species
@@ -1216,7 +1217,7 @@ public:
      * @param kfwd    Output vector containing the forward reaction rate
      *                constants. Length: nReactions().
      */
-    virtual void getFwdRateConstants(double* kfwd) {
+    virtual void getFwdRateConstants(span<double> kfwd) {
         throw NotImplementedError("Kinetics::getFwdRateConstants");
     }
 
@@ -1236,8 +1237,7 @@ public:
      * @param doIrreversible boolean indicating whether irreversible reactions
      *                       should be included.
      */
-    virtual void getRevRateConstants(double* krev,
-                                     bool doIrreversible = false) {
+    virtual void getRevRateConstants(span<double> krev, bool doIrreversible = false) {
         throw NotImplementedError("Kinetics::getRevRateConstants");
     }
 

--- a/include/cantera/kinetics/MultiRate.h
+++ b/include/cantera/kinetics/MultiRate.h
@@ -66,13 +66,13 @@ public:
         m_shared.invalidateCache();
     }
 
-    void getRateConstants(double* kf) override {
+    void getRateConstants(span<double> kf) override {
         for (auto& [iRxn, rate] : m_rxn_rates) {
             kf[iRxn] = rate.evalFromStruct(m_shared);
         }
     }
 
-    void modifyRateConstants(double* kf, double* kr) override {
+    void modifyRateConstants(span<double> kf, span<double> kr) override {
         if constexpr (has_modifyRateConstants<RateType>::value) {
             for (auto& [iRxn, rate] : m_rxn_rates) {
                 rate.modifyRateConstants(m_shared, kf[iRxn], kr[iRxn]);
@@ -80,7 +80,8 @@ public:
         }
     }
 
-    void processRateConstants_ddT(double* rop, const double* kf, double deltaT) override
+    void processRateConstants_ddT(span<double> rop, span<const double> kf,
+                                  double deltaT) override
     {
         if constexpr (has_ddT<RateType>::value) {
             for (const auto& [iRxn, rate] : m_rxn_rates) {
@@ -106,7 +107,8 @@ public:
         }
     }
 
-    void processRateConstants_ddP(double* rop, const double* kf, double deltaP) override
+    void processRateConstants_ddP(span<double> rop, span<const double> kf,
+                                  double deltaP) override
     {
         if constexpr (has_ddP<DataType>::value) {
             double dPinv = 1. / (m_shared.pressure * deltaP);
@@ -130,8 +132,8 @@ public:
         }
     }
 
-    void processRateConstants_ddM(double* rop, const double* kf, double deltaM,
-                                  bool overwrite=true) override
+    void processRateConstants_ddM(span<double> rop, span<const double> kf,
+                                  double deltaM, bool overwrite=true) override
     {
         if constexpr (has_ddM<DataType>::value) {
             double dMinv = 1. / deltaM;
@@ -172,7 +174,7 @@ public:
         _update();
     }
 
-    void update(double T, const vector<double>& extra) override {
+    void update(double T, span<const double> extra) override {
         m_shared.update(T, extra);
         _update();
     }

--- a/include/cantera/kinetics/MultiRateBase.h
+++ b/include/cantera/kinetics/MultiRateBase.h
@@ -49,7 +49,7 @@ public:
 
     //! Evaluate all rate constants handled by the evaluator
     //! @param kf  array of rate constants
-    virtual void getRateConstants(double* kf) = 0;
+    virtual void getRateConstants(span<double> kf) = 0;
 
     //! For certain reaction types that do not follow mass action kinetics (for example,
     //! Butler-Volmer), calculate modifications to the forward and reverse rate
@@ -62,7 +62,7 @@ public:
     //!     is updated by the product StoichManagerN to determine the reverse rates of
     //!     progress.
     //! @since New in %Cantera 3.2
-    virtual void modifyRateConstants(double* kf, double* kr) = 0;
+    virtual void modifyRateConstants(span<double> kf, span<double> kr) = 0;
 
     //! Evaluate all rate constant temperature derivatives handled by the evaluator;
     //! which are multiplied with the array of rate-of-progress variables.
@@ -72,8 +72,7 @@ public:
     //!     contains rop on input, and d(rop)/dT on output
     //! @param kf  array of forward rate constants (numerical derivative only)
     //! @param deltaT  relative temperature perturbation (numerical derivative only)
-    virtual void processRateConstants_ddT(double* rop,
-                                          const double* kf,
+    virtual void processRateConstants_ddT(span<double> rop, span<const double> kf,
                                           double deltaT) = 0;
 
     //! Evaluate all rate constant pressure derivatives handled by the evaluator;
@@ -82,8 +81,7 @@ public:
     //!     contains rop on input, and d(rop)/dP on output
     //! @param kf  array of forward rate constants
     //! @param deltaP  relative pressure perturbation
-    virtual void processRateConstants_ddP(double* rop,
-                                          const double* kf,
+    virtual void processRateConstants_ddP(span<double> rop, span<const double> kf,
                                           double deltaP) = 0;
 
     //! Evaluate all rate constant third-body derivatives handled by the evaluator;
@@ -93,10 +91,8 @@ public:
     //! @param kf  array of forward rate constants
     //! @param deltaM  relative perturbation of third-body concentrations
     //! @param overwrite  if `true`, rop entries not affected by M are set to zero
-    virtual void processRateConstants_ddM(double* rop,
-                                          const double* kf,
-                                          double deltaM,
-                                          bool overwrite=true) = 0;
+    virtual void processRateConstants_ddM(span<double> rop, span<const double> kf,
+                                          double deltaM, bool overwrite=true) = 0;
 
     //! Update common reaction rate data based on temperature.
     //! Only used in conjunction with evalSingle and ReactionRate::eval
@@ -115,7 +111,7 @@ public:
     //! @param extra  extra vector parameter (depends on parameterization)
     //! @warning  This method is an experimental part of the %Cantera API and
     //!     may be changed or removed without notice.
-    virtual void update(double T, const vector<double>& extra) = 0;
+    virtual void update(double T, span<const double> extra) = 0;
 
     //! Update data common to reaction rates of a specific type.
     //! This update mechanism is used by Kinetics reaction rate evaluators.

--- a/include/cantera/kinetics/ReactionData.h
+++ b/include/cantera/kinetics/ReactionData.h
@@ -61,7 +61,7 @@ struct ReactionData
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
      */
-    virtual void update(double T, const vector<double>& extra) {
+    virtual void update(double T, span<const double> extra) {
         throw NotImplementedError("ReactionData::update",
             "ReactionData type does not use extra vector argument.");
     }

--- a/include/cantera/kinetics/ReactionPath.h
+++ b/include/cantera/kinetics/ReactionPath.h
@@ -263,20 +263,20 @@ public:
     void exclude(const string& aaname) {
         m_exclude.push_back(aaname);
     }
-    void include(vector<string>& names) {
+    void include(span<string> names) {
         for (size_t i = 0; i < names.size(); i++) {
             m_include.push_back(names[i]);
         }
     }
-    void exclude(vector<string>& names) {
+    void exclude(span<string> names) {
         for (size_t i = 0; i < names.size(); i++) {
             m_exclude.push_back(names[i]);
         }
     }
-    vector<string>& included() {
+    const span<const string> included() const {
         return m_include;
     }
-    vector<string>& excluded() {
+    const span<const string> excluded() const {
         return m_exclude;
     }
     vector<size_t> species();

--- a/include/cantera/kinetics/ReactionPath.h
+++ b/include/cantera/kinetics/ReactionPath.h
@@ -286,7 +286,7 @@ public:
     /**
      *  @todo Add documentation.
      */
-    void findMajorPaths(double threshold, size_t lda, double* a);
+    void findMajorPaths(double threshold, size_t lda, span<double> a);
 
     //! Set name of the font used.
     void setFont(const string& font) {

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -200,7 +200,7 @@ public:
     //! Kinetics reaction rate evaluators.
     //! @warning  This method is an experimental part of the %Cantera API and
     //!     may be changed or removed without notice.
-    double eval(double T, const vector<double>& extra) {
+    double eval(double T, span<const double> extra) {
         _evaluator().update(T, extra);
         return _evaluator().evalSingle(*this);
     }

--- a/include/cantera/kinetics/StoichManager.h
+++ b/include/cantera/kinetics/StoichManager.h
@@ -136,23 +136,23 @@ public:
         m_ic0(ic0) {
     }
 
-    void incrementSpecies(const double* R, double* S) const {
+    void incrementSpecies(span<const double> R, span<double> S) const {
         S[m_ic0] += R[m_rxn];
     }
 
-    void decrementSpecies(const double* R, double* S) const {
+    void decrementSpecies(span<const double> R, span<double> S) const {
         S[m_ic0] -= R[m_rxn];
     }
 
-    void multiply(const double* S, double* R) const {
+    void multiply(span<const double> S, span<double> R) const {
         R[m_rxn] *= S[m_ic0];
     }
 
-    void incrementReaction(const double* S, double* R) const {
+    void incrementReaction(span<const double> S, span<double> R) const {
         R[m_rxn] += S[m_ic0];
     }
 
-    void decrementReaction(const double* S, double* R) const {
+    void decrementReaction(span<const double> S, span<double> R) const {
         R[m_rxn] -= S[m_ic0];
     }
 
@@ -161,14 +161,14 @@ public:
         m_jc0 = indices.at({m_rxn, m_ic0});
     }
 
-    void derivatives(const double* S, const double* R, vector<double>& jac) const
+    void derivatives(span<const double> S, span<const double> R,
+                     span<double> jac) const
     {
         jac[m_jc0] += R[m_rxn]; // index (m_ic0, m_rxn)
     }
 
 
-    void scale(const double* R, double* out, double factor) const
-    {
+    void scale(span<const double> R, span<double> out, double factor) const {
         out[m_rxn] = R[m_rxn] * factor;
     }
 
@@ -192,17 +192,17 @@ public:
     C2(size_t rxn = 0, size_t ic0 = 0, size_t ic1 = 0)
         : m_rxn(rxn), m_ic0(ic0), m_ic1(ic1) {}
 
-    void incrementSpecies(const double* R, double* S) const {
+    void incrementSpecies(span<const double> R, span<double> S) const {
         S[m_ic0] += R[m_rxn];
         S[m_ic1] += R[m_rxn];
     }
 
-    void decrementSpecies(const double* R, double* S) const {
+    void decrementSpecies(span<const double> R, span<double> S) const {
         S[m_ic0] -= R[m_rxn];
         S[m_ic1] -= R[m_rxn];
     }
 
-    void multiply(const double* S, double* R) const {
+    void multiply(span<const double> S, span<double> R) const {
         if (S[m_ic0] < 0 && S[m_ic1] < 0) {
             R[m_rxn] = 0;
         } else {
@@ -210,11 +210,11 @@ public:
         }
     }
 
-    void incrementReaction(const double* S, double* R) const {
+    void incrementReaction(span<const double> S, span<double> R) const {
         R[m_rxn] += S[m_ic0] + S[m_ic1];
     }
 
-    void decrementReaction(const double* S, double* R) const {
+    void decrementReaction(span<const double> S, span<double> R) const {
         R[m_rxn] -= (S[m_ic0] + S[m_ic1]);
     }
 
@@ -224,7 +224,8 @@ public:
         m_jc1 = indices.at({m_rxn, m_ic1});
     }
 
-    void derivatives(const double* S, const double* R, vector<double>& jac) const
+    void derivatives(span<const double> S, span<const double> R,
+                     span<double> jac) const
     {
         if (S[m_ic1] > 0) {
             jac[m_jc0] += R[m_rxn] * S[m_ic1]; // index (m_ic0, m_rxn)
@@ -234,7 +235,7 @@ public:
         }
     }
 
-    void scale(const double* R, double* out, double factor) const
+    void scale(span<const double> R, span<double> out, double factor) const
     {
         out[m_rxn] = 2 * R[m_rxn] * factor;
     }
@@ -260,19 +261,19 @@ public:
     C3(size_t rxn = 0, size_t ic0 = 0, size_t ic1 = 0, size_t ic2 = 0)
         : m_rxn(rxn), m_ic0(ic0), m_ic1(ic1), m_ic2(ic2) {}
 
-    void incrementSpecies(const double* R, double* S) const {
+    void incrementSpecies(span<const double> R, span<double> S) const {
         S[m_ic0] += R[m_rxn];
         S[m_ic1] += R[m_rxn];
         S[m_ic2] += R[m_rxn];
     }
 
-    void decrementSpecies(const double* R, double* S) const {
+    void decrementSpecies(span<const double> R, span<double> S) const {
         S[m_ic0] -= R[m_rxn];
         S[m_ic1] -= R[m_rxn];
         S[m_ic2] -= R[m_rxn];
     }
 
-    void multiply(const double* S, double* R) const {
+    void multiply(span<const double> S, span<double> R) const {
         if ((S[m_ic0] < 0 && (S[m_ic1] < 0 || S[m_ic2] < 0)) ||
             (S[m_ic1] < 0 && S[m_ic2] < 0)) {
             R[m_rxn] = 0;
@@ -281,11 +282,11 @@ public:
         }
     }
 
-    void incrementReaction(const double* S, double* R) const {
+    void incrementReaction(span<const double> S, span<double> R) const {
         R[m_rxn] += S[m_ic0] + S[m_ic1] + S[m_ic2];
     }
 
-    void decrementReaction(const double* S, double* R) const {
+    void decrementReaction(span<const double> S, span<double> R) const {
         R[m_rxn] -= (S[m_ic0] + S[m_ic1] + S[m_ic2]);
     }
 
@@ -296,7 +297,8 @@ public:
         m_jc2 = indices.at({m_rxn, m_ic2});
     }
 
-    void derivatives(const double* S, const double* R, vector<double>& jac) const
+    void derivatives(span<const double> S, span<const double> R,
+                     span<double> jac) const
     {
         if (S[m_ic1] > 0 && S[m_ic2] > 0) {
             jac[m_jc0] += R[m_rxn] * S[m_ic1] * S[m_ic2];; // index (m_ic0, m_rxn)
@@ -309,7 +311,7 @@ public:
         }
     }
 
-    void scale(const double* R, double* out, double factor) const
+    void scale(span<const double> R, span<double> out, double factor) const
     {
         out[m_rxn] = 3 * R[m_rxn] * factor;
     }
@@ -349,7 +351,7 @@ public:
         }
     }
 
-    void multiply(const double* input, double* output) const {
+    void multiply(span<const double> input, span<double> output) const {
         for (size_t n = 0; n < m_n; n++) {
             double order = m_order[n];
             if (order != 0.0) {
@@ -363,27 +365,27 @@ public:
         }
     }
 
-    void incrementSpecies(const double* input, double* output) const {
+    void incrementSpecies(span<const double> input, span<double> output) const {
         double x = input[m_rxn];
         for (size_t n = 0; n < m_n; n++) {
             output[m_ic[n]] += m_stoich[n]*x;
         }
     }
 
-    void decrementSpecies(const double* input, double* output) const {
+    void decrementSpecies(span<const double> input, span<double> output) const {
         double x = input[m_rxn];
         for (size_t n = 0; n < m_n; n++) {
             output[m_ic[n]] -= m_stoich[n]*x;
         }
     }
 
-    void incrementReaction(const double* input, double* output) const {
+    void incrementReaction(span<const double> input, span<double> output) const {
         for (size_t n = 0; n < m_n; n++) {
             output[m_rxn] += m_stoich[n]*input[m_ic[n]];
         }
     }
 
-    void decrementReaction(const double* input, double* output) const {
+    void decrementReaction(span<const double> input, span<double> output) const {
         for (size_t n = 0; n < m_n; n++) {
             output[m_rxn] -= m_stoich[n]*input[m_ic[n]];
         }
@@ -401,7 +403,8 @@ public:
         }
     }
 
-    void derivatives(const double* S, const double* R, vector<double>& jac) const
+    void derivatives(span<const double> S, span<const double> R,
+                     span<double> jac) const
     {
         for (size_t i = 0; i < m_n; i++) {
             // calculate derivative
@@ -426,7 +429,7 @@ public:
         }
     }
 
-    void scale(const double* R, double* out, double factor) const
+    void scale(span<const double> R, span<double> out, double factor) const
     {
         out[m_rxn] = m_sum_order * R[m_rxn] * factor;
     }
@@ -531,7 +534,7 @@ inline static void _resizeCoeffs(InputIter begin, InputIter end, Indices& ix)
 
 template<class InputIter, class Vec1, class Vec2, class Vec3>
 inline static void _derivatives(InputIter begin, InputIter end,
-                             const Vec1& S, const Vec2& R, Vec3& jac)
+                                const Vec1& S, const Vec2& R, Vec3& jac)
 {
     for (; begin != end; ++begin) {
         begin->derivatives(S, R, jac);
@@ -719,35 +722,35 @@ public:
         m_ready = false;
     }
 
-    void multiply(const double* input, double* output) const {
+    void multiply(span<const double> input, span<double> output) const {
         _multiply(m_c1_list.begin(), m_c1_list.end(), input, output);
         _multiply(m_c2_list.begin(), m_c2_list.end(), input, output);
         _multiply(m_c3_list.begin(), m_c3_list.end(), input, output);
         _multiply(m_cn_list.begin(), m_cn_list.end(), input, output);
     }
 
-    void incrementSpecies(const double* input, double* output) const {
+    void incrementSpecies(span<const double> input, span<double> output) const {
         _incrementSpecies(m_c1_list.begin(), m_c1_list.end(), input, output);
         _incrementSpecies(m_c2_list.begin(), m_c2_list.end(), input, output);
         _incrementSpecies(m_c3_list.begin(), m_c3_list.end(), input, output);
         _incrementSpecies(m_cn_list.begin(), m_cn_list.end(), input, output);
     }
 
-    void decrementSpecies(const double* input, double* output) const {
+    void decrementSpecies(span<const double> input, span<double> output) const {
         _decrementSpecies(m_c1_list.begin(), m_c1_list.end(), input, output);
         _decrementSpecies(m_c2_list.begin(), m_c2_list.end(), input, output);
         _decrementSpecies(m_c3_list.begin(), m_c3_list.end(), input, output);
         _decrementSpecies(m_cn_list.begin(), m_cn_list.end(), input, output);
     }
 
-    void incrementReactions(const double* input, double* output) const {
+    void incrementReactions(span<const double> input, span<double> output) const {
         _incrementReactions(m_c1_list.begin(), m_c1_list.end(), input, output);
         _incrementReactions(m_c2_list.begin(), m_c2_list.end(), input, output);
         _incrementReactions(m_c3_list.begin(), m_c3_list.end(), input, output);
         _incrementReactions(m_cn_list.begin(), m_cn_list.end(), input, output);
     }
 
-    void decrementReactions(const double* input, double* output) const {
+    void decrementReactions(span<const double> input, span<double> output) const {
         _decrementReactions(m_c1_list.begin(), m_c1_list.end(), input, output);
         _decrementReactions(m_c2_list.begin(), m_c2_list.end(), input, output);
         _decrementReactions(m_c3_list.begin(), m_c3_list.end(), input, output);
@@ -777,7 +780,8 @@ public:
      *  @param conc    Species concentration.
      *  @param rates   Rates-of-progress.
      */
-    Eigen::SparseMatrix<double> derivatives(const double* conc, const double* rates)
+    Eigen::SparseMatrix<double> derivatives(span<const double> conc,
+                                            span<const double> rates)
     {
         // calculate derivative entries using known sparse storage order
         std::fill(m_values.begin(), m_values.end(), 0.);
@@ -792,7 +796,7 @@ public:
     }
 
     //! Scale input by reaction order and factor
-    void scale(const double* in, double* out, double factor) const
+    void scale(span<const double> in, span<double> out, double factor) const
     {
         _scale(m_c1_list.begin(), m_c1_list.end(), in, out, factor);
         _scale(m_c2_list.begin(), m_c2_list.end(), in, out, factor);

--- a/include/cantera/kinetics/StoichManager.h
+++ b/include/cantera/kinetics/StoichManager.h
@@ -336,8 +336,8 @@ class C_AnyN
 public:
     C_AnyN() = default;
 
-    C_AnyN(size_t rxn, const vector<size_t>& ic,
-           const vector<double>& order_, const vector<double>& stoich_) :
+    C_AnyN(size_t rxn, span<const size_t> ic,
+           span<const double> order_, span<const double> stoich_) :
         m_n(ic.size()),
         m_rxn(rxn) {
         m_ic.resize(m_n);
@@ -646,13 +646,13 @@ public:
      * This function is the same as the add() function below. However, the order
      * of each species in the power list expression is set to one automatically.
      */
-    void add(size_t rxn, const vector<size_t>& k) {
+    void add(size_t rxn, span<const size_t> k) {
         vector<double> order(k.size(), 1.0);
         vector<double> stoich(k.size(), 1.0);
         add(rxn, k, order, stoich);
     }
 
-    void add(size_t rxn, const vector<size_t>& k, const vector<double>& order) {
+    void add(size_t rxn, span<const size_t> k, span<const double> order) {
         vector<double> stoich(k.size(), 1.0);
         add(rxn, k, order, stoich);
     }
@@ -673,8 +673,8 @@ public:
      *  @param stoich  This is used to handle fractional stoichiometric
      *     coefficients on the product side of irreversible reactions.
      */
-    void add(size_t rxn, const vector<size_t>& k, const vector<double>& order,
-             const vector<double>& stoich) {
+    void add(size_t rxn, span<const size_t> k, span<const double> order,
+             span<const double> stoich) {
         if (order.size() != k.size()) {
             throw CanteraError(
                 "StoichManagerN::add()", "size of order and species arrays differ");

--- a/include/cantera/kinetics/ThirdBodyCalc.h
+++ b/include/cantera/kinetics/ThirdBodyCalc.h
@@ -72,7 +72,7 @@ public:
     }
 
     //! Update third-body concentrations in full vector
-    void update(const vector<double>& conc, double ctot, double* concm) const {
+    void update(span<const double> conc, double ctot, span<double> concm) const {
         for (size_t i = 0; i < m_reaction_index.size(); i++) {
             double sum = 0.0;
             for (size_t j = 0; j < m_species[i].size(); j++) {
@@ -83,7 +83,7 @@ public:
     }
 
     //! Multiply output with effective third-body concentration
-    void multiply(double* output, const double* concm) {
+    void multiply(span<double> output, span<const double> concm) {
         for (size_t i = 0; i < m_mass_action_index.size(); i++) {
             size_t ix = m_reaction_index[m_mass_action_index[i]];
             output[ix] *= concm[ix];
@@ -94,13 +94,13 @@ public:
     /*!
      *  @param product   Product of law of mass action and rate terms.
      */
-    Eigen::SparseMatrix<double> derivatives(const double* product) {
-        Eigen::Map<const Eigen::VectorXd> mapped(product, m_multipliers.rows());
+    Eigen::SparseMatrix<double> derivatives(span<const double> product) {
+        Eigen::Map<const Eigen::VectorXd> mapped(product.data(), m_multipliers.rows());
         return mapped.asDiagonal() * m_multipliers;
     }
 
     //! Scale entries involving third-body collider in law of mass action by factor
-    void scale(const double* in, double* out, double factor) const {
+    void scale(span<const double> in, span<double> out, double factor) const {
         for (size_t i = 0; i < m_mass_action_index.size(); i++) {
             size_t ix = m_reaction_index[m_mass_action_index[i]];
             out[ix] = factor * in[ix];
@@ -109,8 +109,8 @@ public:
 
     //! Scale entries involving third-body collider in rate expression
     //! by third-body concentration and factor
-    void scaleM(const double* in, double* out,
-                const double* concm, double factor) const
+    void scaleM(span<const double> in, span<double> out,
+                span<const double> concm, double factor) const
     {
         for (size_t i = 0; i < m_no_mass_action_index.size(); i++) {
             size_t ix = m_reaction_index[m_no_mass_action_index[i]];

--- a/include/cantera/numerics/eigen_dense.h
+++ b/include/cantera/numerics/eigen_dense.h
@@ -15,6 +15,7 @@
 #else
 #include "cantera/ext/Eigen/Dense"
 #endif
+#include <concepts>
 
 namespace Cantera
 {
@@ -31,10 +32,28 @@ typedef Eigen::Map<const Eigen::RowVectorXd> ConstMappedRowVector;
 
 //! @}
 
-//! Convenience wrapper for accessing Eigen VectorXd data as a span
+template<class Derived>
+concept EigenDenseDouble = std::same_as<typename Derived::Scalar, double>;
+
+// Require a 1D type with contiguous storage
+template<class Derived>
+concept EigenVectorLike = EigenDenseDouble<Derived>
+    && (Derived::IsVectorAtCompileTime == 1);
+
+//! Convenience wrapper for accessing Eigen vector/array/map data as a span
 //! @todo Remove once %Cantera requires Eigen 5.0 or newer.
-inline span<double> asSpan(Eigen::VectorXd& v) {
-    return span<double>(v.data(), v.size());
+template<EigenVectorLike Derived>
+inline span<double> asSpan(Eigen::DenseBase<Derived>& v)
+{
+    return span<double>(v.derived().data(), v.size());
+}
+
+//! Convenience wrapper for accessing Eigen vector/array/map data as a span
+//! @todo Remove once %Cantera requires Eigen 5.0 or newer.
+template<EigenVectorLike Derived>
+inline span<const double> asSpan(const Eigen::DenseBase<Derived>& v)
+{
+    return span<const double>(v.derived().data(), v.size());
 }
 
 }

--- a/include/cantera/numerics/funcs.h
+++ b/include/cantera/numerics/funcs.h
@@ -35,7 +35,7 @@ namespace Cantera
  * @returns the value of of the interpolated function at x.
  * @ingroup mathUtils
  */
-double linearInterp(double x, const vector<double>& xpts, const vector<double>& fpts);
+double linearInterp(double x, span<const double> xpts, span<const double> fpts);
 
 //! Numerical integration of a function using the trapezoidal rule.
 /*!

--- a/include/cantera/oneD/Flow1D.h
+++ b/include/cantera/oneD/Flow1D.h
@@ -467,7 +467,7 @@ protected:
             m_wtm[j] = m_thermo->meanMolecularWeight();
             m_cp[j] = m_thermo->cp_mass();
             m_thermo->getPartialMolarEnthalpies(span<double>(&m_hk(0, j), m_nsp));
-            m_kin->getNetProductionRates(&m_wdot(0, j));
+            m_kin->getNetProductionRates(span<double>(&m_wdot(0, j), m_nsp));
         }
     }
 

--- a/interfaces/cython/cantera/kinetics.pxd
+++ b/interfaces/cython/cantera/kinetics.pxd
@@ -84,59 +84,59 @@ cdef extern from "cantera/cython/kinetics_utils.h":
     cdef void CxxSparseCscData "sparseCscData" (CxxSparseMatrix, double*, int*, int*) except +translate_exception
 
     # Kinetics per-reaction properties
-    cdef void kin_getFwdRatesOfProgress(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getRevRatesOfProgress(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getNetRatesOfProgress(CxxKinetics*, double*) except +translate_exception
+    cdef void kin_getFwdRatesOfProgress(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getRevRatesOfProgress(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getNetRatesOfProgress(CxxKinetics*, span[double]) except +translate_exception
 
-    cdef void kin_getFwdRateConstants_ddT(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getFwdRateConstants_ddP(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getFwdRateConstants_ddC(CxxKinetics*, double*) except +translate_exception
+    cdef void kin_getFwdRateConstants_ddT(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getFwdRateConstants_ddP(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getFwdRateConstants_ddC(CxxKinetics*, span[double]) except +translate_exception
 
-    cdef void kin_getFwdRatesOfProgress_ddT(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getRevRatesOfProgress_ddT(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getNetRatesOfProgress_ddT(CxxKinetics*, double*) except +translate_exception
+    cdef void kin_getFwdRatesOfProgress_ddT(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getRevRatesOfProgress_ddT(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getNetRatesOfProgress_ddT(CxxKinetics*, span[double]) except +translate_exception
 
-    cdef void kin_getFwdRatesOfProgress_ddP(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getRevRatesOfProgress_ddP(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getNetRatesOfProgress_ddP(CxxKinetics*, double*) except +translate_exception
+    cdef void kin_getFwdRatesOfProgress_ddP(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getRevRatesOfProgress_ddP(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getNetRatesOfProgress_ddP(CxxKinetics*, span[double]) except +translate_exception
 
-    cdef void kin_getFwdRatesOfProgress_ddC(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getRevRatesOfProgress_ddC(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getNetRatesOfProgress_ddC(CxxKinetics*, double*) except +translate_exception
+    cdef void kin_getFwdRatesOfProgress_ddC(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getRevRatesOfProgress_ddC(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getNetRatesOfProgress_ddC(CxxKinetics*, span[double]) except +translate_exception
 
-    cdef void kin_getEquilibriumConstants(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getFwdRateConstants(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getRevRateConstants(CxxKinetics*, double*) except +translate_exception
+    cdef void kin_getEquilibriumConstants(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getFwdRateConstants(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getRevRateConstants(CxxKinetics*, span[double]) except +translate_exception
 
-    cdef void kin_getDeltaEnthalpy(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getDeltaGibbs(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getDeltaEntropy(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getDeltaSSEnthalpy(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getDeltaSSGibbs(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getDeltaSSEntropy(CxxKinetics*, double*) except +translate_exception
+    cdef void kin_getDeltaEnthalpy(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getDeltaGibbs(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getDeltaEntropy(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getDeltaSSEnthalpy(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getDeltaSSGibbs(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getDeltaSSEntropy(CxxKinetics*, span[double]) except +translate_exception
 
-    cdef void kin_getThirdBodyConcentrations(CxxKinetics*, double*) except +translate_exception
+    cdef void kin_getThirdBodyConcentrations(CxxKinetics*, span[double]) except +translate_exception
 
     # Kinetics per-species properties
-    cdef void kin_getCreationRates(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getDestructionRates(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getNetProductionRates(CxxKinetics*, double*) except +translate_exception
+    cdef void kin_getCreationRates(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getDestructionRates(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getNetProductionRates(CxxKinetics*, span[double]) except +translate_exception
 
-    cdef void kin_getCreationRates_ddT(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getDestructionRates_ddT(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getNetProductionRates_ddT(CxxKinetics*, double*) except +translate_exception
+    cdef void kin_getCreationRates_ddT(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getDestructionRates_ddT(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getNetProductionRates_ddT(CxxKinetics*, span[double]) except +translate_exception
 
-    cdef void kin_getCreationRates_ddP(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getDestructionRates_ddP(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getNetProductionRates_ddP(CxxKinetics*, double*) except +translate_exception
+    cdef void kin_getCreationRates_ddP(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getDestructionRates_ddP(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getNetProductionRates_ddP(CxxKinetics*, span[double]) except +translate_exception
 
-    cdef void kin_getCreationRates_ddC(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getDestructionRates_ddC(CxxKinetics*, double*) except +translate_exception
-    cdef void kin_getNetProductionRates_ddC(CxxKinetics*, double*) except +translate_exception
+    cdef void kin_getCreationRates_ddC(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getDestructionRates_ddC(CxxKinetics*, span[double]) except +translate_exception
+    cdef void kin_getNetProductionRates_ddC(CxxKinetics*, span[double]) except +translate_exception
 
 
 
-ctypedef void (*kineticsMethod1d)(CxxKinetics*, double*) except +translate_exception
+ctypedef void (*kineticsMethod1d)(CxxKinetics*, span[double]) except +translate_exception
 ctypedef CxxSparseMatrix (*kineticsMethodSparse)(CxxKinetics*) except +translate_exception
 
 cdef class Kinetics(_SolutionBase):

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -8,6 +8,7 @@ import numpy as np
 
 from .reaction cimport *
 from ._utils cimport *
+from .ctcxx cimport span
 from . import _utils
 
 # NOTE: These cdef functions cannot be members of Kinetics because they would
@@ -17,7 +18,8 @@ cdef np.ndarray get_species_array(Kinetics kin, kineticsMethod1d method):
     cdef np.ndarray[np.double_t, ndim=1] data = np.empty(kin.n_total_species)
     if kin.n_total_species == 0:
         return data
-    method(kin.kinetics, &data[0])
+    cdef span[double] view = span[double](&data[0], <size_t>data.size)
+    method(kin.kinetics, view)
     # @todo: Fix _selected_species to work with interface kinetics
     if kin._selected_species.size:
         return data[kin._selected_species]
@@ -28,7 +30,8 @@ cdef np.ndarray get_reaction_array(Kinetics kin, kineticsMethod1d method):
     cdef np.ndarray[np.double_t, ndim=1] data = np.empty(kin.n_reactions)
     if kin.n_reactions == 0:
         return data
-    method(kin.kinetics, &data[0])
+    cdef span[double] view = span[double](&data[0], <size_t>data.size)
+    method(kin.kinetics, view)
     return data
 
 cdef np.ndarray get_dense(CxxSparseMatrix& smat):

--- a/interfaces/cython/cantera/mixture.pxd
+++ b/interfaces/cython/cantera/mixture.pxd
@@ -27,7 +27,7 @@ cdef extern from "cantera/equil/MultiPhase.h" namespace "Cantera":
 
         double phaseMoles(size_t) except +translate_exception
         void setPhaseMoles(size_t, double) except +translate_exception
-        void setMoles(double*) except +translate_exception
+        void setMoles(span[double]) except +translate_exception
         void setMolesByName(string) except +translate_exception
 
         double speciesMoles(size_t) except +translate_exception

--- a/interfaces/cython/cantera/mixture.pyx
+++ b/interfaces/cython/cantera/mixture.pyx
@@ -2,6 +2,7 @@
 # at https://cantera.org/license.txt for license and copyright information.
 
 import numpy as np
+cimport numpy as np
 
 from .solutionbase cimport *
 from .ctcxx cimport span
@@ -267,12 +268,9 @@ cdef class Mixture:
                 self.mix.setMolesByName(stringify(moles))
                 return
 
-            if len(moles) != self.n_species:
-                raise ValueError('mole array must be of length n_species')
-
             cdef np.ndarray[np.double_t, ndim=1] data = \
                 np.ascontiguousarray(moles, dtype=np.double)
-            self.mix.setMoles(&data[0])
+            self.mix.setMoles(span[double](&data[0], data.size))
 
     def element_moles(self, e):
         """

--- a/interfaces/cython/cantera/reaction.pxd
+++ b/interfaces/cython/cantera/reaction.pxd
@@ -9,6 +9,8 @@ from .func1 cimport *
 from .delegator cimport CxxDelegator
 from libcpp.map cimport multimap
 
+# TODO: Drop after requiring Cython 3.1.0 or newer
+ctypedef const double const_double
 
 cdef extern from "cantera/kinetics/ReactionRateFactory.h" namespace "Cantera":
     cdef shared_ptr[CxxReactionRate] CxxNewReactionRate "newReactionRate" (CxxAnyMap&) except +translate_exception
@@ -57,8 +59,8 @@ cdef extern from "cantera/kinetics/TwoTempPlasmaRate.h" namespace "Cantera":
 cdef extern from "cantera/kinetics/ElectronCollisionPlasmaRate.h" namespace "Cantera":
     cdef cppclass CxxElectronCollisionPlasmaRate "Cantera::ElectronCollisionPlasmaRate" (CxxReactionRate):
         CxxElectronCollisionPlasmaRate(CxxAnyMap) except +translate_exception
-        vector[double]& energyLevels()
-        vector[double]& crossSections()
+        span[const_double] energyLevels()
+        span[const_double] crossSections()
 
 cdef extern from "cantera/base/Array.h" namespace "Cantera":
     cdef cppclass CxxArray2D "Cantera::Array2D":
@@ -131,8 +133,9 @@ cdef extern from "cantera/kinetics/Falloff.h" namespace "Cantera":
         void setLowRate(CxxArrheniusRate&) except +translate_exception
         CxxArrheniusRate& highRate()
         void setHighRate(CxxArrheniusRate&) except +translate_exception
-        void getFalloffCoeffs(vector[double]&)
-        void setFalloffCoeffs(vector[double]&) except +translate_exception
+        void getFalloffCoeffs(span[double])
+        void setFalloffCoeffs(span[double]) except +translate_exception
+        size_t nParameters()
         double evalF(double, double) except +translate_exception
 
     cdef cppclass CxxLindemannRate "Cantera::LindemannRate" (CxxFalloffRate):

--- a/samples/cxx/custom/custom.cpp
+++ b/samples/cxx/custom/custom.cpp
@@ -90,7 +90,7 @@ public:
         double rho = m_gas->density();
         double cp = m_gas->cp_mass();
         m_gas->getPartialMolarEnthalpies(m_hbar);
-        m_kinetics->getNetProductionRates(&m_wdot[0]);
+        m_kinetics->getNetProductionRates(m_wdot);
 
         /* -------------------------- ENERGY EQUATION ------------------------- */
         // the rate of change of the system temperature is found using the energy

--- a/samples/cxx/demo/demo.cpp
+++ b/samples/cxx/demo/demo.cpp
@@ -81,9 +81,9 @@ void demoprog()
     // since the gas has been set to an equilibrium state, the forward
     // and reverse rates of progress should be equal for all
     // reversible reactions, and the net rates should be zero.
-    kin->getFwdRatesOfProgress(&qf[0]);
-    kin->getRevRatesOfProgress(&qr[0]);
-    kin->getNetRatesOfProgress(&q[0]);
+    kin->getFwdRatesOfProgress(qf);
+    kin->getRevRatesOfProgress(qr);
+    kin->getNetRatesOfProgress(q);
 
     writelog("\n\n");
     for (int i = 0; i < irxns; i++) {

--- a/samples/f77/demo_ftnlib.cpp
+++ b/samples/f77/demo_ftnlib.cpp
@@ -289,32 +289,32 @@ extern "C" {
 
     void getnetproductionrates_(double* wdot)
     {
-        _kin->getNetProductionRates(wdot);
+        _kin->getNetProductionRates(span<double>(wdot, _kin->nTotalSpecies()));
     }
 
     void getcreationrates_(double* cdot)
     {
-        _kin->getCreationRates(cdot);
+        _kin->getCreationRates(span<double>(cdot, _kin->nTotalSpecies()));
     }
 
     void getdestructionrates_(double* ddot)
     {
-        _kin->getDestructionRates(ddot);
+        _kin->getDestructionRates(span<double>(ddot, _kin->nTotalSpecies()));
     }
 
     void getnetratesofprogress_(double* q)
     {
-        _kin->getNetRatesOfProgress(q);
+        _kin->getNetRatesOfProgress(span<double>(q, _kin->nReactions()));
     }
 
     void getfwdratesofprogress_(double* q)
     {
-        _kin->getFwdRatesOfProgress(q);
+        _kin->getFwdRatesOfProgress(span<double>(q, _kin->nReactions()));
     }
 
     void getrevratesofprogress_(double* q)
     {
-        _kin->getRevRatesOfProgress(q);
+        _kin->getRevRatesOfProgress(span<double>(q, _kin->nReactions()));
     }
 
     //-------------------- transport properties --------------------

--- a/src/equil/vcs_util.cpp
+++ b/src/equil/vcs_util.cpp
@@ -16,7 +16,7 @@
 namespace Cantera
 {
 
-double vcs_l2norm(const vector<double>& vec)
+double vcs_l2norm(span<const double> vec)
 {
     if (vec.empty()) {
         return 0.0;

--- a/src/fortran/fct.cpp
+++ b/src/fortran/fct.cpp
@@ -809,7 +809,7 @@ extern "C" {
     {
         try {
             Kinetics* k = _fkin(n);
-            k->getFwdRatesOfProgress(fwdROP);
+            k->getFwdRatesOfProgress(span<double>(fwdROP, k->nReactions()));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -820,7 +820,7 @@ extern "C" {
     {
         try {
             Kinetics* k = _fkin(n);
-            k->getRevRatesOfProgress(revROP);
+            k->getRevRatesOfProgress(span<double>(revROP, k->nReactions()));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -840,7 +840,7 @@ extern "C" {
     {
         try {
             Kinetics* k = _fkin(n);
-            k->getNetRatesOfProgress(netROP);
+            k->getNetRatesOfProgress(span<double>(netROP, k->nReactions()));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -851,7 +851,7 @@ extern "C" {
     {
         try {
             Kinetics* k = _fkin(n);
-            k->getCreationRates(cdot);
+            k->getCreationRates(span<double>(cdot, k->nTotalSpecies()));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -862,7 +862,7 @@ extern "C" {
     {
         try {
             Kinetics* k = _fkin(n);
-            k->getDestructionRates(ddot);
+            k->getDestructionRates(span<double>(ddot, k->nTotalSpecies()));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -873,7 +873,7 @@ extern "C" {
     {
         try {
             Kinetics* k = _fkin(n);
-            k->getNetProductionRates(wdot);
+            k->getNetProductionRates(span<double>(wdot, k->nTotalSpecies()));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -893,7 +893,7 @@ extern "C" {
     {
         try {
             Kinetics* k = _fkin(n);
-            k->getEquilibriumConstants(kc);
+            k->getEquilibriumConstants(span<double>(kc, k->nReactions()));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }

--- a/src/kinetics/ElectronCollisionPlasmaRate.cpp
+++ b/src/kinetics/ElectronCollisionPlasmaRate.cpp
@@ -77,7 +77,8 @@ void ElectronCollisionPlasmaRate::getParameters(AnyMap& node) const {
 }
 
 void ElectronCollisionPlasmaRate::updateInterpolatedCrossSection(
-    const vector<double>& sharedLevels) {
+    span<const double> sharedLevels)
+{
     m_crossSectionsInterpolated.clear();
     m_crossSectionsInterpolated.reserve(sharedLevels.size());
     for (double level : sharedLevels) {

--- a/src/kinetics/Falloff.cpp
+++ b/src/kinetics/Falloff.cpp
@@ -286,22 +286,22 @@ void TroeRate::getFalloffCoeffs(vector<double>& c) const
     c[2] = 1.0 / m_rt1;
 }
 
-void TroeRate::updateTemp(double T, double* work) const
+void TroeRate::updateTemp(double T, span<double> work) const
 {
     double Fcent = (1.0 - m_a) * exp(-T*m_rt3) + m_a * exp(-T*m_rt1);
     if (m_t2) {
         Fcent += exp(- m_t2 / T);
     }
-    *work = log10(std::max(Fcent, SmallNumber));
+    work[0] = log10(std::max(Fcent, SmallNumber));
 }
 
-double TroeRate::F(double pr, const double* work) const
+double TroeRate::F(double pr, span<const double> work) const
 {
     double lpr = log10(std::max(pr,SmallNumber));
-    double cc = -0.4 - 0.67 * (*work);
-    double nn = 0.75 - 1.27 * (*work);
+    double cc = -0.4 - 0.67 * work[0];
+    double nn = 0.75 - 1.27 * work[0];
     double f1 = (lpr + cc)/ (nn - 0.14 * (lpr + cc));
-    double lgf = (*work) / (1.0 + f1 * f1);
+    double lgf = work[0] / (1.0 + f1 * f1);
     return pow(10.0, lgf);
 }
 
@@ -394,20 +394,20 @@ void SriRate::getFalloffCoeffs(vector<double>& c) const
     c[2] = m_c;
 }
 
-void SriRate::updateTemp(double T, double* work) const
+void SriRate::updateTemp(double T, span<double> work) const
 {
-    *work = m_a * exp(- m_b / T);
+    work[0] = m_a * exp(- m_b / T);
     if (m_c != 0.0) {
-        *work += exp(- T/m_c);
+        work[0] += exp(- T/m_c);
     }
     work[1] = m_d * pow(T,m_e);
 }
 
-double SriRate::F(double pr, const double* work) const
+double SriRate::F(double pr, span<const double> work) const
 {
     double lpr = log10(std::max(pr,SmallNumber));
     double xx = 1.0/(1.0 + lpr*lpr);
-    return pow(*work, xx) * work[1];
+    return pow(work[0], xx) * work[1];
 }
 
 void SriRate::setParameters(const AnyMap& node, const UnitStack& rate_units)
@@ -488,19 +488,19 @@ void TsangRate::getFalloffCoeffs(vector<double>& c) const
     c[0] = m_a;
 }
 
-void TsangRate::updateTemp(double T, double* work) const
+void TsangRate::updateTemp(double T, span<double> work) const
 {
     double Fcent = m_a + (m_b * T);
-    *work = log10(std::max(Fcent, SmallNumber));
+    work[0] = log10(std::max(Fcent, SmallNumber));
 }
 
-double TsangRate::F(double pr, const double* work) const
+double TsangRate::F(double pr, span<const double> work) const
 {   //identical to TroeRate::F
     double lpr = log10(std::max(pr,SmallNumber));
-    double cc = -0.4 - 0.67 * (*work);
-    double nn = 0.75 - 1.27 * (*work);
+    double cc = -0.4 - 0.67 * work[0];
+    double nn = 0.75 - 1.27 * work[0];
     double f1 = (lpr + cc)/ (nn - 0.14 * (lpr + cc));
-    double lgf = (*work) / (1.0 + f1 * f1);
+    double lgf = work[0] / (1.0 + f1 * f1);
     return pow(10.0, lgf);
 }
 

--- a/src/kinetics/Group.cpp
+++ b/src/kinetics/Group.cpp
@@ -36,7 +36,7 @@ void Group::validate()
     }
 }
 
-std::ostream& Group::fmt(std::ostream& s, const vector<string>& esymbols) const
+std::ostream& Group::fmt(std::ostream& s, span<const string> esymbols) const
 {
     s << "(";
     bool first = true;

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -702,7 +702,7 @@ void InterfaceKinetics::getDerivativeSettings(AnyMap& settings) const
 }
 
 Eigen::SparseMatrix<double> InterfaceKinetics::calculateCompositionDerivatives(
-    StoichManagerN& stoich, const vector<double>& in)
+    StoichManagerN& stoich, span<const double> in)
 {
     vector<double>& outV = m_rbuf1;
     // derivatives handled by StoichManagerN

--- a/src/kinetics/InterfaceRate.cpp
+++ b/src/kinetics/InterfaceRate.cpp
@@ -20,14 +20,14 @@ void InterfaceData::update(double T)
         "Missing state information: 'InterfaceData' requires species coverages.");
 }
 
-void InterfaceData::update(double T, const vector<double>& values)
+void InterfaceData::update(double T, span<const double> values)
 {
     warn_user("InterfaceData::update",
         "This method does not update the site density.");
     ReactionData::update(T);
     sqrtT = sqrt(T);
     if (coverages.size() == 0) {
-        coverages = values;
+        coverages.assign(values.begin(), values.end());
         logCoverages.resize(values.size());
     } else if (values.size() == coverages.size()) {
         std::copy(values.begin(), values.end(), coverages.begin());

--- a/src/kinetics/InterfaceRate.cpp
+++ b/src/kinetics/InterfaceRate.cpp
@@ -209,12 +209,12 @@ void InterfaceRateBase::getCoverageDependencies(AnyMap& dependencies) const
 }
 
 void InterfaceRateBase::addCoverageDependence(const string& sp, double a, double m,
-                                              const vector<double>& e)
+                                              span<const double> e)
 {
     if (std::find(m_cov.begin(), m_cov.end(), sp) == m_cov.end()) {
         m_cov.push_back(sp);
         m_ac.push_back(a);
-        m_ec.push_back(e);
+        m_ec.emplace_back(e.begin(), e.end());
         m_mc.push_back(m);
         m_indices.clear();
     } else {
@@ -223,7 +223,7 @@ void InterfaceRateBase::addCoverageDependence(const string& sp, double a, double
     }
 }
 
-void InterfaceRateBase::setSpecies(const vector<string>& species)
+void InterfaceRateBase::setSpecies(span<const string> species)
 {
     m_indices.clear();
     for (size_t k = 0; k < m_cov.size(); k++) {

--- a/src/kinetics/ReactionPath.cpp
+++ b/src/kinetics/ReactionPath.cpp
@@ -749,8 +749,8 @@ int ReactionPathBuilder::build(Kinetics& s, const string& element,
     s.getRevRatesOfProgress(m_ropr);
 
     // species explicitly included or excluded
-    vector<string>& in_nodes = r.included();
-    vector<string>& out_nodes = r.excluded();
+    auto in_nodes = r.included();
+    auto out_nodes = r.excluded();
 
     vector<int> status(s.nTotalSpecies(), 0);
     for (size_t ni = 0; ni < in_nodes.size(); ni++) {

--- a/src/kinetics/ReactionPath.cpp
+++ b/src/kinetics/ReactionPath.cpp
@@ -142,7 +142,7 @@ void ReactionPathDiagram::add(shared_ptr<ReactionPathDiagram> d)
     add(*d.get());
 }
 
-void ReactionPathDiagram::findMajorPaths(double athreshold, size_t lda, double* a)
+void ReactionPathDiagram::findMajorPaths(double athreshold, size_t lda, span<double> a)
 {
     double netmax = 0.0;
     for (size_t n = 0; n < nNodes(); n++) {
@@ -745,8 +745,8 @@ int ReactionPathBuilder::build(Kinetics& s, const string& element,
         return -1;
     }
 
-    s.getFwdRatesOfProgress(m_ropf.data());
-    s.getRevRatesOfProgress(m_ropr.data());
+    s.getFwdRatesOfProgress(m_ropf);
+    s.getRevRatesOfProgress(m_ropr);
 
     // species explicitly included or excluded
     vector<string>& in_nodes = r.included();

--- a/src/numerics/funcs.cpp
+++ b/src/numerics/funcs.cpp
@@ -10,7 +10,7 @@
 namespace Cantera
 {
 
-double linearInterp(double x, const vector<double>& xpts, const vector<double>& fpts)
+double linearInterp(double x, span<const double> xpts, span<const double> fpts)
 {
     AssertThrowMsg(!xpts.empty(), "linearInterp", "x data empty");
     AssertThrowMsg(!fpts.empty(), "linearInterp", "f(x) data empty");

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -718,7 +718,7 @@ void ReactingSurf1D::eval(size_t jg, double* xg, double* rg,
         m_flow_right->setGas(xg + rightloc, 0);
     }
 
-    m_kin->getNetProductionRates(m_work.data());
+    m_kin->getNetProductionRates(m_work);
     double rs0 = 1.0/m_sphase->siteDensity();
 
     if (m_enabled) {

--- a/src/thermo/EEDFTwoTermApproximation.cpp
+++ b/src/thermo/EEDFTwoTermApproximation.cpp
@@ -485,8 +485,8 @@ void EEDFTwoTermApproximation::calculateTotalCrossSection()
     m_totalCrossSectionCenter.assign(m_points, 0.0);
     m_totalCrossSectionEdge.assign(m_points + 1, 0.0);
     for (size_t k = 0; k < m_phase->nCollisions(); k++) {
-        auto& x = m_phase->collisionRate(k)->energyLevels();
-        auto& y = m_phase->collisionRate(k)->crossSections();
+        auto x = m_phase->collisionRate(k)->energyLevels();
+        auto y = m_phase->collisionRate(k)->crossSections();
 
         for (size_t i = 0; i < m_points; i++) {
             m_totalCrossSectionCenter[i] += m_X_targets[m_klocTargets[k]] *
@@ -504,8 +504,8 @@ void EEDFTwoTermApproximation::calculateTotalElasticCrossSection()
     m_sigmaElastic.clear();
     m_sigmaElastic.resize(m_points, 0.0);
     for (size_t k : m_phase->kElastic()) {
-        auto& x = m_phase->collisionRate(k)->energyLevels();
-        auto& y = m_phase->collisionRate(k)->crossSections();
+        auto x = m_phase->collisionRate(k)->energyLevels();
+        auto y = m_phase->collisionRate(k)->crossSections();
         // Note:
         // moleFraction(m_kTargets[k]) <=> m_X_targets[m_klocTargets[k]]
         double mass_ratio = ElectronMass / (m_phase->molecularWeight(m_kTargets[k]) / Avogadro);
@@ -528,8 +528,8 @@ void EEDFTwoTermApproximation::setGridCache()
     m_i.resize(m_phase->nCollisions());
     for (size_t k = 0; k < m_phase->nCollisions(); k++) {
         auto& collision = m_phase->collisionRate(k);
-        auto& x = collision->energyLevels();
-        auto& y = collision->crossSections();
+        auto x = collision->energyLevels();
+        auto y = collision->crossSections();
         vector<double> eps1(m_points + 1);
         int shiftFactor = (collision->kind() == "ionization") ? 2 : 1;
 
@@ -580,7 +580,8 @@ void EEDFTwoTermApproximation::setGridCache()
         }
 
         // construct sigma_offset
-        auto x_offset = collision->energyLevels();
+        vector<double> x_offset(collision->energyLevels().begin(),
+                                collision->energyLevels().end());
         for (auto& element : x_offset) {
             element -= collision->threshold();
         }

--- a/src/thermo/PlasmaPhase.cpp
+++ b/src/thermo/PlasmaPhase.cpp
@@ -479,8 +479,10 @@ void PlasmaPhase::addCollision(shared_ptr<Reaction> collision)
         m_kInelastic.push_back(i);
     }
 
-    m_energyLevels.push_back(rate.energyLevels());
-    m_crossSections.push_back(rate.crossSections());
+    auto levels = rate.energyLevels();
+    m_energyLevels.emplace_back(levels.begin(), levels.end());
+    auto sections = rate.crossSections();
+    m_crossSections.emplace_back(sections.begin(), sections.end());
     m_eedfSolver->setGridCache();
 }
 

--- a/src/zeroD/ConstPressureMoleReactor.cpp
+++ b/src/zeroD/ConstPressureMoleReactor.cpp
@@ -64,7 +64,7 @@ void ConstPressureMoleReactor::eval(double time, double* LHS, double* RHS)
     auto imw = m_thermo->inverseMolecularWeights();
 
     if (m_chem) {
-        m_kin->getNetProductionRates(&m_wdot[0]); // "omega dot"
+        m_kin->getNetProductionRates(m_wdot); // "omega dot"
     }
 
     // external heat transfer

--- a/src/zeroD/ConstPressureReactor.cpp
+++ b/src/zeroD/ConstPressureReactor.cpp
@@ -72,7 +72,7 @@ void ConstPressureReactor::eval(double time, double* LHS, double* RHS)
     dmdt += mdot_surf;
 
     if (m_chem) {
-        m_kin->getNetProductionRates(&m_wdot[0]); // "omega dot"
+        m_kin->getNetProductionRates(m_wdot); // "omega dot"
     }
 
     for (size_t k = 0; k < m_nsp; k++) {

--- a/src/zeroD/FlowReactor.cpp
+++ b/src/zeroD/FlowReactor.cpp
@@ -55,7 +55,7 @@ void FlowReactor::getStateDae(double* y, double* ydot)
     y[3] = m_thermo->temperature();
 
     if (m_chem) {
-        m_kin->getNetProductionRates(m_wdot.data()); // "omega dot"
+        m_kin->getNetProductionRates(m_wdot); // "omega dot"
     }
 
     // set the initial coverages
@@ -179,7 +179,7 @@ void FlowReactor::evalDae(double time, double* y, double* ydot, double* residual
     m_thermo->getPartialMolarEnthalpies(m_hk);
     // get net production
     if (m_chem) {
-        m_kin->getNetProductionRates(m_wdot.data());
+        m_kin->getNetProductionRates(m_wdot);
     }
 
     // set dphi/dz variables

--- a/src/zeroD/IdealGasConstPressureMoleReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureMoleReactor.cpp
@@ -62,7 +62,7 @@ void IdealGasConstPressureMoleReactor::eval(double time, double* LHS, double* RH
     auto imw = m_thermo->inverseMolecularWeights();
 
     if (m_chem) {
-        m_kin->getNetProductionRates(&m_wdot[0]); // "omega dot"
+        m_kin->getNetProductionRates(m_wdot); // "omega dot"
     }
 
     // external heat transfer
@@ -161,7 +161,7 @@ void IdealGasConstPressureMoleReactor::getJacobianElements(
         // gas phase
         m_thermo->getPartialMolarCp(asSpan(specificHeat));
         m_thermo->getPartialMolarEnthalpies(asSpan(enthalpy));
-        m_kin->getNetProductionRates(netProductionRates.data());
+        m_kin->getNetProductionRates(asSpan(netProductionRates));
         // scale production rates by the volume for gas species
         for (size_t i = 0; i < m_nsp; i++) {
             netProductionRates[i] *= m_vol;

--- a/src/zeroD/IdealGasConstPressureReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureReactor.cpp
@@ -68,7 +68,7 @@ void IdealGasConstPressureReactor::eval(double time, double* LHS, double* RHS)
     m_thermo->getPartialMolarEnthalpies(m_hk);
 
     if (m_chem) {
-        m_kin->getNetProductionRates(&m_wdot[0]); // "omega dot"
+        m_kin->getNetProductionRates(m_wdot); // "omega dot"
     }
 
     // external heat transfer

--- a/src/zeroD/IdealGasMoleReactor.cpp
+++ b/src/zeroD/IdealGasMoleReactor.cpp
@@ -122,7 +122,7 @@ void IdealGasMoleReactor::eval(double time, double* LHS, double* RHS)
     auto imw = m_thermo->inverseMolecularWeights();
 
     if (m_chem) {
-        m_kin->getNetProductionRates(&m_wdot[0]); // "omega dot"
+        m_kin->getNetProductionRates(m_wdot); // "omega dot"
     }
 
     // external heat transfer and compression work
@@ -228,7 +228,7 @@ void IdealGasMoleReactor::getJacobianElements(vector<Eigen::Triplet<double>>& tr
         Eigen::VectorXd specificHeat = Eigen::VectorXd::Zero(m_nsp);
         // getting species data
         m_thermo->getPartialMolarIntEnergies(asSpan(internal_energy));
-        m_kin->getNetProductionRates(netProductionRates.data());
+        m_kin->getNetProductionRates(asSpan(netProductionRates));
         m_thermo->getPartialMolarCp(asSpan(specificHeat));
         // convert Cp to Cv for ideal gas as Cp - Cv = R
         for (size_t i = 0; i < m_nsp; i++) {

--- a/src/zeroD/IdealGasReactor.cpp
+++ b/src/zeroD/IdealGasReactor.cpp
@@ -66,7 +66,7 @@ void IdealGasReactor::eval(double time, double* LHS, double* RHS)
     auto Y = m_thermo->massFractions();
 
     if (m_chem) {
-        m_kin->getNetProductionRates(&m_wdot[0]); // "omega dot"
+        m_kin->getNetProductionRates(m_wdot); // "omega dot"
     }
 
     double mdot_surf = dot(m_sdot.begin(), m_sdot.end(), mw.begin());

--- a/src/zeroD/MoleReactor.cpp
+++ b/src/zeroD/MoleReactor.cpp
@@ -116,7 +116,7 @@ void MoleReactor::eval(double time, double* LHS, double* RHS)
     RHS[1] = m_vdot;
 
     if (m_chem) {
-        m_kin->getNetProductionRates(&m_wdot[0]); // "omega dot"
+        m_kin->getNetProductionRates(m_wdot); // "omega dot"
     }
 
     // Energy equation.

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -138,7 +138,7 @@ void Reactor::eval(double time, double* LHS, double* RHS)
     RHS[1] = m_vdot;
 
     if (m_chem) {
-        m_kin->getNetProductionRates(&m_wdot[0]); // "omega dot"
+        m_kin->getNetProductionRates(m_wdot); // "omega dot"
     }
 
     for (size_t k = 0; k < m_nsp; k++) {

--- a/src/zeroD/ReactorSurface.cpp
+++ b/src/zeroD/ReactorSurface.cpp
@@ -104,7 +104,7 @@ void ReactorSurface::updateState(double* y)
 {
     m_surf->setCoveragesNoNorm(span<const double>(y, m_nsp));
     m_thermo->setState_TP(m_reactors[0]->temperature(), m_reactors[0]->pressure());
-    m_kinetics->getNetProductionRates(m_sdot.data());
+    m_kinetics->getNetProductionRates(m_sdot);
 }
 
 void ReactorSurface::eval(double t, double* LHS, double* RHS)
@@ -248,7 +248,7 @@ void MoleReactorSurface::updateState(double* y)
     }
     m_surf->setCoveragesNoNorm(m_cov_tmp);
     m_thermo->setState_TP(m_reactors[0]->temperature(), m_reactors[0]->pressure());
-    m_kinetics->getNetProductionRates(m_sdot.data());
+    m_kinetics->getNetProductionRates(m_sdot);
 }
 
 void MoleReactorSurface::eval(double t, double* LHS, double* RHS)

--- a/test/clib/test_ctkin.cpp
+++ b/test/clib/test_ctkin.cpp
@@ -43,7 +43,7 @@ TEST(ctkin, kinetics)
     vector<double> c_ropf(nr);
     kin_getFwdRatesOfProgress(kin, 325, c_ropf.data());
     vector<double> cpp_ropf(nr);
-    kinetics->getFwdRatesOfProgress(cpp_ropf.data());
+    kinetics->getFwdRatesOfProgress(cpp_ropf);
 
     for (size_t n = 0; n < nr; n++) {
         ASSERT_NEAR(cpp_ropf[n], c_ropf[n], 1e-6);

--- a/test/equil/equil_gas.cpp
+++ b/test/equil/equil_gas.cpp
@@ -9,6 +9,8 @@
 #include "cantera/base/global.h"
 #include "cantera/base/utilities.h"
 
+#include <numeric>
+
 using namespace Cantera;
 
 bool double_close(double expected, double actual, double tol)
@@ -93,11 +95,13 @@ TEST_F(OverconstrainedEquil, BasisOptimize)
     mphase.addPhase(gas.get(), 10.0);
     mphase.init();
     int usedZeroedSpecies = 0;
-    vector<size_t> orderVectorSpecies;
-    vector<size_t> orderVectorElements;
+    vector<size_t> orderVectorSpecies(mphase.nSpecies());
+    vector<size_t> orderVectorElements(mphase.nElements());
+    std::iota(orderVectorSpecies.begin(), orderVectorSpecies.end(), 0);
+    std::iota(orderVectorElements.begin(), orderVectorElements.end(), 0);
 
     bool doFormMatrix = true;
-    vector<double> formRxnMatrix;
+    vector<double> formRxnMatrix(mphase.nSpecies() * mphase.nElements());
 
     size_t nc = BasisOptimize(&usedZeroedSpecies, doFormMatrix, &mphase,
                               orderVectorSpecies, orderVectorElements,
@@ -112,11 +116,13 @@ TEST_F(OverconstrainedEquil, DISABLED_BasisOptimize2)
     mphase.addPhase(gas.get(), 10.0);
     mphase.init();
     int usedZeroedSpecies = 0;
-    vector<size_t> orderVectorSpecies;
-    vector<size_t> orderVectorElements;
+    vector<size_t> orderVectorSpecies(mphase.nSpecies());
+    vector<size_t> orderVectorElements(mphase.nElements());
+    std::iota(orderVectorSpecies.begin(), orderVectorSpecies.end(), 0);
+    std::iota(orderVectorElements.begin(), orderVectorElements.end(), 0);
 
     bool doFormMatrix = true;
-    vector<double> formRxnMatrix;
+    vector<double> formRxnMatrix(mphase.nSpecies() * mphase.nElements());
 
     size_t nc = BasisOptimize(&usedZeroedSpecies, doFormMatrix, &mphase,
                               orderVectorSpecies, orderVectorElements,

--- a/test/general/test_composite.cpp
+++ b/test/general/test_composite.cpp
@@ -17,8 +17,8 @@ TEST(Solution, clone_idealgas)
     EXPECT_EQ(soln->kinetics()->nReactions(), dup->kinetics()->nReactions());
     EXPECT_EQ(soln->thermo()->name(), dup->thermo()->name());
     EXPECT_NEAR(soln->thermo()->enthalpy_mass(), dup->thermo()->enthalpy_mass(), 1e-5);
-    soln->kinetics()->getFwdRateConstants(kf1.data());
-    dup->kinetics()->getFwdRateConstants(kf2.data());
+    soln->kinetics()->getFwdRateConstants(kf1);
+    dup->kinetics()->getFwdRateConstants(kf2);
     for (size_t i = 0; i < nrxn; i++) {
         EXPECT_NEAR(kf1[i], kf2[i], 1e-12*kf1[i]);
     }
@@ -26,7 +26,7 @@ TEST(Solution, clone_idealgas)
                 dup->transport()->thermalConductivity(), 1e-11);
     dup->thermo()->setState_TP(600, OneAtm);
     EXPECT_DOUBLE_EQ(soln->thermo()->temperature(), 400.0);
-    dup->kinetics()->getFwdRateConstants(kf2.data());
+    dup->kinetics()->getFwdRateConstants(kf2);
     EXPECT_GT(kf2[2], kf1[2]);
 }
 
@@ -41,14 +41,14 @@ TEST(Solution, clone_surf_complete)
     EXPECT_DOUBLE_EQ(soln2->adjacent("gas")->thermo()->pressure(), 3*OneAtm);
 
     vector<double> ropf1(nrxn), ropf2(nrxn);
-    soln1->kinetics()->getFwdRatesOfProgress(ropf1.data());
-    soln2->kinetics()->getFwdRatesOfProgress(ropf2.data());
+    soln1->kinetics()->getFwdRatesOfProgress(ropf1);
+    soln2->kinetics()->getFwdRatesOfProgress(ropf2);
     for (size_t i = 0; i < nrxn; i++) {
         EXPECT_NEAR(ropf1[i], ropf2[i], 1e-12*ropf1[i]);
         soln2->kinetics()->setMultiplier(i, 0.0);
     }
     // Original mixture should still have same (non-zero) rates
-    soln1->kinetics()->getFwdRatesOfProgress(ropf1.data());
+    soln1->kinetics()->getFwdRatesOfProgress(ropf1);
     for (size_t i = 0; i < nrxn; i++) {
         EXPECT_NEAR(ropf1[i], ropf2[i], 1e-12*ropf1[i]);
     }
@@ -70,14 +70,14 @@ TEST(Solution, clone_surf_manual)
     EXPECT_DOUBLE_EQ(soln2->adjacent("gas")->thermo()->pressure(), 3*OneAtm);
 
     vector<double> ropf1(nrxn), ropf2(nrxn);
-    soln1->kinetics()->getFwdRatesOfProgress(ropf1.data());
-    soln2->kinetics()->getFwdRatesOfProgress(ropf2.data());
+    soln1->kinetics()->getFwdRatesOfProgress(ropf1);
+    soln2->kinetics()->getFwdRatesOfProgress(ropf2);
     for (size_t i = 0; i < nrxn; i++) {
         EXPECT_NEAR(ropf1[i], ropf2[i], 1e-12*ropf1[i]);
         soln2->kinetics()->setMultiplier(i, 0.0);
     }
     // Original mixture should still have same (non-zero) rates
-    soln1->kinetics()->getFwdRatesOfProgress(ropf1.data());
+    soln1->kinetics()->getFwdRatesOfProgress(ropf1);
     for (size_t i = 0; i < nrxn; i++) {
         EXPECT_NEAR(ropf1[i], ropf2[i], 1e-12*ropf1[i]);
     }

--- a/test/general/test_serialization.cpp
+++ b/test/general/test_serialization.cpp
@@ -183,8 +183,8 @@ TEST(YamlWriter, reactions)
 
     ASSERT_EQ(kin1->nReactions(), kin2->nReactions());
     vector<double> kf1(kin1->nReactions()), kf2(kin1->nReactions());
-    kin1->getFwdRateConstants(kf1.data());
-    kin2->getFwdRateConstants(kf2.data());
+    kin1->getFwdRateConstants(kf1);
+    kin2->getFwdRateConstants(kf2);
     for (size_t i = 0; i < kin1->nReactions(); i++) {
         EXPECT_NEAR(kf1[i], kf2[i], 1e-13 * kf1[i]) << "for reaction i = " << i;
     }
@@ -212,8 +212,8 @@ TEST(YamlWriter, reaction_units_from_Yaml)
 
     ASSERT_EQ(kin1->nReactions(), kin2->nReactions());
     vector<double> kf1(kin1->nReactions()), kf2(kin1->nReactions());
-    kin1->getFwdRateConstants(kf1.data());
-    kin2->getFwdRateConstants(kf2.data());
+    kin1->getFwdRateConstants(kf1);
+    kin2->getFwdRateConstants(kf2);
     for (size_t i = 0; i < kin1->nReactions(); i++) {
         EXPECT_NEAR(kf1[i], kf2[i], 1e-13 * kf1[i]) << "for reaction i = " << i;
     }
@@ -239,8 +239,8 @@ TEST(YamlWriter, chebyshev_units_from_Yaml)
 
     ASSERT_EQ(kin1->nReactions(), kin2->nReactions());
     vector<double> kf1(kin1->nReactions()), kf2(kin1->nReactions());
-    kin1->getFwdRateConstants(kf1.data());
-    kin2->getFwdRateConstants(kf2.data());
+    kin1->getFwdRateConstants(kf1);
+    kin2->getFwdRateConstants(kf2);
     for (size_t i = 0; i < kin1->nReactions(); i++) {
         EXPECT_NEAR(kf1[i], kf2[i], 1e-13 * kf1[i]) << "for reaction i = " << i;
     }
@@ -311,16 +311,16 @@ TEST(YamlWriter, Interface)
 
     ASSERT_EQ(kin1->nReactions(), kin2->nReactions());
     vector<double> kf1(kin1->nReactions()), kf2(kin1->nReactions());
-    kin1->getFwdRateConstants(kf1.data());
-    kin2->getFwdRateConstants(kf2.data());
+    kin1->getFwdRateConstants(kf1);
+    kin2->getFwdRateConstants(kf2);
     for (size_t i = 0; i < kin1->nReactions(); i++) {
         EXPECT_NEAR(kf1[i], kf2[i], 1e-13 * kf1[i]) << "for reaction i = " << i;
     }
 
     vector<double> wdot1(kin1->nTotalSpecies());
     vector<double> wdot2(kin2->nTotalSpecies());
-    kin1->getNetProductionRates(wdot1.data());
-    kin2->getNetProductionRates(wdot2.data());
+    kin1->getNetProductionRates(wdot1);
+    kin2->getNetProductionRates(wdot2);
     for (size_t i = 0; i < kin1->nTotalSpecies(); i++) {
         EXPECT_NEAR(wdot1[i], wdot2[i], 1e-13 * fabs(wdot1[i])) << "for species i = " << i;
     }
@@ -348,16 +348,16 @@ TEST(YamlWriter, sofc)
 
     ASSERT_EQ(tpb_kin1->nReactions(), tpb_kin2->nReactions());
     vector<double> kf1(tpb_kin1->nReactions()), kf2(tpb_kin1->nReactions());
-    tpb_kin1->getFwdRateConstants(kf1.data());
-    tpb_kin2->getFwdRateConstants(kf2.data());
+    tpb_kin1->getFwdRateConstants(kf1);
+    tpb_kin2->getFwdRateConstants(kf2);
     for (size_t i = 0; i < tpb_kin1->nReactions(); i++) {
         EXPECT_NEAR(kf1[i], kf2[i], 1e-13 * kf1[i]) << "for tpb reaction i = " << i;
     }
 
     vector<double> wdot1(tpb_kin1->nTotalSpecies());
     vector<double> wdot2(tpb_kin2->nTotalSpecies());
-    tpb_kin1->getNetProductionRates(wdot1.data());
-    tpb_kin2->getNetProductionRates(wdot2.data());
+    tpb_kin1->getNetProductionRates(wdot1);
+    tpb_kin2->getNetProductionRates(wdot2);
     for (size_t i = 0; i < tpb_kin1->nTotalSpecies(); i++) {
         EXPECT_NEAR(wdot1[i], wdot2[i], 1e-13 * fabs(wdot1[i])) << "for species i = " << i;
     }
@@ -365,16 +365,16 @@ TEST(YamlWriter, sofc)
     ASSERT_EQ(ox_kin1->nReactions(), ox_kin2->nReactions());
     kf1.resize(ox_kin1->nReactions());
     kf2.resize(ox_kin1->nReactions());
-    ox_kin1->getFwdRateConstants(kf1.data());
-    ox_kin2->getFwdRateConstants(kf2.data());
+    ox_kin1->getFwdRateConstants(kf1);
+    ox_kin2->getFwdRateConstants(kf2);
     for (size_t i = 0; i < ox_kin1->nReactions(); i++) {
         EXPECT_NEAR(kf1[i], kf2[i], 1e-13 * kf1[i]) << "for ox reaction i = " << i;
     }
 
     wdot1.resize(ox_kin1->nTotalSpecies());
     wdot2.resize(ox_kin2->nTotalSpecies());
-    ox_kin1->getNetProductionRates(wdot1.data());
-    ox_kin2->getNetProductionRates(wdot2.data());
+    ox_kin1->getNetProductionRates(wdot1);
+    ox_kin2->getNetProductionRates(wdot2);
     for (size_t i = 0; i < ox_kin1->nTotalSpecies(); i++) {
         EXPECT_NEAR(wdot1[i], wdot2[i], 1e-13 * fabs(wdot1[i])) << "for ox species i = " << i;
     }

--- a/test/kinetics/kineticsFromScratch.cpp
+++ b/test/kinetics/kineticsFromScratch.cpp
@@ -49,12 +49,12 @@ public:
 
         vector<double> k(1), k_ref(kin_ref->nReactions());
 
-        kin.getFwdRateConstants(&k[0]);
-        kin_ref->getFwdRateConstants(&k_ref[0]);
+        kin.getFwdRateConstants(k);
+        kin_ref->getFwdRateConstants(k_ref);
         EXPECT_DOUBLE_EQ(k_ref[iRef], k[0]);
 
-        kin.getRevRateConstants(&k[0]);
-        kin_ref->getRevRateConstants(&k_ref[0]);
+        kin.getRevRateConstants(k);
+        kin_ref->getRevRateConstants(k_ref);
         EXPECT_DOUBLE_EQ(k_ref[iRef], k[0]);
     }
 };
@@ -637,12 +637,12 @@ public:
 
         vector<double> k(1), k_ref(kin_ref->nReactions());
 
-        kin.getFwdRateConstants(&k[0]);
-        kin_ref->getFwdRateConstants(&k_ref[0]);
+        kin.getFwdRateConstants(k);
+        kin_ref->getFwdRateConstants(k_ref);
         EXPECT_DOUBLE_EQ(k_ref[iRef], k[0]);
 
-        kin.getRevRateConstants(&k[0]);
-        kin_ref->getRevRateConstants(&k_ref[0]);
+        kin.getRevRateConstants(k);
+        kin_ref->getRevRateConstants(k_ref);
         EXPECT_DOUBLE_EQ(k_ref[iRef], k[0]);
     }
 };
@@ -730,32 +730,32 @@ public:
         vector<double> k(kin.nReactions()), k_ref(kin_ref->nReactions());
         vector<double> w(kin.nTotalSpecies()), w_ref(kin_ref->nTotalSpecies());
 
-        kin.getFwdRateConstants(k.data());
-        kin_ref->getFwdRateConstants(k_ref.data());
+        kin.getFwdRateConstants(k);
+        kin_ref->getFwdRateConstants(k_ref);
         for (size_t i = 0; i < kin.nReactions(); i++) {
             EXPECT_DOUBLE_EQ(k_ref[i], k[i]) << "i = " << i << "; N = " << N;
         }
 
-        kin.getFwdRatesOfProgress(k.data());
-        kin_ref->getFwdRatesOfProgress(k_ref.data());
+        kin.getFwdRatesOfProgress(k);
+        kin_ref->getFwdRatesOfProgress(k_ref);
         for (size_t i = 0; i < kin.nReactions(); i++) {
             EXPECT_DOUBLE_EQ(k_ref[i], k[i]) << "i = " << i << "; N = " << N;
         }
 
-        kin.getRevRateConstants(k.data());
-        kin_ref->getRevRateConstants(k_ref.data());
+        kin.getRevRateConstants(k);
+        kin_ref->getRevRateConstants(k_ref);
         for (size_t i = 0; i < kin.nReactions(); i++) {
             EXPECT_NEAR(k_ref[i], k[i], k_ref[i]*1e-12) << "i = " << i << "; N = " << N;
         }
 
-        kin.getRevRatesOfProgress(k.data());
-        kin_ref->getRevRatesOfProgress(k_ref.data());
+        kin.getRevRatesOfProgress(k);
+        kin_ref->getRevRatesOfProgress(k_ref);
         for (size_t i = 0; i < kin.nReactions(); i++) {
             EXPECT_NEAR(k_ref[i], k[i], k_ref[i]*1e-12) << "i = " << i << "; N = " << N;
         }
 
-        kin.getCreationRates(w.data());
-        kin_ref->getCreationRates(w_ref.data());
+        kin.getCreationRates(w);
+        kin_ref->getCreationRates(w_ref);
         for (size_t i = 0; i < kin.nTotalSpecies(); i++) {
             size_t iref = pp_ref->speciesIndex(p->speciesName(i));
             EXPECT_NEAR(w_ref[iref], w[i], w_ref[iref]*1e-12) << "sp = " << p->speciesName(i) << "; N = " << N;

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -597,7 +597,7 @@ TEST(Reaction, PythonExtensibleRate)
     auto rate = R->rate();
     EXPECT_EQ(rate->type(), "square-rate");
     vector<double> kf(sol->kinetics()->nReactions());
-    sol->kinetics()->getFwdRateConstants(kf.data());
+    sol->kinetics()->getFwdRateConstants(kf);
     EXPECT_DOUBLE_EQ(kf[0], 3.14 * 300 * 300);
 }
 
@@ -710,8 +710,8 @@ TEST(Kinetics, ElectrochemFromYaml)
     auto kin = soln->kinetics();
     soln->adjacent("graphite")->thermo()->setElectricPotential(0.4);
     vector<double> ropf(kin->nReactions()), ropr(kin->nReactions());
-    kin->getFwdRatesOfProgress(ropf.data());
-    kin->getRevRatesOfProgress(ropr.data());
+    kin->getFwdRatesOfProgress(ropf);
+    kin->getRevRatesOfProgress(ropr);
 
     EXPECT_NEAR(ropf[0], 0.279762338, 1e-8);
     EXPECT_NEAR(ropr[0], 0.045559670, 1e-8);
@@ -835,10 +835,10 @@ public:
 
         vector<double> kf(kin->nReactions()), kr(kin->nReactions());
         vector<double> ropf(kin->nReactions()), ropr(kin->nReactions());
-        kin->getFwdRateConstants(kf.data());
-        kin->getRevRateConstants(kr.data());
-        kin->getFwdRatesOfProgress(ropf.data());
-        kin->getRevRatesOfProgress(ropr.data());
+        kin->getFwdRateConstants(kf);
+        kin->getRevRateConstants(kr);
+        kin->getFwdRatesOfProgress(ropf);
+        kin->getRevRatesOfProgress(ropr);
         EXPECT_NEAR(kf[iOld], kf[iNew], 1e-13 * kf[iOld]);
         EXPECT_NEAR(kr[iOld], kr[iNew], 1e-13 * kr[iOld]);
         EXPECT_NEAR(ropf[iOld], ropf[iNew], 1e-13 * ropf[iOld]);

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -335,11 +335,13 @@ TEST(Reaction, FalloffFromYaml2)
     EXPECT_DOUBLE_EQ(rate->highRate().preExponentialFactor(), 6e11);
     EXPECT_DOUBLE_EQ(rate->lowRate().preExponentialFactor(), 1.04e20);
     EXPECT_DOUBLE_EQ(rate->lowRate().activationEnergy(), 1600);
-    vector<double> params;
+    vector<double> params(rate->nParameters());
+    ASSERT_EQ(params.size(), (size_t) 4);
     rate->getFalloffCoeffs(params);
-    ASSERT_EQ(params.size(), (size_t) 3);
     EXPECT_DOUBLE_EQ(params[0], 0.562);
     EXPECT_DOUBLE_EQ(params[1], 91.0);
+    EXPECT_DOUBLE_EQ(params[2], 5836.0);
+    EXPECT_DOUBLE_EQ(params[3], 0.0);
     EXPECT_EQ(R->input["source"].asString(), "somewhere");
 }
 

--- a/test/kinetics/pdep.cpp
+++ b/test/kinetics/pdep.cpp
@@ -54,7 +54,7 @@ TEST_F(PdepTest, PlogLowPressure)
     // Test that P-log reactions have the right low-pressure limit
     set_TP(500.0, 1e-7);
     vector<double> kf(7);
-    soln_->kinetics()->getFwdRateConstants(&kf[0]);
+    soln_->kinetics()->getFwdRateConstants(kf);
 
     // Pre-exponential factor decreases by 10^3 for second-order reaction
     // when converting from cm + mol to m + kmol
@@ -74,7 +74,7 @@ TEST_F(PdepTest, PlogHighPressure)
     // Test that P-log reactions have the right high-pressure limit
     set_TP(500.0, 1e10);
     vector<double> kf(7);
-    soln_->kinetics()->getFwdRateConstants(&kf[0]);
+    soln_->kinetics()->getFwdRateConstants(kf);
 
     // Pre-exponential factor decreases by 10^3 for second-order reaction
     // when converting from cm + mol to m + kmol
@@ -91,7 +91,7 @@ TEST_F(PdepTest, PlogDuplicatePressures)
     set_TP(500.0, 1e10);
     vector<double> kf(7);
 
-    soln_->kinetics()->getFwdRateConstants(&kf[0]);
+    soln_->kinetics()->getFwdRateConstants(kf);
     double kf1 = k(1.3700e+14, -0.79, 17603.0) + k(1.2800e+03, 1.71, 9774.0);
     double kf2 = k(-7.4100e+27, -5.54, 12108.0) + k(1.9000e+12, -0.29, 8306.0);
 
@@ -105,7 +105,7 @@ TEST_F(PdepTest, PlogCornerCases)
     // is exactly of the specified interpolation values
     set_TP(500.0, 101325);
     vector<double> kf(7);
-    soln_->kinetics()->getFwdRateConstants(&kf[0]);
+    soln_->kinetics()->getFwdRateConstants(kf);
 
     double kf0 = k(4.910800e+28, -4.8507, 24772.8);
     double kf1 = k(1.2600e+17, -1.83, 15003.0) + k(1.2300e+01, 2.68, 6335.0);
@@ -120,7 +120,7 @@ TEST_F(PdepTest, PlogIntermediatePressure1)
 {
     set_TP(1100.0, 20*101325);
     vector<double> ropf(7);
-    soln_->kinetics()->getFwdRatesOfProgress(&ropf[0]);
+    soln_->kinetics()->getFwdRatesOfProgress(ropf);
 
     // Expected rates computed using Chemkin
     // ROP increases by 10**3 when converting from mol/cm3 to kmol/m3
@@ -134,7 +134,7 @@ TEST_F(PdepTest, PlogIntermediatePressure2)
 {
     set_TP(1100.0, 0.5*101325);
     vector<double> ropf(7);
-    soln_->kinetics()->getFwdRatesOfProgress(&ropf[0]);
+    soln_->kinetics()->getFwdRatesOfProgress(ropf);
 
     EXPECT_NEAR(5.244649e+02, ropf[0], 5e-2);
     EXPECT_NEAR(2.252537e+02, ropf[1], 2e-2);
@@ -146,7 +146,7 @@ TEST_F(PdepTest, PlogIntermediatePressure3)
 {
     set_TP(800.0, 70*101325);
     vector<double> ropf(7);
-    soln_->kinetics()->getFwdRatesOfProgress(&ropf[0]);
+    soln_->kinetics()->getFwdRatesOfProgress(ropf);
 
     EXPECT_NEAR(2.274501e+04, ropf[0], 1e+1);
     EXPECT_NEAR(2.307191e+05, ropf[1], 1e+2);
@@ -160,7 +160,7 @@ TEST_F(PdepTest, ChebyshevIntermediate1)
     vector<double> kf(7);
 
     set_TP(1100.0, 20 * 101325);
-    soln_->kinetics()->getFwdRateConstants(&kf[0]);
+    soln_->kinetics()->getFwdRateConstants(kf);
     // Expected rates computed using RMG-py
     EXPECT_NEAR(3.130698657e+06, kf[4], 1e-1);
     EXPECT_NEAR(1.187949573e+00, kf[5], 1e-7);
@@ -177,7 +177,7 @@ TEST_F(PdepTest, ChebyshevIntermediate2)
     vector<double> kf(7);
 
     set_TP(400.0, 0.1 * 101325);
-    soln_->kinetics()->getFwdRateConstants(&kf[0]);
+    soln_->kinetics()->getFwdRateConstants(kf);
     // Expected rates computed using RMG-py
     EXPECT_NEAR(1.713599902e+05, kf[4], 1e-3);
     EXPECT_NEAR(9.581780687e-24, kf[5], 1e-31);
@@ -189,7 +189,7 @@ TEST_F(PdepTest, ChebyshevIntermediateROP)
     set_TP(1100.0, 30 * 101325);
     vector<double> ropf(7);
     // Expected rates computed using Chemkin
-    soln_->kinetics()->getFwdRatesOfProgress(&ropf[0]);
+    soln_->kinetics()->getFwdRatesOfProgress(ropf);
     EXPECT_NEAR(4.552930e+03, ropf[4], 1e-1);
     EXPECT_NEAR(4.877390e-02, ropf[5], 1e-5);
 }
@@ -200,22 +200,22 @@ TEST_F(PdepTest, ChebyshevEdgeCases)
 
     // Minimum P
     set_TP(500.0, 1000.0);
-    soln_->kinetics()->getFwdRateConstants(&kf[0]);
+    soln_->kinetics()->getFwdRateConstants(kf);
     EXPECT_NEAR(1.225785655e+06, kf[4], 1e-2);
 
     // Maximum P
     set_TP(500.0, 1.0e7);
-    soln_->kinetics()->getFwdRateConstants(&kf[0]);
+    soln_->kinetics()->getFwdRateConstants(kf);
     EXPECT_NEAR(1.580981157e+03, kf[4], 1e-5);
 
     // Minimum T
     set_TP(300.0, 101325);
-    soln_->kinetics()->getFwdRateConstants(&kf[0]);
+    soln_->kinetics()->getFwdRateConstants(kf);
     EXPECT_NEAR(5.405987017e+03, kf[4], 1e-5);
 
     // Maximum T
     set_TP(2000.0, 101325);
-    soln_->kinetics()->getFwdRateConstants(&kf[0]);
+    soln_->kinetics()->getFwdRateConstants(kf);
     EXPECT_NEAR(3.354054351e+07, kf[4], 1e-1);
 }
 

--- a/test/kinetics/rates.cpp
+++ b/test/kinetics/rates.cpp
@@ -43,8 +43,8 @@ TEST_F(FracCoeffTest, RateConstants)
 {
     vector<double> kf(kin->nReactions(), 0.0);
     vector<double> kr(kin->nReactions(), 0.0);
-    kin->getFwdRateConstants(&kf[0]);
-    kin->getRevRateConstants(&kr[0]);
+    kin->getFwdRateConstants(kf);
+    kin->getRevRateConstants(kr);
 
     // sum of reaction orders is 1.0; kf has units of 1/s
     EXPECT_DOUBLE_EQ(1e13, kf[0]);
@@ -64,8 +64,8 @@ TEST_F(FracCoeffTest, RatesOfProgress)
     vector<double> conc(therm->nSpecies(), 0.0);
     vector<double> ropf(kin->nReactions(), 0.0);
     therm->getConcentrations(conc);
-    kin->getFwdRateConstants(&kf[0]);
-    kin->getFwdRatesOfProgress(&ropf[0]);
+    kin->getFwdRateConstants(kf);
+    kin->getFwdRatesOfProgress(ropf);
 
     EXPECT_DOUBLE_EQ(conc[kH2O]*kf[0], ropf[0]);
     EXPECT_DOUBLE_EQ(pow(conc[kH2], 0.8)*conc[kO2]*pow(conc[kOH],2)*kf[1],
@@ -77,9 +77,9 @@ TEST_F(FracCoeffTest, CreationDestructionRates)
     vector<double> ropf(kin->nReactions(), 0.0);
     vector<double> cdot(therm->nSpecies(), 0.0);
     vector<double> ddot(therm->nSpecies(), 0.0);
-    kin->getFwdRatesOfProgress(&ropf[0]);
-    kin->getCreationRates(&cdot[0]);
-    kin->getDestructionRates(&ddot[0]);
+    kin->getFwdRatesOfProgress(ropf);
+    kin->getCreationRates(cdot);
+    kin->getDestructionRates(ddot);
 
     EXPECT_DOUBLE_EQ(ropf[0], ddot[kH2O]);
     EXPECT_DOUBLE_EQ(1.4*ropf[0], cdot[kH]);
@@ -100,7 +100,7 @@ TEST_F(FracCoeffTest, EquilibriumConstants)
     vector<double> Kc(kin->nReactions(), 0.0);
     vector<double> mu0(therm->nSpecies(), 0.0);
 
-    kin->getEquilibriumConstants(&Kc[0]);
+    kin->getEquilibriumConstants(Kc);
     therm->getGibbs_ref(mu0); // at pRef
 
     double deltaG0_0 = 1.4 * mu0[kH] + 0.6 * mu0[kOH] + 0.2 * mu0[kO2] - mu0[kH2O];
@@ -131,7 +131,7 @@ public:
         ASSERT_EQ(12, (int) nSpec);
         ASSERT_EQ(12, (int) nRxn);
         vector<double> wdot(nSpec);
-        soln->kinetics()->getNetProductionRates(&wdot[0]);
+        soln->kinetics()->getNetProductionRates(wdot);
         for (size_t i = 0; i < nSpec; i++) {
             EXPECT_NEAR(wdot_ref[i], wdot[i], std::abs(wdot_ref[i])*2e-5 + 1e-9);
         }
@@ -141,8 +141,8 @@ public:
 
         vector<double> ropf(nRxn);
         vector<double> ropr(nRxn);
-        soln->kinetics()->getFwdRatesOfProgress(&ropf[0]);
-        soln->kinetics()->getRevRatesOfProgress(&ropr[0]);
+        soln->kinetics()->getFwdRatesOfProgress(ropf);
+        soln->kinetics()->getRevRatesOfProgress(ropr);
         for (size_t i = 0; i < nRxn; i++) {
             EXPECT_NEAR(ropf_ref[i], ropf[i], std::abs(ropf_ref[i])*2e-5 + 1e-9);
             EXPECT_NEAR(ropr_ref[i], ropr[i], std::abs(ropr_ref[i])*2e-5 + 1e-9);
@@ -167,7 +167,7 @@ TEST(InterfaceReaction, CoverageDependency) {
     iface->thermo()->setState_TP(T, 101325);
     iface->thermo()->setCoveragesByName("PT(S):0.7, H(S):0.3");
     vector<double> kf(iface->kinetics()->nReactions());
-    iface->kinetics()->getFwdRateConstants(&kf[0]);
+    iface->kinetics()->getFwdRateConstants(kf);
     EXPECT_NEAR(kf[0], 4.4579e7 * pow(T, 0.5), 1e-14*kf[0]);
     // Energies in XML file are converted from J/mol to J/kmol
     EXPECT_NEAR(kf[1], 3.7e20 * exp(-(67.4e6-6e6*0.3)/(GasConstant*T)), 1e-14*kf[1]);
@@ -186,7 +186,7 @@ TEST(LinearBurkeRate, RateCombinations)
     auto kf = [&](size_t iRxn, double T, double P, const string& X="P1:1.0") {
         thermo.setState_TPX(T, P, X);
         vector<double> rates(kin.nReactions());
-        kin.getFwdRateConstants(rates.data());
+        kin.getFwdRateConstants(rates);
         return rates[iRxn];
     };
 

--- a/test/python/test_mixture.py
+++ b/test/python/test_mixture.py
@@ -137,10 +137,10 @@ class TestMixture:
         assert mix.species_moles[2] == approx(S[2])
         assert mix.phase_moles(0) == approx(sum(S[:phase1.n_species]))
 
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="too small"):
             mix.species_moles = (1, 2, 3)
 
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError, match="too small"):
             mix.species_moles = 9
 
     def test_element_moles(self, mix):

--- a/test_problems/diamondSurf/runDiamond.cpp
+++ b/test_problems/diamondSurf/runDiamond.cpp
@@ -12,8 +12,6 @@ using namespace Cantera;
 
 int main(int argc, char** argv)
 {
-    int i, k;
-
     try {
         CanteraError::setStackTraceDepth(20);
         auto iface = newInterface("diamond.yaml", "diamond_100");
@@ -62,14 +60,11 @@ int main(int argc, char** argv)
         AssertThrow(p == p, "main");
         AssertThrowMsg(p == p, "main", "are you kidding");
 
-        double src[20];
-        for (i = 0; i < 20; i++) {
-            src[i] = 0.0;
-        }
+        vector<double> src(ikin->nTotalSpecies());
         ikin->getNetProductionRates(src);
         double sum = 0.0;
         double naH = 0.0;
-        for (k = 0; k < 13; k++) {
+        for (size_t k = 0; k < 13; k++) {
             if (k < 4) {
                 naH = gas->nAtoms(k, 0);
             } else if (k == 4) {
@@ -91,7 +86,7 @@ int main(int argc, char** argv)
 
         diamond100->getMoleFractions(x);
         cout << "Coverages:" << endl;
-        for (k = 0; k < 8; k++) {
+        for (size_t k = 0; k < 8; k++) {
             cout << k << "   " << diamond100->speciesName(k)
                  << "   "
                  << x[k] << endl;

--- a/test_problems/stoichSolidKinetics/stoichSolidKinetics.cpp
+++ b/test_problems/stoichSolidKinetics/stoichSolidKinetics.cpp
@@ -20,19 +20,19 @@ void printValue(const string& label, double value)
 void printRates(InterfaceKinetics& iKin)
 {
     vector<double> work(iKin.nReactions(), 0.0);
-    iKin.getNetRatesOfProgress(&work[0]);
+    iKin.getNetRatesOfProgress(work);
     printValue("ROP_net       = ", work[0]);
 
-    iKin.getFwdRatesOfProgress(&work[0]);
+    iKin.getFwdRatesOfProgress(work);
     printValue("ROP_forward   = ", work[0]);
 
-    iKin.getRevRatesOfProgress(&work[0]);
+    iKin.getRevRatesOfProgress(work);
     printValue("ROP_reverse   = ", work[0]);
 
-    iKin.getFwdRateConstants(&work[0]);
+    iKin.getFwdRateConstants(work);
     printValue("    kfwd      = ", work[0]);
 
-    iKin.getRevRateConstants(&work[0]);
+    iKin.getRevRateConstants(work);
     printValue("    krev      = ", work[0]);
 }
 
@@ -70,10 +70,10 @@ void testProblem()
          << "        CaCO3(s) =   CO2(g) +  CaO(s)  \n" << endl;
 
     for (int ktrials = 0; ktrials < 2; ktrials++) {
-        iKin.getDeltaSSGibbs(&work[0]);
+        iKin.getDeltaSSGibbs(work);
         printValue("   deltaGSS      = ", work[0]);
 
-        iKin.getDeltaGibbs(&work[0]);
+        iKin.getDeltaGibbs(work);
         printValue("   deltaG        = ", work[0]);
 
         gasTP->getChemPotentials(work);

--- a/test_problems/surfSolverTest/surfaceSolver.cpp
+++ b/test_problems/surfSolverTest/surfaceSolver.cpp
@@ -16,7 +16,8 @@ using namespace Cantera;
 
 #define MSSIZE 200
 
-void printGas(ostream& oooo, ThermoPhase* gasTP, InterfaceKinetics* iKin_ptr, double* src)
+void printGas(ostream& oooo, ThermoPhase* gasTP, InterfaceKinetics* iKin_ptr,
+              span<const double> src)
 {
     vector<double> x(gasTP->nSpecies());
     vector<double> C(gasTP->nSpecies());
@@ -48,8 +49,8 @@ void printGas(ostream& oooo, ThermoPhase* gasTP, InterfaceKinetics* iKin_ptr, do
     oooo << endl;
 }
 
-void printBulk(ostream& oooo,
-               ThermoPhase* bulkPhaseTP, InterfaceKinetics* iKin_ptr, double* src)
+void printBulk(ostream& oooo, ThermoPhase* bulkPhaseTP, InterfaceKinetics* iKin_ptr,
+               span<const double> src)
 {
     vector<double> x(bulkPhaseTP->nSpecies());
     vector<double> C(bulkPhaseTP->nSpecies());
@@ -94,8 +95,8 @@ void printBulk(ostream& oooo,
     oooo << endl;
 }
 
-void printSurf(ostream& oooo,
-               ThermoPhase* surfPhaseTP, InterfaceKinetics* iKin_ptr, double* src)
+void printSurf(ostream& oooo, ThermoPhase* surfPhaseTP, InterfaceKinetics* iKin_ptr,
+               span<const double> src)
 {
     vector<double> x(surfPhaseTP->nSpecies());
     string surfParticlePhaseName = surfPhaseTP->name();
@@ -165,16 +166,16 @@ int main(int argc, char** argv)
         /*
          * Download the source terms for the rate equations
          */
-        double src[MSSIZE];
+        vector<double> src(iKin_ptr->nTotalSpecies());
         iKin_ptr->getNetProductionRates(src);
 
         printGas(cout, gasTP, iKin_ptr, src);
         printBulk(cout, bulkPhaseTP, iKin_ptr, src);
-        printSurf(cout, surfPhaseTP, iKin_ptr, src) ;
+        printSurf(cout, surfPhaseTP, iKin_ptr, src);
 
         printGas(ofile, gasTP, iKin_ptr, src);
         printBulk(ofile, bulkPhaseTP, iKin_ptr, src);
-        printSurf(ofile, surfPhaseTP, iKin_ptr, src) ;
+        printSurf(ofile, surfPhaseTP, iKin_ptr, src);
         /*****************************************************************************/
         /*  Now Tweak the inputs and do a quick calculation */
         /****************************************************************************/


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

This PR continues the work started in #2077 toward implementing https://github.com/Cantera/enhancements/issues/237, updating the classes that are in the `kinetics` and `equil` directories.

**AI Statement (required)**

- **Extensive use of generative AI.**
  Significant portions of code or documentation were generated with AI, including logic and implementation decisions. All generated code and documentation were reviewed and understood by the contributor. *Primarily done using GPT-Codex-5.2 within the Codex extension for VS Code*.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
