### PR TITLE
Tweaks to simplify working with coding agents

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 *.hdf binary
 *.hdf5 binary
 *.h5 binary
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true -diff

--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ environment.y*
 coverage/
 coverage.info
 .coverage
+# pixi environments
+.pixi/*
+!.pixi/config.toml

--- a/SConstruct
+++ b/SConstruct
@@ -992,7 +992,10 @@ def get_processor_name():
     elif platform.system() == "Darwin":
         os.environ['PATH'] = os.environ['PATH'] + os.pathsep + '/usr/sbin'
         command ="sysctl -n machdep.cpu.brand_string"
-        return subprocess.check_output(command, shell=True).decode().strip()
+        try:
+            return subprocess.check_output(command, shell=True).decode().strip()
+        except subprocess.CalledProcessError:
+            return "<unknown processor>"
     elif platform.system() == "Linux":
         command = "lscpu || cat /proc/cpuinfo"
         all_info = subprocess.check_output(command, shell=True).decode().strip()

--- a/include/cantera/equil/vcs_VolPhase.h
+++ b/include/cantera/equil/vcs_VolPhase.h
@@ -368,8 +368,8 @@ public:
 
     //! Get a constant form of the Species Formula Matrix
     /*!
-     *  Returns a `double**` pointer such that `fm[e][f]` is the formula
-     *  matrix entry for element `e` for species `k`
+     * Returns a matrix `M` where `M(k, e)` is the entry for element `e` and
+     * species `k`.
      */
     const Array2D& getFormulaMatrix() const;
 

--- a/include/cantera/kinetics/Group.h
+++ b/include/cantera/kinetics/Group.h
@@ -127,9 +127,6 @@ public:
 
     std::ostream& fmt(std::ostream& s, const vector<string>& esymbols) const;
 
-    friend std::ostream& operator<<(std::ostream& s,
-                                    const Group& g);
-
 private:
     vector<int> m_comp;
     int m_sign;

--- a/src/base/stringUtils.cpp
+++ b/src/base/stringUtils.cpp
@@ -121,8 +121,9 @@ Composition parseCompString(const string& ss, const vector<string>& names)
 double fpValue(const string& val)
 {
     double rval;
+    static const auto locale = std::locale("C");
     std::stringstream ss(val);
-    ss.imbue(std::locale("C"));
+    ss.imbue(locale);
     ss >> rval;
     return rval;
 }

--- a/src/kinetics/Group.cpp
+++ b/src/kinetics/Group.cpp
@@ -57,14 +57,4 @@ std::ostream& Group::fmt(std::ostream& s, const vector<string>& esymbols) const
     return s;
 }
 
-std::ostream& operator<<(std::ostream& s, const Group& g)
-{
-    if (g.valid()) {
-        s << g.m_comp;
-    } else {
-        s << "<none>";
-    }
-    return s;
-}
-
 }


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Provide workaround for calling `sysctl`, which is not allowed within Codex's sandbox
- Avoid repeated instantiations of `std::locale` objects which slowed down running tests within Codex's sandbox
- Add a couple of configuration modifications to make working with [Pixi](https://pixi.prefix.dev/latest/) easier. These are just the changes that `pixi init` wants to make to already-tracked files. I'm holding off on adding `pixi.toml` or `pixi.lock` files for the time being. The motivation for this is in part that I think it's a little easier to get agents to run build and test commands when they don't have to figure out what Conda environment they're supposed to activate.
- A couple of other minor changes that I didn't want to roll into #2085.

**AI Statement (required)**

- **No generative AI was used.** This contribution was written entirely without AI assistance.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
