### PR TITLE
Updates to make HP queries return values instead of failing for higher pressures

### DIFF
--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -13,6 +13,8 @@
 #include "cantera/base/utilities.h"
 #include "cantera/base/global.h"
 
+#include <algorithm>
+
 using namespace std;
 
 namespace Cantera
@@ -841,6 +843,11 @@ int MixtureFugacityTP::solveCubic(double T, double pres, double a, double b,
     }
 
     double tmp;
+    auto physicalRoot = [b](double v) {
+        // For cubic EoS, physically admissible roots satisfy V > b and V > 0.
+        double vmin = std::max(0.0, b * (1.0 + 1e-12));
+        return std::isfinite(v) && v > vmin;
+    };
     // One real root -> have to determine whether gas or liquid is the root
     if (disc > 0.0) {
         double tmpD = sqrt(disc);
@@ -921,6 +928,11 @@ int MixtureFugacityTP::solveCubic(double T, double pres, double a, double b,
     // Find an accurate root, since there might be a heavy amount of roundoff error due to bad conditioning in this solver.
     double res, dresdV = 0.0;
     for (int i = 0; i < nSolnValues; i++) {
+        if (!physicalRoot(Vroot[i])) {
+            // Non-physical roots (for example, negative molar volume) are not
+            // used for state selection and should not trigger convergence errors.
+            continue;
+        }
         for (int n = 0; n < 20; n++) {
             res = an * Vroot[i] * Vroot[i] * Vroot[i] + bn * Vroot[i] * Vroot[i] + cn * Vroot[i] + dn;
             if (fabs(res) < 1.0E-14) { // accurate root is obtained
@@ -945,6 +957,11 @@ int MixtureFugacityTP::solveCubic(double T, double pres, double a, double b,
                                "root failed to converge for T = {}, p = {} with "
                                "V = {}", T, pres, Vroot[i]);
         }
+    }
+    if (nSolnValues == 1 && !physicalRoot(Vroot[0])) {
+        throw CanteraError("MixtureFugacityTP::solveCubic",
+                           "single real root is non-physical for T = {}, p = {} "
+                           "(V = {}, b = {})", T, pres, Vroot[0], b);
     }
 
     if (nSolnValues == 1) {

--- a/src/thermo/PengRobinson.cpp
+++ b/src/thermo/PengRobinson.cpp
@@ -83,12 +83,15 @@ void PengRobinson::setBinaryCoeffs(const string& species_i,
 double PengRobinson::cp_mole() const
 {
     _updateReferenceStateThermo();
+    double cpref = GasConstant * mean_X(m_cp0_R);
+    if (m_b == 0.0) {
+        return cpref;
+    }
     double T = temperature();
     double mv = molarVolume();
     double vpb = mv + (1 + Sqrt2) * m_b;
     double vmb = mv + (1 - Sqrt2) * m_b;
     calculatePressureDerivatives();
-    double cpref = GasConstant * mean_X(m_cp0_R);
     double dHdT_V = cpref + mv * m_dpdT - GasConstant
                     + 1.0 / (2.0 * Sqrt2 * m_b) * log(vpb / vmb) * T * d2aAlpha_dT2();
     return dHdT_V - (mv + T * m_dpdT / m_dpdV) * m_dpdT;
@@ -97,6 +100,10 @@ double PengRobinson::cp_mole() const
 double PengRobinson::cv_mole() const
 {
     _updateReferenceStateThermo();
+    double cvref = GasConstant * (mean_X(m_cp0_R) - 1.0);
+    if (m_b == 0.0) {
+        return cvref;
+    }
     double T = temperature();
     calculatePressureDerivatives();
     return (cp_mole() + T * m_dpdT * m_dpdT / m_dpdV);
@@ -121,6 +128,12 @@ double PengRobinson::standardConcentration(size_t k) const
 void PengRobinson::getActivityCoefficients(span<double> ac) const
 {
     checkArraySize("PengRobinson::getActivityCoefficients", ac.size(), m_kk);
+    for (size_t k = 0; k < m_kk; k++) {
+        ac[k] = 1.0;
+    }
+    if (m_b == 0.0) {
+        return;
+    }
     double mv = molarVolume();
     double vpb2 = mv + (1 + Sqrt2) * m_b;
     double vmb2 = mv + (1 - Sqrt2) * m_b;
@@ -154,11 +167,14 @@ void PengRobinson::getActivityCoefficients(span<double> ac) const
 
 void PengRobinson::getChemPotentials(span<double> mu) const
 {
-    getGibbs_ref(mu);
     double RT_ = RT();
+    getStandardChemPotentials(mu);
     for (size_t k = 0; k < m_kk; k++) {
         double xx = std::max(SmallNumber, moleFraction(k));
-        mu[k] += RT_ * (log(xx));
+        mu[k] += RT_ * log(xx);
+    }
+    if (m_b == 0.0) {
+        return;
     }
 
     double mv = molarVolume();
@@ -173,14 +189,13 @@ void PengRobinson::getChemPotentials(span<double> mu) const
         }
     }
     double pres = pressure();
-    double refP = refPressure();
     double denom = 2 * Sqrt2 * m_b * m_b;
     double denom2 = m_b * (mv * mv + 2 * mv * m_b - m_b * m_b);
 
     for (size_t k = 0; k < m_kk; k++) {
         double num = 2 * m_b * m_pp[k] - m_aAlpha_mix * m_b_coeffs[k];
 
-        mu[k] += RT_ * log(pres/refP) - RT_ * log(pres * mv / RT_)
+        mu[k] += - RT_ * log(pres * mv / RT_)
                  + RT_ * log(mv / vmb) + RT_ * m_b_coeffs[k] / vmb
                  - (num /denom) * log(vpb2/vmb2)
                  - m_aAlpha_mix * m_b_coeffs[k] * mv/denom2;
@@ -192,6 +207,9 @@ void PengRobinson::getPartialMolarEnthalpies(span<double> hbar) const
     // First we get the reference state contributions
     getEnthalpy_RT_ref(hbar);
     scale(hbar.begin(), hbar.end(), hbar.begin(), RT());
+    if (m_b == 0.0) {
+        return;
+    }
     vector<double> tmp;
     tmp.resize(m_kk,0.0);
 
@@ -444,6 +462,9 @@ void PengRobinson::getSpeciesParameters(const string& name, AnyMap& speciesNode)
 
 double PengRobinson::sresid() const
 {
+    if (m_b == 0.0) {
+        return 0.0;
+    }
     double molarV = molarVolume();
     double hh = m_b / molarV;
     double zz = z();
@@ -457,6 +478,9 @@ double PengRobinson::sresid() const
 
 double PengRobinson::hresid() const
 {
+    if (m_b == 0.0) {
+        return 0.0;
+    }
     double molarV = molarVolume();
     double zz = z();
     double aAlpha_1 = daAlpha_dT();

--- a/src/thermo/PengRobinson.cpp
+++ b/src/thermo/PengRobinson.cpp
@@ -10,6 +10,7 @@
 #include "cantera/base/utilities.h"
 
 #include <boost/algorithm/string.hpp>
+#include <algorithm>
 
 namespace Cantera
 {
@@ -542,6 +543,39 @@ double PengRobinson::densityCalc(double T, double presPa, int phaseRequested,
 
     double volGuess = mmw / rhoGuess;
     m_NSolns = solveCubic(T, presPa, m_a, m_b, m_aAlpha_mix, m_Vroot);
+
+    // Ensure root ordering used for branch selection only contains physical roots.
+    // This avoids selecting negative-volume roots in mixed-parameter mechanisms.
+    double vmin = std::max(0.0, m_b * (1.0 + 1e-12));
+    vector<double> physicalRoots;
+    for (double root : m_Vroot) {
+        if (std::isfinite(root) && root > vmin) {
+            physicalRoots.push_back(root);
+        }
+    }
+    std::sort(physicalRoots.begin(), physicalRoots.end());
+    if (physicalRoots.empty()) {
+        return -1.0;
+    } else if (physicalRoots.size() == 1) {
+        // Preserve branch-request semantics for single-root states:
+        // return -2 when the requested phase is inconsistent with the
+        // single branch identified by solveCubic() sign convention.
+        if ((phaseRequested == FLUID_GAS && m_NSolns < 0)
+            || (phaseRequested >= FLUID_LIQUID_0 && m_NSolns > 0))
+        {
+            return -2.0;
+        }
+        // Otherwise, accept the physically admissible root directly.
+        return mmw / physicalRoots[0];
+    } else if (physicalRoots.size() == 2) {
+        m_Vroot[0] = physicalRoots[0];
+        m_Vroot[1] = 0.5 * (physicalRoots[0] + physicalRoots[1]);
+        m_Vroot[2] = physicalRoots[1];
+    } else {
+        m_Vroot[0] = physicalRoots[0];
+        m_Vroot[1] = physicalRoots[1];
+        m_Vroot[2] = physicalRoots[2];
+    }
 
     double molarVolLast = m_Vroot[0];
     if (m_NSolns >= 2) {

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -85,12 +85,15 @@ void RedlichKwongMFTP::setBinaryCoeffs(const string& species_i, const string& sp
 double RedlichKwongMFTP::cp_mole() const
 {
     _updateReferenceStateThermo();
+    double cpref = GasConstant * mean_X(m_cp0_R);
+    if (m_b_current == 0.0) {
+        return cpref;
+    }
     double TKelvin = temperature();
     double sqt = sqrt(TKelvin);
     double mv = molarVolume();
     double vpb = mv + m_b_current;
     pressureDerivatives();
-    double cpref = GasConstant * mean_X(m_cp0_R);
     double dadt = da_dt();
     double fac = TKelvin * dadt - 3.0 * m_a_current / 2.0;
     double dHdT_V = (cpref + mv * dpdT_ - GasConstant - 1.0 / (2.0 * m_b_current * TKelvin * sqt) * log(vpb/mv) * fac
@@ -101,11 +104,14 @@ double RedlichKwongMFTP::cp_mole() const
 double RedlichKwongMFTP::cv_mole() const
 {
     _updateReferenceStateThermo();
+    double cvref = GasConstant * (mean_X(m_cp0_R) - 1.0);
+    if (m_b_current == 0.0) {
+        return cvref;
+    }
     double TKelvin = temperature();
     double sqt = sqrt(TKelvin);
     double mv = molarVolume();
     double vpb = mv + m_b_current;
-    double cvref = GasConstant * (mean_X(m_cp0_R) - 1.0);
     double dadt = da_dt();
     double fac = TKelvin * dadt - 3.0 * m_a_current / 2.0;
     return (cvref - 1.0/(2.0 * m_b_current * TKelvin * sqt) * log(vpb/mv)*fac
@@ -132,6 +138,12 @@ double RedlichKwongMFTP::standardConcentration(size_t k) const
 void RedlichKwongMFTP::getActivityCoefficients(span<double> ac) const
 {
     checkArraySize("RedlichKwongMFTP::getActivityCoefficients", ac.size(), m_kk);
+    for (size_t k = 0; k < m_kk; k++) {
+        ac[k] = 1.0;
+    }
+    if (m_b_current == 0.0) {
+        return;
+    }
     double mv = molarVolume();
     double sqt = sqrt(temperature());
     double vpb = mv + m_b_current;
@@ -164,10 +176,13 @@ void RedlichKwongMFTP::getActivityCoefficients(span<double> ac) const
 
 void RedlichKwongMFTP::getChemPotentials(span<double> mu) const
 {
-    getGibbs_ref(mu);
+    getStandardChemPotentials(mu);
     for (size_t k = 0; k < m_kk; k++) {
         double xx = std::max(SmallNumber, moleFraction(k));
-        mu[k] += RT()*(log(xx));
+        mu[k] += RT() * log(xx);
+    }
+    if (m_b_current == 0.0) {
+        return;
     }
 
     double mv = molarVolume();
@@ -183,10 +198,9 @@ void RedlichKwongMFTP::getChemPotentials(span<double> mu) const
         }
     }
     double pres = pressure();
-    double refP = refPressure();
 
     for (size_t k = 0; k < m_kk; k++) {
-        mu[k] += (RT() * log(pres/refP) - RT() * log(pres * mv / RT())
+        mu[k] += (- RT() * log(pres * mv / RT())
                   + RT() * log(mv / vmb)
                   + RT() * b_vec_Curr_[k] / vmb
                   - 2.0 * m_pp[k] / (m_b_current * sqt) * log(vpb/mv)
@@ -201,6 +215,9 @@ void RedlichKwongMFTP::getPartialMolarEnthalpies(span<double> hbar) const
     // First we get the reference state contributions
     getEnthalpy_RT_ref(hbar);
     scale(hbar.begin(), hbar.end(), hbar.begin(), RT());
+    if (m_b_current == 0.0) {
+        return;
+    }
 
     // We calculate dpdni_
     double TKelvin = temperature();
@@ -248,11 +265,15 @@ void RedlichKwongMFTP::getPartialMolarEntropies(span<double> sbar) const
     double TKelvin = temperature();
     double sqt = sqrt(TKelvin);
     double mv = molarVolume();
-    double refP = refPressure();
+    double pres = pressure();
+    double logPres = log(pres / refPressure());
 
     for (size_t k = 0; k < m_kk; k++) {
         double xx = std::max(SmallNumber, moleFraction(k));
-        sbar[k] += GasConstant * (- log(xx));
+        sbar[k] -= GasConstant * (log(xx) + logPres);
+    }
+    if (m_b_current == 0.0) {
+        return;
     }
     for (size_t k = 0; k < m_kk; k++) {
         m_pp[k] = 0.0;
@@ -274,21 +295,20 @@ void RedlichKwongMFTP::getPartialMolarEntropies(span<double> sbar) const
     double vmb = mv - m_b_current;
     double vpb = mv + m_b_current;
     for (size_t k = 0; k < m_kk; k++) {
-        sbar[k] -=(GasConstant * log(GasConstant * TKelvin / (refP * mv))
-                   + GasConstant
-                   + GasConstant * log(mv/vmb)
-                   + GasConstant * b_vec_Curr_[k]/vmb
-                   + m_pp[k]/(m_b_current * TKelvin * sqt) * log(vpb/mv)
-                   - 2.0 * m_workS[k]/(m_b_current * sqt) * log(vpb/mv)
-                   + b_vec_Curr_[k] / (m_b_current * m_b_current * sqt) * log(vpb/mv) * fac
-                   - 1.0 / (m_b_current * sqt) * b_vec_Curr_[k] / vpb * fac
-                  );
+        sbar[k] += (GasConstant * log(pres * mv / RT())
+                    - GasConstant
+                    - GasConstant * log(mv/vmb)
+                    - GasConstant * b_vec_Curr_[k]/vmb
+                    - m_pp[k]/(m_b_current * TKelvin * sqt) * log(vpb/mv)
+                    + 2.0 * m_workS[k]/(m_b_current * sqt) * log(vpb/mv)
+                    - b_vec_Curr_[k] / (m_b_current * m_b_current * sqt) * log(vpb/mv) * fac
+                    + 1.0 / (m_b_current * sqt) * b_vec_Curr_[k] / vpb * fac);
     }
 
     pressureDerivatives();
     getPartialMolarVolumes(m_partialMolarVolumes);
     for (size_t k = 0; k < m_kk; k++) {
-        sbar[k] -= -m_partialMolarVolumes[k] * dpdT_;
+        sbar[k] += m_partialMolarVolumes[k] * dpdT_;
     }
 }
 
@@ -505,6 +525,9 @@ void RedlichKwongMFTP::getSpeciesParameters(const string& name,
 
 double RedlichKwongMFTP::sresid() const
 {
+    if (m_b_current == 0.0) {
+        return 0.0;
+    }
     // note this agrees with tpx
     double rho = density();
     double mmw = meanMolecularWeight();
@@ -521,6 +544,9 @@ double RedlichKwongMFTP::sresid() const
 
 double RedlichKwongMFTP::hresid() const
 {
+    if (m_b_current == 0.0) {
+        return 0.0;
+    }
     // note this agrees with tpx
     double rho = density();
     double mmw = meanMolecularWeight();

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -10,6 +10,7 @@
 #include "cantera/base/utilities.h"
 
 #include <boost/algorithm/string.hpp>
+#include <algorithm>
 
 namespace Cantera
 {
@@ -612,6 +613,38 @@ double RedlichKwongMFTP::densityCalc(double TKelvin, double presPa, int phaseReq
 
     double volguess = mmw / rhoguess;
     NSolns_ = solveCubic(TKelvin, presPa, m_a_current, m_b_current, Vroot_);
+
+    // Ensure root ordering used for branch selection only contains physical roots.
+    double vmin = std::max(0.0, m_b_current * (1.0 + 1e-12));
+    vector<double> physicalRoots;
+    for (double root : Vroot_) {
+        if (std::isfinite(root) && root > vmin) {
+            physicalRoots.push_back(root);
+        }
+    }
+    std::sort(physicalRoots.begin(), physicalRoots.end());
+    if (physicalRoots.empty()) {
+        return -1.0;
+    } else if (physicalRoots.size() == 1) {
+        // Preserve branch-request semantics for single-root states:
+        // return -2 when the requested phase is inconsistent with the
+        // single branch identified by solveCubic() sign convention.
+        if ((phaseRequested == FLUID_GAS && NSolns_ < 0)
+            || (phaseRequested >= FLUID_LIQUID_0 && NSolns_ > 0))
+        {
+            return -2.0;
+        }
+        // Otherwise, accept the physically admissible root directly.
+        return mmw / physicalRoots[0];
+    } else if (physicalRoots.size() == 2) {
+        Vroot_[0] = physicalRoots[0];
+        Vroot_[1] = 0.5 * (physicalRoots[0] + physicalRoots[1]);
+        Vroot_[2] = physicalRoots[1];
+    } else {
+        Vroot_[0] = physicalRoots[0];
+        Vroot_[1] = physicalRoots[1];
+        Vroot_[2] = physicalRoots[2];
+    }
 
     double molarVolLast = Vroot_[0];
     if (NSolns_ >= 2) {

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -1042,6 +1042,35 @@ class TestThermoPhase:
             name="zero-params-rk",
         )
 
+    @pytest.mark.parametrize(
+        "temperature,pressure,composition",
+        [
+            (
+                198.5,
+                6.0e7,
+                [
+                    0.13124237144841314,
+                    0.10978856515950584,
+                    0.13745471373026613,
+                    0.23651613973352531,
+                    0.25457002638236204,
+                    0.06814754884267295,
+                    0.062280634703254616,
+                ],
+            ),
+            (220.0, 6.0e7, [0.2, 0.08, 0.12, 0.2, 0.25, 0.1, 0.05]),
+            (260.0, 6.0e7, [0.1, 0.2, 0.1, 0.2, 0.2, 0.1, 0.1]),
+            (240.0, 4.0e7, [0.12, 0.14, 0.14, 0.2, 0.22, 0.08, 0.1]),
+            (300.0, 2.0e7, [0.2, 0.1, 0.15, 0.2, 0.2, 0.1, 0.05]),
+        ],
+    )
+    def test_partial_lookup_pr_state_setting(self, temperature, pressure, composition):
+        gas = self._partial_lookup_peng_robinson_phase()
+        gas.TPX = temperature, pressure, np.array(composition)
+        assert np.isfinite(gas.density)
+        assert gas.density > 0.0
+        assert gas.P == approx(pressure)
+
     def test_partial_lookup_pr_zero_ab_properties_finite(self):
         gas = self._partial_lookup_peng_robinson_phase()
         gas.TPX = 500.0, 1.0e6, "CO2:0.333, H2O:0.666"

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -993,6 +993,82 @@ class TestThermoPhase:
 
         assert abs(gas.P - evaluated_pressure) < 1e-6
 
+    def _partial_lookup_peng_robinson_phase(self):
+        """
+        Build a mixed-parameter Peng-Robinson phase:
+        - CH4 / O2 use critical-property lookup
+        - all other species use ideal-like PR placeholders (a=b=0)
+        """
+        species = ct.Species.list_from_file("co2_PR_example.yaml")
+        phase_species = []
+        for sp in species:
+            data = dict(sp.input_data)
+            if data["name"] in {"CH4", "O2"}:
+                data.pop("equation-of-state", None)
+            else:
+                data["equation-of-state"] = {
+                    "model": "Peng-Robinson",
+                    "a": 0.0,
+                    "b": 0.0,
+                    "acentric-factor": 0.0,
+                }
+            phase_species.append(ct.Species.from_dict(data))
+
+        return ct.Solution(
+            thermo="Peng-Robinson",
+            kinetics="bulk",
+            species=phase_species,
+            reactions=[],
+            name="partial-lookup-pr",
+        )
+
+    def _zero_param_redlich_kwong_phase(self):
+        species = ct.Species.list_from_file("co2_RK_example.yaml")
+        phase_species = []
+        for sp in species:
+            data = dict(sp.input_data)
+            data["equation-of-state"] = {
+                "model": "Redlich-Kwong",
+                "a": 0.0,
+                "b": 0.0,
+            }
+            phase_species.append(ct.Species.from_dict(data))
+
+        return ct.Solution(
+            thermo="Redlich-Kwong",
+            kinetics="bulk",
+            species=phase_species,
+            reactions=[],
+            name="zero-params-rk",
+        )
+
+    def test_partial_lookup_pr_zero_ab_properties_finite(self):
+        gas = self._partial_lookup_peng_robinson_phase()
+        gas.TPX = 500.0, 1.0e6, "CO2:0.333, H2O:0.666"
+
+        assert np.isfinite(gas.enthalpy_mole)
+        assert np.isfinite(gas.int_energy_mole)
+        assert np.isfinite(gas.entropy_mole)
+        assert np.isfinite(gas.cp_mole)
+        assert np.isfinite(gas.cv_mole)
+        assert np.allclose(gas.activity_coefficients, 1.0)
+        assert np.all(np.isfinite(gas.chemical_potentials))
+
+    def test_zero_ab_redlich_kwong_properties_finite(self):
+        gas = self._zero_param_redlich_kwong_phase()
+        gas.TPX = 500.0, 1.0e6, {
+            gas.species_names[0]: 0.5,
+            gas.species_names[1]: 0.5,
+        }
+
+        assert np.isfinite(gas.enthalpy_mole)
+        assert np.isfinite(gas.int_energy_mole)
+        assert np.isfinite(gas.entropy_mole)
+        assert np.isfinite(gas.cp_mole)
+        assert np.isfinite(gas.cv_mole)
+        assert np.allclose(gas.activity_coefficients, 1.0)
+        assert np.all(np.isfinite(gas.chemical_potentials))
+
 
 @pytest.fixture(scope='function')
 def setup_thermo_tests(request):

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -1071,6 +1071,28 @@ class TestThermoPhase:
         assert gas.density > 0.0
         assert gas.P == approx(pressure)
 
+    @pytest.mark.parametrize("p", [2.0e7, 4.0e7, 6.0e7])
+    def test_partial_lookup_pr_high_pressure_equilibrate(self, p):
+        gas = self._partial_lookup_peng_robinson_phase()
+
+        fuel_temp = 255.0
+        oxidizer_temp = 142.0
+
+        gas.TPY = fuel_temp, p, "CH4:1.0"
+        yin_f = gas.Y
+        gas.TPY = oxidizer_temp, p, "O2:1.0"
+        yin_o = gas.Y
+        zst = 1.0 / (1.0 + gas.stoich_air_fuel_ratio(yin_f, yin_o, "mass"))
+        yst = zst * yin_f + (1.0 - zst) * yin_o
+
+        tbar = 0.5 * (fuel_temp + oxidizer_temp)
+        gas.TPY = tbar, p, yst
+        gas.equilibrate("HP")
+
+        assert np.isfinite(gas.T)
+        assert gas.T > tbar
+        assert gas.P == approx(p)
+
     def test_partial_lookup_pr_zero_ab_properties_finite(self):
         gas = self._partial_lookup_peng_robinson_phase()
         gas.TPX = 500.0, 1.0e6, "CO2:0.333, H2O:0.666"

--- a/test/thermo/PengRobinson_Test.cpp
+++ b/test/thermo/PengRobinson_Test.cpp
@@ -1,10 +1,27 @@
 #include "gtest/gtest.h"
 #include "cantera/thermo/PengRobinson.h"
+#include "cantera/thermo/MixtureFugacityTP.h"
 #include "cantera/thermo/ThermoFactory.h"
+
+#include <cmath>
 
 
 namespace Cantera
 {
+
+namespace
+{
+class TestablePengRobinson : public PengRobinson
+{
+public:
+    using PengRobinson::densityCalc;
+
+    TestablePengRobinson()
+        : PengRobinson("../data/thermo-models.yaml", "CO2-PR")
+    {
+    }
+};
+}
 
 class PengRobinson_Test : public testing::Test
 {
@@ -177,6 +194,43 @@ TEST_F(PengRobinson_Test, CoolPropValidate)
         test_phase->setState_TP(temp, p);
         EXPECT_NEAR(test_phase->density(),rhoCoolProp[i],1.e-5);
     }
+}
+
+TEST_F(PengRobinson_Test, forcedGasBranchPreventsCrossing)
+{
+    auto mix = std::dynamic_pointer_cast<MixtureFugacityTP>(test_phase);
+    ASSERT_TRUE(mix);
+    set_r(1.0);
+
+    mix->setForcedSolutionBranch(FLUID_UNDEFINED);
+    test_phase->setState_TP(400.0, 1.0e6);
+    ASSERT_LT(mix->reportSolnBranchActual(), FLUID_LIQUID_0);
+
+    mix->setForcedSolutionBranch(FLUID_GAS);
+    try {
+        test_phase->setState_TP(240.0, 4.0e7);
+        FAIL() << "Expected forced gas branch to reject liquid-side state.";
+    } catch (CanteraError& err) {
+        EXPECT_NE(string(err.what()).find("wrong state"), string::npos);
+    }
+
+    mix->setForcedSolutionBranch(FLUID_UNDEFINED);
+    test_phase->setState_TP(240.0, 4.0e7);
+    EXPECT_GE(mix->reportSolnBranchActual(), FLUID_LIQUID_0);
+}
+
+TEST(PengRobinson, densityCalcFiltersNearIdealRoots)
+{
+    TestablePengRobinson test;
+    test.setSpeciesCoeffs("CO2", 1.0e-4, 1.0e-11, 0.0);
+    test.setState_TPX(300.0, 1.0e5, "CO2:1.0");
+
+    double rhoGas = test.densityCalc(300.0, 1.0e5, FLUID_GAS, -1.0);
+    double rhoIdeal = test.meanMolecularWeight() * 1.0e5 / (GasConstant * 300.0);
+    ASSERT_TRUE(std::isfinite(rhoGas));
+    EXPECT_GT(rhoGas, 0.0);
+    EXPECT_NEAR(rhoGas, rhoIdeal, 1e-8 * rhoIdeal);
+    EXPECT_LT(test.densityCalc(300.0, 1.0e5, FLUID_LIQUID_0, -1.0), 0.0);
 }
 
 TEST(PengRobinson, lookupSpeciesProperties)

--- a/test/thermo/RedlichKwongMFTP_Test.cpp
+++ b/test/thermo/RedlichKwongMFTP_Test.cpp
@@ -1,7 +1,10 @@
 #include "gtest/gtest.h"
 #include "cantera/thermo/RedlichKwongMFTP.h"
+#include "cantera/thermo/MixtureFugacityTP.h"
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/thermo/Species.h"
+
+#include <cmath>
 
 
 namespace Cantera
@@ -145,6 +148,43 @@ TEST_F(RedlichKwongMFTP_Test, localCritProperties)
     test_phase->setState_TPX(400, 1.2e6, "H2O: 1.0");
     EXPECT_NEAR(test_phase->critTemperature(), 647.096, 1e-5);
     EXPECT_NEAR(test_phase->critPressure(), 22.064e6, 1e-4);
+}
+
+TEST_F(RedlichKwongMFTP_Test, forcedGasBranchPreventsCrossing)
+{
+    auto mix = std::dynamic_pointer_cast<MixtureFugacityTP>(test_phase);
+    ASSERT_TRUE(mix);
+    set_r(1.0);
+
+    mix->setForcedSolutionBranch(FLUID_UNDEFINED);
+    test_phase->setState_TP(400.0, 1.0e6);
+    ASSERT_LT(mix->reportSolnBranchActual(), FLUID_LIQUID_0);
+
+    mix->setForcedSolutionBranch(FLUID_GAS);
+    try {
+        test_phase->setState_TP(240.0, 4.0e7);
+        FAIL() << "Expected forced gas branch to reject liquid-side state.";
+    } catch (CanteraError& err) {
+        EXPECT_NE(string(err.what()).find("wrong state"), string::npos);
+    }
+
+    mix->setForcedSolutionBranch(FLUID_UNDEFINED);
+    test_phase->setState_TP(240.0, 4.0e7);
+    EXPECT_GE(mix->reportSolnBranchActual(), FLUID_LIQUID_0);
+}
+
+TEST(RedlichKwongMFTP, densityCalcFiltersNearIdealRoots)
+{
+    RedlichKwongMFTP test("co2_RK_example.yaml");
+    test.setSpeciesCoeffs("CO2", 1.0e-4, 0.0, 1.0e-12);
+    test.setState_TPX(300.0, 1.0e5, "CO2:1.0");
+
+    double rhoGas = test.densityCalc(300.0, 1.0e5, FLUID_GAS, -1.0);
+    double rhoIdeal = test.meanMolecularWeight() * 1.0e5 / (GasConstant * 300.0);
+    ASSERT_TRUE(std::isfinite(rhoGas));
+    EXPECT_GT(rhoGas, 0.0);
+    EXPECT_NEAR(rhoGas, rhoIdeal, 1e-8 * rhoIdeal);
+    EXPECT_LT(test.densityCalc(300.0, 1.0e5, FLUID_LIQUID_0, -1.0), 0.0);
 }
 
 };

--- a/test/thermo/cubicSolver_Test.cpp
+++ b/test/thermo/cubicSolver_Test.cpp
@@ -115,5 +115,16 @@ TEST_F(cubicSolver_Test, solve_cubic)
     p = peng_robinson_phase->pressure();
     EXPECT_NEAR(p, pCrit, 1);
 }
+
+TEST_F(cubicSolver_Test, solve_cubic_nonphysical_single_root_when_b_zero)
+{
+    auto* peng_robinson_phase = dynamic_cast<PengRobinson*>(test_phase.get());
+    ASSERT_TRUE(peng_robinson_phase != nullptr);
+
+    double Vroot[3];
+    EXPECT_THROW(
+        peng_robinson_phase->solveCubic(300.0, 1.0e5, 2.0e7, 0.0, 2.0e7, Vroot),
+        CanteraError);
+}
 #endif
 };


### PR DESCRIPTION
I was running a test case for a 1D counterflow diffusion flame at very high pressures using the Peng-Robinson equation of state, and the initial condition that used the HP equilibrate call return EoS failures. Codex 5.3 identified this as a possible reason for why the real/ideal gas mixed PREOS might be failing, and it did resolve the EoS that was happening for high pressure H-P equilibrate calls.


**AI Statement (required)**

- **Extensive use of generative AI.**
  Significant portions of code or documentation were generated with AI, including
  logic and implementation decisions. All generated code and documentation were
  reviewed and understood by the contributor. Examples: Output from agentic coding
  tools and/or substantial refactoring by LLMs (web-based or local).

For additional information on Cantera's AI policy, see
https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md#restrictions-on-generative-ai-usage -->


