### PR TITLE
Convert reactor and 1D flame solvers to use std::span

### DIFF
--- a/include/cantera/base/Delegator.h
+++ b/include/cantera/base/Delegator.h
@@ -185,58 +185,61 @@ public:
         *m_funcs_v_csr_vp[name] = makeDelegate(func, when, *m_funcs_v_csr_vp[name]);
     }
 
-    //! Set delegates for member functions with the signature `void(double*)`
+    //! Set delegates for member functions with the signature `void(span<double>)`
     void setDelegate(const string& name,
-                     const function<void(std::array<size_t, 1>, double*)>& func,
+                     const function<void(std::array<size_t, 1>, span<double>)>& func,
                      const string& when)
     {
         if (!m_funcs_v_dp.count(name)) {
             throw NotImplementedError("Delegator::setDelegate",
-                "for function named '{}' with signature 'void(double*)'.", name);
+                "for function named '{}' with signature 'void(span<double>)'.", name);
         }
         *m_funcs_v_dp[name] = makeDelegate(func, when, *m_funcs_v_dp[name]);
     }
 
-    //! Set delegates for member functions with the signature `void(double, double*)`
+    //! Set delegates for member functions with the signature
+    //! `void(double, span<double>)`
     void setDelegate(
         const string& name,
-        const function<void(std::array<size_t, 1>, double, double*)>& func,
+        const function<void(std::array<size_t, 1>, double, span<double>)>& func,
         const string& when)
     {
         if (!m_funcs_v_d_dp.count(name)) {
             throw NotImplementedError("Delegator::setDelegate",
-                "for function named '{}' with signature 'void(double, double*)'.",
+                "for function named '{}' with signature 'void(double, span<double>)'.",
                 name);
         }
         *m_funcs_v_d_dp[name] = makeDelegate(func, when, *m_funcs_v_d_dp[name]);
     }
 
     //! Set delegates for member functions with the signature
-    //! `void(double, double*, double*)`
+    //! `void(double, span<double>, span<double>)`
     void setDelegate(
         const string& name,
-        const function<void(std::array <size_t, 2>, double, double*, double*)>& func,
+        const function<void(std::array <size_t, 2>, double, span<double>,
+                            span<double>)>& func,
         const string& when)
     {
         if (!m_funcs_v_d_dp_dp.count(name)) {
             throw NotImplementedError("Delegator::setDelegate",
                 "for function named '{}' with signature "
-                "'void(double, double*, double*)'.", name);
+                "'void(double, span<double>, span<double>)'.", name);
         }
         *m_funcs_v_d_dp_dp[name] = makeDelegate(func, when, *m_funcs_v_d_dp_dp[name]);
     }
 
     //! Set delegates for member functions with the signature
-    //! `void(double*, double*, double*)`
+    //! `void(span<double>, span<double>, span<double>)`
     void setDelegate(
         const string& name,
-        const function<void(std::array<size_t, 3>, double*, double*, double*)>& func,
+        const function<void(std::array<size_t, 3>, span<double>, span<double>,
+                            span<double>)>& func,
         const string& when)
     {
         if (!m_funcs_v_dp_dp_dp.count(name)) {
             throw NotImplementedError("Delegator::setDelegate",
                 "for function named '{}' with signature "
-                "'void(double*, double*, double*)'.", name);
+                "'void(span<double>, span<double>, span<double>)'.", name);
         }
         *m_funcs_v_dp_dp_dp[name] = makeDelegate(func, when, *m_funcs_v_dp_dp_dp[name]);
     }
@@ -348,39 +351,43 @@ protected:
         m_funcs_v_csr_vp[name] = &target;
     }
 
-    //! Install a function with the signature `void(double*)` as being delegatable
+    //! Install a function with the signature `void(span<double>)` as being delegatable
     void install(const string& name,
-                 function<void(std::array<size_t, 1>, double*)>& target,
-                 const function<void(std::array<size_t, 1>, double*)>& func)
+                 function<void(std::array<size_t, 1>, span<double>)>& target,
+                 const function<void(std::array<size_t, 1>, span<double>)>& func)
     {
         target = func;
         m_funcs_v_dp[name] = &target;
     }
 
-    //! Install a function with the signature `void(double, double*)` as being delegatable
+    //! Install a function with the signature `void(double, span<double>)` as being delegatable
     void install(const string& name,
-                 function<void(std::array<size_t, 1>, double, double*)>& target,
-                 const function<void(std::array<size_t, 1>, double, double*)>& func)
+                 function<void(std::array<size_t, 1>, double, span<double>)>& target,
+                 const function<void(std::array<size_t, 1>, double, span<double>)>& func)
     {
         target = func;
         m_funcs_v_d_dp[name] = &target;
     }
 
-    //! Install a function with the signature `void(double, double*, double*)` as being
-    //! delegatable
+    //! Install a function with the signature `void(double, span<double>, span<double>)`
+    //! as being delegatable
     void install(const string& name,
-                 function<void(std::array<size_t, 2>, double, double*, double*)>& target,
-                 const function<void(std::array<size_t, 2>, double, double*, double*)>& func)
+                 function<void(std::array<size_t, 2>, double, span<double>,
+                               span<double>)>& target,
+                 const function<void(std::array<size_t, 2>, double, span<double>,
+                               span<double>)>& func)
     {
         target = func;
         m_funcs_v_d_dp_dp[name] = &target;
     }
 
     //! Install a function with the signature
-    //! `void(double*, double*, double*)` as being delegatable
+    //! `void(span<double>, span<double>, span<double>)` as being delegatable
     void install(const string& name,
-                 function<void(std::array<size_t, 3>, double*, double*, double*)>& target,
-                 const function<void(std::array<size_t, 3>, double*, double*, double*)>& base)
+                 function<void(std::array<size_t, 3>, span<double>, span<double>,
+                               span<double>)>& target,
+                 const function<void(std::array<size_t, 3>, span<double>, span<double>,
+                               span<double>)>& base)
     {
         target = base;
         m_funcs_v_dp_dp_dp[name] = &target;
@@ -516,7 +523,7 @@ protected:
     //! - `US` for `UnitStack`
     //! - prefix `c` for `const` arguments
     //! - suffix `r` for reference arguments
-    //! - suffix `p` for pointer arguments
+    //! - suffix `p` for span arguments
     //! @{
 
     // Delegates with no return value
@@ -526,12 +533,14 @@ protected:
     map<string, function<void(AnyMap&)>*> m_funcs_v_AMr;
     map<string, function<void(const AnyMap&, const UnitStack&)>*> m_funcs_v_cAMr_cUSr;
     map<string, function<void(const string&, void*)>*> m_funcs_v_csr_vp;
-    map<string, function<void(std::array<size_t, 1>, double*)>*> m_funcs_v_dp;
-    map<string, function<void(std::array<size_t, 1>, double, double*)>*> m_funcs_v_d_dp;
+    map<string, function<void(std::array<size_t, 1>, span<double>)>*> m_funcs_v_dp;
+    map<string, function<void(std::array<size_t, 1>, double, span<double>)>*> m_funcs_v_d_dp;
     map<string,
-        function<void(std::array<size_t, 2>, double, double*, double*)>*> m_funcs_v_d_dp_dp;
+        function<void(std::array<size_t, 2>, double, span<double>,
+                      span<double>)>*> m_funcs_v_d_dp_dp;
     map<string,
-        function<void(std::array<size_t, 3>, double*, double*, double*)>*> m_funcs_v_dp_dp_dp;
+        function<void(std::array<size_t, 3>, span<double>, span<double>,
+                      span<double>)>*> m_funcs_v_dp_dp_dp;
 
     // Delegates with a return value
     map<string, function<double(void*)>> m_base_d_vp;

--- a/include/cantera/base/utilities.h
+++ b/include/cantera/base/utilities.h
@@ -176,10 +176,9 @@ void checkFinite(const double tmp);
 /*!
  * Throws an exception if any element is NaN, +Inf, or -Inf
  * @param name    Name to be used in the exception message if the check fails
- * @param values  Array of *N* values to be checked
- * @param N       Number of elements in *values*
+ * @param values  Array of values to be checked
  */
-void checkFinite(const string& name, const double* values, size_t N);
+void checkFinite(const string& name, span<const double> values);
 
 //! Const accessor for a value in a map.
 /*

--- a/include/cantera/numerics/AdaptivePreconditioner.h
+++ b/include/cantera/numerics/AdaptivePreconditioner.h
@@ -28,7 +28,7 @@ public:
     void initialize(size_t networkSize) override;
     const string type() const override { return "Adaptive"; }
     void factorize() override;
-    void solve(const size_t stateSize, double* rhs_vector, double* output) override;
+    void solve(span<const double> rhs_vector, span<double> output) override;
     void stateAdjustment(vector<double>& state) override;
 
     int info() const override {

--- a/include/cantera/numerics/CVodesIntegrator.h
+++ b/include/cantera/numerics/CVodesIntegrator.h
@@ -31,7 +31,7 @@ public:
      */
     CVodesIntegrator();
     ~CVodesIntegrator() override;
-    void setTolerances(double reltol, size_t n, double* abstol) override;
+    void setTolerances(double reltol, span<const double> abstol) override;
     void setTolerances(double reltol, double abstol) override;
     void setSensitivityTolerances(double reltol, double abstol) override;
     void initialize(double t0, FuncEval& func) override;
@@ -39,8 +39,8 @@ public:
     void integrate(double tout) override;
     double step(double tout) override;
     double& solution(size_t k) override;
-    double* solution() override;
-    double* derivative(double tout, int n) override;
+    span<double> solution() override;
+    span<double> derivative(double tout, int n) override;
     int lastOrder() const override;
     int nEquations() const  override{
         return static_cast<int>(m_neq);

--- a/include/cantera/numerics/EigenSparseDirectJacobian.h
+++ b/include/cantera/numerics/EigenSparseDirectJacobian.h
@@ -18,7 +18,7 @@ public:
     EigenSparseDirectJacobian() = default;
     const string type() const override { return "eigen-sparse-direct"; }
     void factorize() override;
-    void solve(const size_t stateSize, double* rhs_vector, double* output) override;
+    void solve(span<const double> rhs_vector, span<double> output) override;
 
 protected:
     Eigen::SparseLU<Eigen::SparseMatrix<double>> m_solver;

--- a/include/cantera/numerics/EigenSparseJacobian.h
+++ b/include/cantera/numerics/EigenSparseJacobian.h
@@ -21,7 +21,7 @@ public:
     void reset() override;
     void setValue(size_t row, size_t col, double value) override;
     void updatePreconditioner() override;
-    void updateTransient(double rdt, int* mask) override;
+    void updateTransient(double rdt, span<const int> mask) override;
 
     //! Set all Jacobian elements. Replaces the existing elements.
     void setFromTriplets(const vector<Eigen::Triplet<double>>& trips) {

--- a/include/cantera/numerics/FuncEval.h
+++ b/include/cantera/numerics/FuncEval.h
@@ -41,7 +41,8 @@ public:
      * @param[out] ydot rate of change of solution vector, length neq()
      * @param[in] p sensitivity parameter vector, length nparams()
      */
-    virtual void eval(double t, double* y, double* ydot, double* p) {
+    virtual void eval(double t, span<const double> y, span<double> ydot,
+                      span<const double> p) {
         throw NotImplementedError("FuncEval::eval");
     }
 
@@ -49,18 +50,18 @@ public:
      * Evaluate the right-hand-side DAE function. Called by the integrator.
      * @param[in] t time.
      * @param[in] y solution vector, length neq()
-     * @param[out] ydot rate of change of solution vector, length neq()
+     * @param[in] ydot rate of change of solution vector, length neq()
      * @param[in] p sensitivity parameter vector, length nparams()
      * @param[out] residual the DAE residuals, length nparams()
      */
-    virtual void evalDae(double t, double* y, double* ydot, double* p,
-                         double* residual) {
+    virtual void evalDae(double t, span<const double> y, span<const double> ydot,
+                         span<const double> p, span<double> residual) {
         throw NotImplementedError("FuncEval::evalDae");
     }
 
     //! Given a vector of length neq(), mark which variables should be
     //! considered algebraic constraints
-    virtual void getConstraints(double* constraints) {
+    virtual void getConstraints(span<double> constraints) {
         throw NotImplementedError("FuncEval::getConstraints");
     }
 
@@ -73,7 +74,7 @@ public:
      *  @returns 0 for a successful evaluation; 1 after a potentially-
      *      recoverable error; -1 after an unrecoverable error.
      */
-    int evalNoThrow(double t, double* y, double* ydot);
+    int evalNoThrow(double t, span<const double> y, span<double> ydot);
 
     //! Evaluate the right-hand side using return code to indicate status.
     /*!
@@ -84,7 +85,8 @@ public:
      *  @returns 0 for a successful evaluation; 1 after a potentially-
      *      recoverable error; -1 after an unrecoverable error.
      */
-    int evalDaeNoThrow(double t, double* y, double* ydot, double* residual);
+    int evalDaeNoThrow(double t, span<const double> y, span<const double> ydot,
+                       span<double> residual);
 
     /**
      * Evaluate the setup processes for the Jacobian preconditioner.
@@ -94,7 +96,7 @@ public:
      * @warning This function is an experimental part of the %Cantera API and may be
      * changed or removed without notice.
      */
-    virtual void preconditionerSetup(double t, double* y, double gamma) {
+    virtual void preconditionerSetup(double t, span<const double> y, double gamma) {
         throw NotImplementedError("FuncEval::preconditionerSetup");
     }
 
@@ -105,7 +107,7 @@ public:
      * @warning This function is an experimental part of the %Cantera API and may be
      * changed or removed without notice.
      */
-    virtual void preconditionerSolve(double* rhs, double* output) {
+    virtual void preconditionerSolve(span<const double> rhs, span<double> output) {
         throw NotImplementedError("FuncEval::preconditionerSolve");
     }
 
@@ -124,7 +126,7 @@ public:
      * @warning This function is an experimental part of the %Cantera API and may be
      * changed or removed without notice.
      */
-    int preconditioner_setup_nothrow(double t, double* y, double gamma);
+    int preconditioner_setup_nothrow(double t, span<const double> y, double gamma);
 
     /**
      * Preconditioner solve that doesn't throw an error but returns a
@@ -135,7 +137,7 @@ public:
      * @warning This function is an experimental part of the %Cantera API and may be
      * changed or removed without notice.
      */
-    int preconditioner_solve_nothrow(double* rhs, double* output);
+    int preconditioner_solve_nothrow(span<const double> rhs, span<double> output);
 
     //! Number of event/root functions exposed to the integrator.
     //! 0 indicates root finding is disabled.
@@ -152,22 +154,22 @@ public:
      * @param[out] gout Array of length nRootFunctions() to be filled with the
      *      values of the root functions
      */
-    virtual void evalRootFunctions(double t, const double* y, double* gout) { }
+    virtual void evalRootFunctions(double t, span<const double> y, span<double> gout) {}
 
     //! Wrapper for evalRootFunctions that converts exceptions to return codes.
     //! @returns 0 for a successful evaluation, 1 after a potentially-
     //!     recoverable error, or -1 after an unrecoverable error.
-    int evalRootFunctionsNoThrow(double t, const double* y, double* gout);
+    int evalRootFunctionsNoThrow(double t, span<const double> y, span<double> gout);
 
     //! Fill in the vector *y* with the current state of the system.
     //! Used for getting the initial state for ODE systems.
-    virtual void getState(double* y) {
+    virtual void getState(span<double> y) {
         throw NotImplementedError("FuncEval::getState");
     }
 
     //! Fill in the vectors *y* and *ydot* with the current state of the system.
     //! Used for getting the initial state for DAE systems.
-    virtual void getStateDae(double* y, double* ydot) {
+    virtual void getStateDae(span<double> y, span<double> ydot) {
         throw NotImplementedError("FuncEval::getStateDae");
     }
 

--- a/include/cantera/numerics/IdasIntegrator.h
+++ b/include/cantera/numerics/IdasIntegrator.h
@@ -31,7 +31,7 @@ public:
      */
     IdasIntegrator();
     ~IdasIntegrator() override;
-    void setTolerances(double reltol, size_t n, double* abstol) override;
+    void setTolerances(double reltol, span<const double> abstol) override;
     void setTolerances(double reltol, double abstol) override;
     void setSensitivityTolerances(double reltol, double abstol) override;
     void setLinearSolverType(const string& linearSolverType) override;
@@ -40,7 +40,7 @@ public:
     void integrate(double tout) override;
     double step(double tout) override;
     double& solution(size_t k) override;
-    double* solution() override;
+    span<double> solution() override;
     int nEquations() const override {
         return static_cast<int>(m_neq);
     }

--- a/include/cantera/numerics/Integrator.h
+++ b/include/cantera/numerics/Integrator.h
@@ -120,12 +120,11 @@ public:
 
     //! Solve a linear system Ax=b where A is the preconditioner
     /*!
-     * @param[in] stateSize length of the rhs and output vectors
      * @param[in] rhs right hand side vector used in linear system
      * @param[out] output output vector for solution
      */
-    virtual void preconditionerSolve(size_t stateSize, double* rhs, double* output) {
-        m_preconditioner->solve(stateSize, rhs, output);
+    virtual void preconditionerSolve(span<const double> rhs, span<double> output) {
+        m_preconditioner->solve(rhs, output);
     }
 
     //! Return the side of the system on which the preconditioner is applied

--- a/include/cantera/numerics/Integrator.h
+++ b/include/cantera/numerics/Integrator.h
@@ -54,11 +54,9 @@ public:
     //! Set error tolerances.
     /*!
      * @param reltol scalar relative tolerance
-     * @param n      Number of equations
-     * @param abstol array of N absolute tolerance values
+     * @param abstol vector of absolute tolerance values, length nEquations().
      */
-    virtual void setTolerances(double reltol, size_t n,
-                               double* abstol) {
+    virtual void setTolerances(double reltol, span<const double> abstol) {
         warn("setTolerances");
     }
 
@@ -183,15 +181,15 @@ public:
     }
 
     //! The current value of the solution of the system of equations.
-    virtual double* solution() {
+    virtual span<double> solution() {
         warn("solution");
-        return 0;
+        return {};
     }
 
     //! n-th derivative of the output function at time tout.
-    virtual double* derivative(double tout, int n) {
+    virtual span<double> derivative(double tout, int n) {
         warn("derivative");
-        return 0;
+        return {};
     }
 
     //! Order used during the last solution step

--- a/include/cantera/numerics/SystemJacobian.h
+++ b/include/cantera/numerics/SystemJacobian.h
@@ -86,7 +86,7 @@ public:
     //! @f$ \alpha @f$.
     //! @param rdt  Reciprocal of the time step [1/s]
     //! @param mask  Mask for transient terms: 1 if transient, 0 if algebraic.
-    virtual void updateTransient(double rdt, int* mask) {
+    virtual void updateTransient(double rdt, span<const int> mask) {
         throw NotImplementedError("SystemJacobian::updateTransient");
     }
 
@@ -96,10 +96,9 @@ public:
     //! matrix, depending on whether updateTransient() or updatePreconditioner() was
     //! called last.
     //!
-    //! @param[in] stateSize length of the rhs and output vectors
     //! @param[in] rhs_vector right hand side vector used in linear system
     //! @param[out] output output vector for solution
-    virtual void solve(const size_t stateSize, double* rhs_vector, double* output) {
+    virtual void solve(span<const double> rhs_vector, span<double> output) {
         throw NotImplementedError("SystemJacobian::solve");
     };
 

--- a/include/cantera/numerics/sundials_headers.h
+++ b/include/cantera/numerics/sundials_headers.h
@@ -1,6 +1,7 @@
 #ifndef CT_SUNDIALS_HEADERS
 #define CT_SUNDIALS_HEADERS
 
+#include "cantera/base/ct_defs.h"
 #include "sundials/sundials_types.h"
 #include "sundials/sundials_math.h"
 #include "sundials/sundials_nvector.h"
@@ -31,5 +32,16 @@
 #define IDA_SV 2
 
 typedef long int sd_size_t;
+
+namespace Cantera
+{
+
+//! Access a SUNDIALS `N_Vector` as a `span<double>`
+inline span<double> asSpan(N_Vector v)
+{
+    return span<double>(NV_DATA_S(v), NV_LENGTH_S(v));
+}
+
+}
 
 #endif

--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -78,7 +78,7 @@ public:
     }
 
     //! Set the mole fractions by specifying an array.
-    virtual void setMoleFractions(const double* xin) {
+    virtual void setMoleFractions(span<const double> xin) {
         throw NotImplementedError("Boundary1D::setMoleFractions");
     }
 
@@ -107,7 +107,7 @@ public:
         return m_mdot;
     }
 
-    void setupGrid(size_t n, const double* z) override {}
+    void setupGrid(span<const double> z) override {}
 
     void fromArray(const shared_ptr<SolutionArray>& arr) override;
 
@@ -160,21 +160,22 @@ public:
 
     void setTemperature(double T) override;
 
-    void show(const double* x) override;
+    void show(span<const double> x) override;
 
     size_t nSpecies() override {
         return m_nsp;
     }
 
     void setMoleFractions(const string& xin) override;
-    void setMoleFractions(const double* xin) override;
+    void setMoleFractions(span<const double> xin) override;
     double massFraction(size_t k) override {
         return m_yin[k];
     }
 
     void updateState(size_t loc) override;
     void init() override;
-    void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
+    void eval(size_t jg, span<const double> xg, span<double> rg, span<int> diagg,
+              double rdt) override;
     shared_ptr<SolutionArray> toArray(bool normalize=false) override;
     void fromArray(const shared_ptr<SolutionArray>& arr) override;
 
@@ -214,11 +215,12 @@ public:
         return "empty";
     }
 
-    void show(const double* x) override {}
+    void show(span<const double> x) override {}
 
     void init() override;
 
-    void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
+    void eval(size_t jg, span<const double> xg, span<double> rg, span<int> diagg,
+              double rdt) override;
 
     shared_ptr<SolutionArray> toArray(bool normalize=false) override;
 };
@@ -249,7 +251,8 @@ public:
 
     void init() override;
 
-    void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
+    void eval(size_t jg, span<const double> xg, span<double> rg, span<int> diagg,
+              double rdt) override;
 
     shared_ptr<SolutionArray> toArray(bool normalize=false) override;
 };
@@ -280,7 +283,8 @@ public:
 
     void init() override;
 
-    void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
+    void eval(size_t jg, span<const double> xg, span<double> rg, span<int> diagg,
+              double rdt) override;
 
     shared_ptr<SolutionArray> toArray(bool normalize=false) override;
 };
@@ -305,20 +309,21 @@ public:
         return "outlet-reservoir";
     }
 
-    void show(const double* x) override {}
+    void show(span<const double> x) override {}
 
     size_t nSpecies() override {
         return m_nsp;
     }
 
     void setMoleFractions(const string& xin) override;
-    void setMoleFractions(const double* xin) override;
+    void setMoleFractions(span<const double> xin) override;
     double massFraction(size_t k) override {
         return m_yres[k];
     }
 
     void init() override;
-    void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
+    void eval(size_t jg, span<const double> xg, span<double> rg, span<int> diagg,
+              double rdt) override;
     shared_ptr<SolutionArray> toArray(bool normalize=false) override;
     void fromArray(const shared_ptr<SolutionArray>& arr) override;
 
@@ -355,10 +360,11 @@ public:
     }
 
     void init() override;
-    void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
+    void eval(size_t jg, span<const double> xg, span<double> rg, span<int> diagg,
+              double rdt) override;
     shared_ptr<SolutionArray> toArray(bool normalize=false) override;
     void fromArray(const shared_ptr<SolutionArray>& arr) override;
-    void show(const double* x) override;
+    void show(span<const double> x) override;
 };
 
 
@@ -395,23 +401,24 @@ public:
     size_t componentIndex(const string& name, bool checkAlias=true) const override;
 
     void init() override;
-    void resetBadValues(double* xg) override;
+    void resetBadValues(span<double> xg) override;
 
-    void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
+    void eval(size_t jg, span<const double> xg, span<double> rg, span<int> diagg,
+              double rdt) override;
 
     double value(const string& component) const override;
     shared_ptr<SolutionArray> toArray(bool normalize=false) override;
     void fromArray(const shared_ptr<SolutionArray>& arr) override;
 
-    void _getInitialSoln(double* x) override {
-        m_sphase->getCoverages(span<double>(x, m_nsp));
+    void _getInitialSoln(span<double> x) override {
+        m_sphase->getCoverages(x);
     }
 
-    void _finalize(const double* x) override {
-        std::copy(x, x+m_nsp, m_fixed_cov.begin());
+    void _finalize(span<const double> x) override {
+        std::copy(x.begin(), x.end(), m_fixed_cov.begin());
     }
 
-    void show(const double* x) override;
+    void show(span<const double> x) override;
 
 protected:
     InterfaceKinetics* m_kin = nullptr; //!< surface kinetics mechanism

--- a/include/cantera/oneD/IonFlow.h
+++ b/include/cantera/oneD/IonFlow.h
@@ -53,9 +53,8 @@ public:
      * If in the future the class GasTransport is improved, this method may
      * be discarded. This method specifies this profile.
      */
-    void setElectronTransport(vector<double>& tfix,
-                              vector<double>& diff_e,
-                              vector<double>& mobi_e);
+    void setElectronTransport(span<const double> tfix, span<const double> diff_e,
+                              span<const double> mobi_e);
 
 protected:
 
@@ -81,7 +80,7 @@ protected:
      *
      * For argument explanation, see evalContinuity() base class.
      */
-    void evalElectricField(double* x, double* rsd, int* diag,
+    void evalElectricField(span<const double> x, span<double> rsd, span<int> diag,
                            double rdt, size_t jmin, size_t jmax) override;
 
     /**
@@ -94,16 +93,16 @@ protected:
      *
      * For argument explanation, see evalContinuity() base class.
      */
-    void evalSpecies(double* x, double* rsd, int* diag,
+    void evalSpecies(span<const double> x, span<double> rsd, span<int> diag,
                      double rdt, size_t jmin, size_t jmax) override;
-    void updateTransport(double* x, size_t j0, size_t j1) override;
-    void updateDiffFluxes(const double* x, size_t j0, size_t j1) override;
+    void updateTransport(span<const double> x, size_t j0, size_t j1) override;
+    void updateDiffFluxes(span<const double> x, size_t j0, size_t j1) override;
     //! Solving phase one: the fluxes of charged species are turned off and the electric
     //! field is not solved.
-    void frozenIonMethod(const double* x, size_t j0, size_t j1);
+    void frozenIonMethod(span<const double> x, size_t j0, size_t j1);
     //! Solving phase two: the electric field equation is added coupled
     //! by the electrical drift
-    void electricFieldMethod(const double* x, size_t j0, size_t j1);
+    void electricFieldMethod(span<const double> x, size_t j0, size_t j1);
     //! flag for solving electric field or not
     bool m_do_electric_field = false;
 
@@ -136,22 +135,22 @@ protected:
     size_t m_kElectron = npos;
 
     //! electric field [V/m]
-    double E(const double* x, size_t j) const {
+    double E(span<const double> x, size_t j) const {
         return x[index(c_offset_E, j)];
     }
 
     //! Axial gradient of the electric field [V/m²]
-    double dEdz(const double* x, size_t j) const {
+    double dEdz(span<const double> x, size_t j) const {
         return (E(x,j)-E(x,j-1))/(z(j)-z(j-1));
     }
 
     //! number density [molecules/m³]
-    double ND(const double* x, size_t k, size_t j) const {
+    double ND(span<const double> x, size_t k, size_t j) const {
         return Avogadro * m_rho[j] * Y(x,k,j) / m_wt[k];
     }
 
     //! total charge density
-    double rho_e(double* x, size_t j) const {
+    double rho_e(span<const double> x, size_t j) const {
         double chargeDensity = 0.0;
         for (size_t k : m_kCharge) {
             chargeDensity += m_speciesCharge[k] * ElectronCharge * ND(x,k,j);

--- a/include/cantera/oneD/MultiJac.h
+++ b/include/cantera/oneD/MultiJac.h
@@ -30,7 +30,7 @@ public:
     void setValue(size_t row, size_t col, double value) override;
     void initialize(size_t nVars) override;
     void setBandwidth(size_t bw) override;
-    void updateTransient(double rdt, integer* mask) override;
+    void updateTransient(double rdt, span<const int> mask) override;
     void factorize() override {
         m_mat.factor();
     }
@@ -43,12 +43,8 @@ public:
         return m_mat.value(i, j);
     }
 
-    void solve(const double* const b, double* const x) {
-        m_mat.solve(b, x);
-    }
-
-    void solve(const size_t stateSize, double* b, double* x) override {
-        m_mat.solve(b, x);
+    void solve(span<const double> b, span<double> x) override {
+        m_mat.solve(b.data(), x.data());
     }
 
     int info() const override {

--- a/include/cantera/oneD/MultiNewton.h
+++ b/include/cantera/oneD/MultiNewton.h
@@ -38,14 +38,15 @@ public:
     //! Compute the undamped Newton step.  The residual function is evaluated
     //! at `x`, but the Jacobian is not recomputed.
     //! @since Starting in %Cantera 3.2, the Jacobian is accessed via the OneDim object.
-    void step(double* x, double* step, SteadyStateSystem& r, int loglevel);
+    void step(span<const double> x, span<double> step, SteadyStateSystem& r,
+              int loglevel);
 
     /**
      * Return the factor by which the undamped Newton step 'step0'
      * must be multiplied in order to keep all solution components in
      * all domains between their specified lower and upper bounds.
      */
-    double boundStep(const double* x0, const double* step0,
+    double boundStep(span<const double> x0, span<const double> step0,
                      const SteadyStateSystem& r, int loglevel);
 
     /**
@@ -115,8 +116,9 @@ public:
      * @since Starting in %Cantera 3.2, the Jacobian is accessed via the
      * SteadyStateSystem object.
      */
-    int dampStep(const double* x0, const double* step0, double* x1, double* step1,
-                 double& s1, SteadyStateSystem& r, int loglevel, bool writetitle);
+    int dampStep(span<const double> x0, span<const double> step0,
+                 span<double> x1, span<double> step1, double& s1,
+                 SteadyStateSystem& r, int loglevel, bool writetitle);
 
     /**
      * Find the solution to F(x) = 0 by damped Newton iteration. On entry, x0
@@ -135,7 +137,8 @@ public:
      * @since Starting in %Cantera 3.2, the Jacobian is accessed via the
      * SteadyStateSystem object.
      */
-    int solve(double* x0, double* x1, SteadyStateSystem& r, int loglevel);
+    int solve(span<const double> x0, span<double> x1, SteadyStateSystem& r,
+              int loglevel);
 
     //! Set options.
     //! @param maxJacAge  Maximum number of steps that can be taken before requiring

--- a/include/cantera/oneD/OneDim.h
+++ b/include/cantera/oneD/OneDim.h
@@ -54,7 +54,7 @@ public:
     //! @f$ n @f$ in domain @f$ d @f$. @f$ N @f$ is the total number of state variables
     //! across all domains and @f$ J_d @f$ is the number of grid points in domain
     //! @f$ d @f$.
-    double weightedNorm(const double* step) const override;
+    double weightedNorm(span<const double> step) const override;
 
     //! Number of domains.
     size_t nDomains() const {
@@ -140,7 +140,7 @@ public:
         return m_pts;
     }
 
-    void initTimeInteg(double dt, double* x) override;
+    void initTimeInteg(double dt, span<const double> x) override;
     void setSteadyMode() override;
 
     /**
@@ -154,13 +154,16 @@ public:
      *                  the default value is used.
      * @param count   Set to zero to omit this call from the statistics
      */
-    void eval(size_t j, double* x, double* r, double rdt=-1.0, int count=1);
+    void eval(size_t j, span<const double> x, span<double> r,
+              double rdt=-1.0, int count=1);
 
-    void eval(double* x, double* r, double rdt=-1.0, int count=1) override {
+    void eval(span<const double> x, span<double> r,
+              double rdt=-1.0, int count=1) override
+    {
         return eval(npos, x, r, rdt, count);
     }
 
-    void evalJacobian(double* x0) override;
+    void evalJacobian(span<const double> x0) override;
 
     //! Return a pointer to the domain global point *i* belongs to.
     /*!
@@ -170,7 +173,7 @@ public:
     Domain1D* pointDomain(size_t i);
 
     void resize() override;
-    void resetBadValues(double* x) override;
+    void resetBadValues(span<double> x) override;
 
     //! Write statistics about the number of iterations and Jacobians at each
     //! grid level

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -213,8 +213,8 @@ public:
     using OneDim::eval;
 
     //! Evaluate the governing equations and return the vector of residuals
-    void getResidual(double rdt, double* resid) {
-        OneDim::eval(npos, *m_state, span<double>(resid, m_state->size()), rdt, 0);
+    void getResidual(double rdt, span<double> resid) {
+        OneDim::eval(npos, *m_state, resid, rdt, 0);
     }
 
     //! Refine the grid in all domains.
@@ -326,7 +326,7 @@ public:
      *         - \lambda^T \frac{\partial f}{\partial p}
      * @f]
      */
-    void solveAdjoint(const double* b, double* lambda);
+    void solveAdjoint(span<const double> b, span<double> lambda);
 
     void resize() override;
 

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -208,13 +208,13 @@ public:
     void solve(int loglevel = 0, bool refine_grid = true);
 
     void eval(double rdt=-1.0, int count = 1) {
-        OneDim::eval(npos, m_state->data(), m_xnew.data(), rdt, count);
+        OneDim::eval(npos, *m_state, m_xnew, rdt, count);
     }
     using OneDim::eval;
 
     //! Evaluate the governing equations and return the vector of residuals
     void getResidual(double rdt, double* resid) {
-        OneDim::eval(npos, m_state->data(), resid, rdt, 0);
+        OneDim::eval(npos, *m_state, span<double>(resid, m_state->size()), rdt, 0);
     }
 
     //! Refine the grid in all domains.

--- a/include/cantera/oneD/refine.h
+++ b/include/cantera/oneD/refine.h
@@ -103,7 +103,7 @@ public:
      *
      * @returns The number of new grid points needed (size of #m_insertPts)
      */
-    int analyze(size_t n, const double* z, const double* x);
+    int analyze(size_t n, span<const double> z, span<const double> x);
 
     //! Returns the number of new grid points that were needed.
     int nNewPoints() {
@@ -147,7 +147,7 @@ public:
      * @param n %Solution component index
      * @param j Grid point index
      */
-    double value(const double* x, size_t n, size_t j);
+    double value(span<const double> x, size_t n, size_t j);
 
     //! Returns the maximum allowable ratio of grid spacing between adjacent intervals
     double maxRatio() {

--- a/include/cantera/zeroD/ConstPressureMoleReactor.h
+++ b/include/cantera/zeroD/ConstPressureMoleReactor.h
@@ -28,18 +28,18 @@ public:
         return "ConstPressureMoleReactor";
     };
 
-    void getState(double* y) override;
-    void eval(double t, double* LHS, double* RHS) override;
-    void evalSteady(double t, double* LHS, double* RHS) override;
+    void getState(span<double> y) override;
+    void eval(double t, span<double> LHS, span<double> RHS) override;
+    void evalSteady(double t, span<double> LHS, span<double> RHS) override;
     vector<size_t> initializeSteady() override;
 
-    void updateState(double* y) override;
+    void updateState(span<const double> y) override;
 
     size_t componentIndex(const string& nm) const override;
     string componentName(size_t k) override;
     double upperBound(size_t k) const override;
     double lowerBound(size_t k) const override;
-    void resetBadValues(double* y) override;
+    void resetBadValues(span<double> y) override;
 
 protected:
     const size_t m_sidx = 1;

--- a/include/cantera/zeroD/ConstPressureReactor.h
+++ b/include/cantera/zeroD/ConstPressureReactor.h
@@ -31,12 +31,12 @@ public:
         return "ConstPressureReactor";
     }
 
-    void getState(double* y) override;
-    void eval(double t, double* LHS, double* RHS) override;
-    void evalSteady(double t, double* LHS, double* RHS) override;
+    void getState(span<double> y) override;
+    void eval(double t, span<double> LHS, span<double> RHS) override;
+    void evalSteady(double t, span<double> LHS, span<double> RHS) override;
     vector<size_t> initializeSteady() override;
 
-    void updateState(double* y) override;
+    void updateState(span<const double> y) override;
 
     //! Return the index in the solution vector for this reactor of the
     //! component named *nm*. Possible values for *nm* are "mass", "enthalpy",
@@ -46,7 +46,7 @@ public:
     string componentName(size_t k) override;
     double upperBound(size_t k) const override;
     double lowerBound(size_t k) const override;
-    void resetBadValues(double* y) override;
+    void resetBadValues(span<double> y) override;
 
 protected:
     double m_initialMass; //!< Initial mass [kg]; used for steady-state calculations

--- a/include/cantera/zeroD/FlowReactor.h
+++ b/include/cantera/zeroD/FlowReactor.h
@@ -32,21 +32,22 @@ public:
     }
 
     //! Not implemented; FlowReactor implements getStateDae() instead.
-    void getState(double* y) override {
+    void getState(span<double> y) override {
         throw NotImplementedError("FlowReactor::getState");
     }
 
-    void getStateDae(double* y, double* ydot) override;
-    void updateState(double* y) override;
+    void getStateDae(span<double> y, span<double> ydot) override;
+    void updateState(span<const double> y) override;
 
     //! Not implemented; FlowReactor implements evalDae() instead.
-    void eval(double t, double* LHS, double* RHS) override {
+    void eval(double t, span<double> LHS, span<double> RHS) override {
         throw NotImplementedError("FlowReactor::eval");
     }
 
-    void evalDae(double t, double* y, double* ydot, double* residual) override;
+    void evalDae(double t, span<const double> y, span<const double> ydot,
+                 span<double> residual) override;
 
-    void getConstraints(double* constraints) override;
+    void getConstraints(span<double> constraints) override;
     vector<size_t> initializeSteady() override {
         throw CanteraError("FlowReactor::initializeSteady",
             "FlowReactor is not compatible with time-dependent steady-state solver.");

--- a/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
@@ -26,14 +26,14 @@ public:
         return "IdealGasConstPressureMoleReactor";
     };
 
-    void getState(double* y) override;
+    void getState(span<double> y) override;
 
     void initialize(double t0=0.0) override;
 
-    void eval(double t, double* LHS, double* RHS) override;
+    void eval(double t, span<double> LHS, span<double> RHS) override;
 
-    void updateState(double* y) override;
-    void getJacobianScalingFactors(double& f_species, double* f_energy) override;
+    void updateState(span<const double> y) override;
+    void getJacobianScalingFactors(double& f_species, span<double> f_energy) override;
 
     //! Calculate an approximate Jacobian to accelerate preconditioned solvers
 

--- a/include/cantera/zeroD/IdealGasConstPressureReactor.h
+++ b/include/cantera/zeroD/IdealGasConstPressureReactor.h
@@ -28,12 +28,12 @@ public:
         return "IdealGasConstPressureReactor";
     }
 
-    void getState(double* y) override;
+    void getState(span<double> y) override;
 
     void initialize(double t0=0.0) override;
-    void eval(double t, double* LHS, double* RHS) override;
-    void evalSteady(double t, double* LHS, double* RHS) override;
-    void updateState(double* y) override;
+    void eval(double t, span<double> LHS, span<double> RHS) override;
+    void evalSteady(double t, span<double> LHS, span<double> RHS) override;
+    void updateState(span<const double> y) override;
     vector<size_t> initializeSteady() override;
 
     //! Return the index in the solution vector for this reactor of the

--- a/include/cantera/zeroD/IdealGasMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasMoleReactor.h
@@ -32,14 +32,14 @@ public:
     double lowerBound(size_t k) const override;
     vector<size_t> initializeSteady() override;
 
-    void getState(double* y) override;
+    void getState(span<double> y) override;
 
     void initialize(double t0=0.0) override;
 
-    void eval(double t, double* LHS, double* RHS) override;
-    void evalSteady(double t, double* LHS, double* RHS) override;
+    void eval(double t, span<double> LHS, span<double> RHS) override;
+    void evalSteady(double t, span<double> LHS, span<double> RHS) override;
 
-    void updateState(double* y) override;
+    void updateState(span<const double> y) override;
 
     //! Calculate an approximate Jacobian to accelerate preconditioned solvers
 
@@ -47,7 +47,7 @@ public:
     //! fully-dense Jacobian. Currently, also neglects terms related to interactions
     //! between reactors, for example via inlets and outlets.
     void getJacobianElements(vector<Eigen::Triplet<double>>& trips) override;
-    void getJacobianScalingFactors(double& f_species, double* f_energy) override;
+    void getJacobianScalingFactors(double& f_species, span<double> f_energy) override;
 
     bool preconditionerSupported() const override {return true;};
 

--- a/include/cantera/zeroD/IdealGasReactor.h
+++ b/include/cantera/zeroD/IdealGasReactor.h
@@ -26,14 +26,14 @@ public:
         return "IdealGasReactor";
     }
 
-    void getState(double* y) override;
+    void getState(span<double> y) override;
 
     void initialize(double t0=0.0) override;
 
-    void eval(double t, double* LHS, double* RHS) override;
-    void evalSteady(double t, double* LHS, double* RHS) override;
+    void eval(double t, span<double> LHS, span<double> RHS) override;
+    void evalSteady(double t, span<double> LHS, span<double> RHS) override;
     vector<size_t> initializeSteady() override;
-    void updateState(double* y) override;
+    void updateState(span<const double> y) override;
 
     //! Return the index in the solution vector for this reactor of the
     //! component named *nm*. Possible values for *nm* are "mass",

--- a/include/cantera/zeroD/MoleReactor.h
+++ b/include/cantera/zeroD/MoleReactor.h
@@ -27,23 +27,23 @@ public:
         return "MoleReactor";
     }
 
-    void getState(double* y) override;
-    void updateState(double* y) override;
-    void eval(double t, double* LHS, double* RHS) override;
+    void getState(span<double> y) override;
+    void updateState(span<const double> y) override;
+    void eval(double t, span<double> LHS, span<double> RHS) override;
     size_t componentIndex(const string& nm) const override;
     string componentName(size_t k) override;
     double upperBound(size_t k) const override;
     double lowerBound(size_t k) const override;
-    void resetBadValues(double* y) override;
+    void resetBadValues(span<double> y) override;
 
 protected:
     //! Get moles of the system from mass fractions stored by thermo object
     //! @param y vector for moles to be put into
-    void getMoles(double* y);
+    void getMoles(span<double> y);
 
     //! Set internal mass variable based on moles given
     //! @param y vector of moles of the system
-    void setMassFromMoles(double* y);
+    void setMassFromMoles(span<const double> y);
 
     //! const value for the species start index
     const size_t m_sidx = 2;

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -80,12 +80,12 @@ public:
         return m_energy;
     }
 
-    void getState(double* y) override;
+    void getState(span<double> y) override;
     void initialize(double t0=0.0) override;
-    void eval(double t, double* LHS, double* RHS) override;
-    void evalSteady(double t, double* LHS, double* RHS) override;
+    void eval(double t, span<double> LHS, span<double> RHS) override;
+    void evalSteady(double t, span<double> LHS, span<double> RHS) override;
     vector<size_t> initializeSteady() override;
-    void updateState(double* y) override;
+    void updateState(span<const double> y) override;
     void addSensitivityReaction(size_t rxn) override;
     void addSensitivitySpeciesEnthalpy(size_t k) override;
 
@@ -97,11 +97,11 @@ public:
     string componentName(size_t k) override;
     double upperBound(size_t k) const override;
     double lowerBound(size_t k) const override;
-    void resetBadValues(double* y) override;
+    void resetBadValues(span<double> y) override;
 
     //! Set absolute step size limits during advance
     //! @param limits array of step size limits with length neq
-    void setAdvanceLimits(const double* limits);
+    void setAdvanceLimits(span<const double> limits);
 
     //! Check whether Reactor object uses advance limits
     //! @returns           True if at least one limit is set, False otherwise
@@ -112,7 +112,7 @@ public:
     //! Retrieve absolute step size limits during advance
     //! @param[out] limits array of step size limits with length neq
     //! @returns           True if at least one limit is set, False otherwise
-    bool getAdvanceLimits(double* limits) const;
+    bool getAdvanceLimits(span<double> limits) const;
 
     //! Set individual step size limit for component name *nm*
     //! @param nm component name
@@ -130,8 +130,8 @@ public:
 
     void setDerivativeSettings(AnyMap& settings) override;
 
-    void applySensitivity(double* params) override;
-    void resetSensitivity(double* params) override;
+    void applySensitivity(span<const double> params) override;
+    void resetSensitivity(span<const double> params) override;
 
 protected:
     //! Update #m_sdot to reflect current production rates of bulk phase species due to

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -242,7 +242,7 @@ public:
     /*!
      *  @param[out] y state vector representing the initial state of the reactor
      */
-    virtual void getState(double* y) {
+    virtual void getState(span<double> y) {
         throw NotImplementedError("ReactorBase::getState",
             "Not implemented for reactor type '{}'.", type());
     }
@@ -253,7 +253,7 @@ public:
      *  @param[out] ydot  state vector representing the initial derivatives of the
      *                    reactor
      */
-    virtual void getStateDae(double* y, double* ydot) {
+    virtual void getStateDae(span<double> y, span<double> ydot) {
         throw NotImplementedError("ReactorBase::getStateDae(y, ydot)");
     }
 
@@ -263,7 +263,7 @@ public:
     //! coefficients for governing equations, length m_nv, default values 1
     //! @param[out] RHS pointer to start of vector of right-hand side
     //! coefficients for governing equations, length m_nv, default values 0
-    virtual void eval(double t, double* LHS, double* RHS) {
+    virtual void eval(double t, span<double> LHS, span<double> RHS) {
         throw NotImplementedError("ReactorBase::eval");
     }
 
@@ -274,7 +274,8 @@ public:
      * @param[in] ydot rate of change of solution vector, length neq()
      * @param[out] residual residuals vector, length neq()
      */
-    virtual void evalDae(double t, double* y, double* ydot, double* residual) {
+    virtual void evalDae(double t, span<const double> y, span<const double> ydot,
+                         span<double> residual) {
         throw NotImplementedError("ReactorBase::evalDae");
     }
 
@@ -284,14 +285,14 @@ public:
     //! that correspond to algebraic constraints.
     //!
     //! @since New in %Cantera 4.0.
-    virtual void evalSteady(double t, double* LHS, double* RHS) {
+    virtual void evalSteady(double t, span<double> LHS, span<double> RHS) {
         throw NotImplementedError("ReactorBase::evalSteady",
             "Not implemented for reactor type '{}'.", type());
     }
 
     //! Given a vector of length neq(), mark which variables should be
     //! considered algebraic constraints
-    virtual void getConstraints(double* constraints) {
+    virtual void getConstraints(span<double> constraints) {
         throw NotImplementedError("ReactorBase::getConstraints");
     }
 
@@ -311,7 +312,7 @@ public:
     }
 
     //! Set the state of the reactor to correspond to the state vector *y*.
-    virtual void updateState(double* y) {
+    virtual void updateState(span<const double> y) {
         throw NotImplementedError("ReactorBase::updateState");
     }
 
@@ -346,7 +347,7 @@ public:
     //! Reset physically or mathematically problematic values, such as negative species
     //! concentrations.
     //! @param[inout] y  current state vector, to be updated; length neq()
-    virtual void resetBadValues(double* y) {
+    virtual void resetBadValues(span<double> y) {
         throw NotImplementedError("ReactorBase::resetBadValues");
     }
 
@@ -378,12 +379,12 @@ public:
 
     //! Set reaction rate multipliers based on the sensitivity variables in
     //! *params*.
-    virtual void applySensitivity(double* params) {
+    virtual void applySensitivity(span<const double> params) {
         throw NotImplementedError("ReactorBase::applySensitivity");
     }
 
     //! Reset the reaction rate multipliers
-    virtual void resetSensitivity(double* params) {
+    virtual void resetSensitivity(span<const double> params) {
         throw NotImplementedError("ReactorBase::resetSensitivity");
     }
 
@@ -452,7 +453,7 @@ public:
     }
 
     //! Return the vector of species mass fractions.
-    const double* massFractions() const;
+    span<const double> massFractions() const;
 
     //! Return the mass fraction of the *k*-th species.
     double massFraction(size_t k) const;
@@ -487,7 +488,7 @@ public:
     //!     equations. Equal to $1/V$.
     //! @param f_energy  Scaling factor for each species term appearing in the energy
     //!     equation.
-    virtual void getJacobianScalingFactors(double& f_species, double* f_energy) {
+    virtual void getJacobianScalingFactors(double& f_species, span<double> f_energy) {
         throw NotImplementedError("ReactorBase::getJacobianScalingFactors");
     }
 

--- a/include/cantera/zeroD/ReactorFactory.h
+++ b/include/cantera/zeroD/ReactorFactory.h
@@ -46,7 +46,7 @@ private:
 //! ```
 class ReactorSurfaceFactory : public Factory<ReactorSurface,
     shared_ptr<Solution> /* surface */,
-    const vector<shared_ptr<ReactorBase>>& /* adjacent reactors */,
+    span<shared_ptr<ReactorBase>> /* adjacent reactors */,
     bool /* clone */, const string& /* name */>
 {
 public:
@@ -125,7 +125,7 @@ shared_ptr<Reservoir> newReservoir(
 //! @param name  Name of the reactor surface.
 //! @since  New in %Cantera 3.2.
 shared_ptr<ReactorSurface> newReactorSurface(
-    shared_ptr<Solution> phase, const vector<shared_ptr<ReactorBase>>& reactors,
+    shared_ptr<Solution> phase, span<shared_ptr<ReactorBase>> reactors,
     bool clone=true, const string& name="(none)");
 
 //! Create a ReactorSurface object with the specified contents and adjacent reactors
@@ -142,7 +142,7 @@ shared_ptr<ReactorSurface> newReactorSurface(
 //! @since  New in %Cantera 4.0.
 shared_ptr<ReactorSurface> newReactorSurface(
     const string& model, shared_ptr<Solution> phase,
-    const vector<shared_ptr<ReactorBase>>& reactors,
+    span<shared_ptr<ReactorBase>> reactors,
     bool clone=true, const string& name="(none)");
 
 //! @}

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -486,7 +486,7 @@ private:
  *      together.
  * @since New in %Cantera 3.2.
  */
-shared_ptr<ReactorNet> newReactorNet(vector<shared_ptr<ReactorBase>>& reactors);
+shared_ptr<ReactorNet> newReactorNet(span<shared_ptr<ReactorBase>> reactors);
 
 }
 

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -459,15 +459,16 @@ protected:
 class SteadyReactorSolver : public SteadyStateSystem
 {
 public:
-    SteadyReactorSolver(ReactorNet* net, double* x0);
-    void eval(double* x, double* r, double rdt=-1.0, int count=1) override;
-    void initTimeInteg(double dt, double* x) override;
-    void evalJacobian(double* x0) override;
-    double weightedNorm(const double* step) const override;
+    SteadyReactorSolver(ReactorNet* net, span<const double> x0);
+    void eval(span<const double> x, span<double> r,
+              double rdt=-1.0, int count=1) override;
+    void initTimeInteg(double dt, span<const double> x) override;
+    void evalJacobian(span<const double> x0) override;
+    double weightedNorm(span<const double> step) const override;
     string componentName(size_t i) const override;
     double upperBound(size_t i) const override;
     double lowerBound(size_t i) const override;
-    void resetBadValues(double* x) override;
+    void resetBadValues(span<double> x) override;
     void writeDebugInfo(const string& header_suffix, const string& message,
                         int loglevel, int attempt_counter) override;
 

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -204,7 +204,7 @@ public:
 
     //! Update the state of all the reactors in the network to correspond to
     //! the values in the solution vector *y*.
-    void updateState(double* y);
+    void updateState(span<const double> y);
 
     //! Return the sensitivity of the *k*-th solution component with respect to
     //! the *p*-th sensitivity parameter.
@@ -242,8 +242,8 @@ public:
      *  @param[in] p sensitivity parameter vector (unused?)
      *  @param[out] j Jacobian matrix, size neq() by neq().
      */
-    void evalJacobian(double t, double* y,
-                      double* ydot, double* p, Array2D* j);
+    void evalJacobian(double t, span<double> y,
+                      span<double> ydot, span<const double> p, Array2D* j);
 
     // overloaded methods of class FuncEval
     size_t neq() const override {
@@ -254,7 +254,8 @@ public:
         return m_reactors.size();
     }
 
-    void eval(double t, double* y, double* ydot, double* p) override;
+    void eval(double t, span<const double> y, span<double> ydot,
+              span<const double> p) override;
 
     //! Evaluate the governing equations adapted for the steady-state solver.
     //!
@@ -263,19 +264,19 @@ public:
     //!     for algebraic variables, this is the residual of the governing equation.
     //!
     //! @since New in %Cantera 4.0.
-    void evalSteady(double* y, double* residual);
+    void evalSteady(span<const double> y, span<double> residual);
 
     //! eval coupling for IDA / DAEs
-    void evalDae(double t, double* y, double* ydot, double* p,
-                 double* residual) override;
+    void evalDae(double t, span<const double> y, span<const double> ydot,
+                 span<const double> p, span<double> residual) override;
 
-    void getState(double* y) override;
-    void getStateDae(double* y, double* ydot) override;
+    void getState(span<double> y) override;
+    void getStateDae(span<double> y, span<double> ydot) override;
 
     //! Return k-th derivative at the current state of the system
-    virtual void getDerivative(int k, double* dky);
+    virtual void getDerivative(int k, span<double> dky);
 
-    void getConstraints(double* constraints) override;
+    void getConstraints(span<double> constraints) override;
 
     size_t nparams() const override {
         return m_sens_params.size();
@@ -303,7 +304,7 @@ public:
     //! This method is used within solveSteady() if certain errors are encountered.
     //!
     //! @param[inout] y  current state vector, to be updated; length neq()
-    void resetBadValues(double* y);
+    void resetBadValues(span<double> y);
 
     //! Used by Reactor and Wall objects to register the addition of
     //! sensitivity parameters so that the ReactorNet can keep track of the
@@ -344,17 +345,17 @@ public:
     virtual void setMaxSteps(int nmax);
 
     //! Set absolute step size limits during advance
-    void setAdvanceLimits(const double* limits);
+    void setAdvanceLimits(span<const double> limits);
 
     //! Check whether ReactorNet object uses advance limits
     bool hasAdvanceLimits() const;
 
     //! Retrieve absolute step size limits during advance
-    bool getAdvanceLimits(double* limits) const;
+    bool getAdvanceLimits(span<double> limits) const;
 
-    void preconditionerSetup(double t, double* y, double gamma) override;
+    void preconditionerSetup(double t, span<const double> y, double gamma) override;
 
-    void preconditionerSolve(double* rhs, double* output) override;
+    void preconditionerSolve(span<const double> rhs, span<double> output) override;
 
     //! Get solver stats from integrator
     AnyMap solverStats() const;
@@ -372,7 +373,8 @@ public:
     //! When limits are active, this sets `gout[0]` to
     //! `1 - max_i(|y[i]-y_base[i]| / limit[i])` so a zero indicates a component has
     //! reached its limit; otherwise `gout[0]` is positive.
-    void evalRootFunctions(double t, const double* y, double* gout) override;
+    void evalRootFunctions(double t, span<const double> y,
+                           span<double> gout) override;
 
 protected:
     //! Check that preconditioning is supported by all reactors in the network
@@ -386,7 +388,7 @@ protected:
     //! Estimate a future state based on current derivatives.
     //! The function is intended for internal use by ReactorNet::advance
     //! and deliberately not exposed in external interfaces.
-    virtual void getEstimate(double time, int k, double* yest);
+    virtual void getEstimate(double time, int k, span<double> yest);
 
     //! Returns the order used for last solution step of the ODE integrator
     //! The function is intended for internal use by ReactorNet::advance

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -91,7 +91,7 @@ public:
 
     //! Set the surface coverages. Array `cov` has length equal to the number of
     //! surface species.
-    void setCoverages(const double* cov);
+    void setCoverages(span<const double> cov);
 
     //! Set the surface coverages by name
     void setCoverages(const Composition& cov);
@@ -101,26 +101,26 @@ public:
 
     //! Get the surface coverages. Array `cov` should have length equal to the
     //! number of surface species.
-    void getCoverages(double* cov) const;
+    void getCoverages(span<double> cov) const;
 
-    void getState(double* y) override;
+    void getState(span<double> y) override;
     void initialize(double t0=0.0) override;
     vector<size_t> initializeSteady() override;
-    void updateState(double* y) override;
-    void eval(double t, double* LHS, double* RHS) override;
-    void evalSteady(double t, double* LHS, double* RHS) override;
+    void updateState(span<const double> y) override;
+    void eval(double t, span<double> LHS, span<double> RHS) override;
+    void evalSteady(double t, span<double> LHS, span<double> RHS) override;
 
     void addSensitivityReaction(size_t rxn) override;
     // void addSensitivitySpeciesEnthalpy(size_t k) override;
-    void applySensitivity(double* params) override;
-    void resetSensitivity(double* params) override;
+    void applySensitivity(span<const double> params) override;
+    void resetSensitivity(span<const double> params) override;
 
     size_t componentIndex(const string& nm) const override;
     string componentName(size_t k) override;
 
     double upperBound(size_t k) const override;
     double lowerBound(size_t k) const override;
-    void resetBadValues(double* y) override;
+    void resetBadValues(span<double> y) override;
     // void setDerivativeSettings(AnyMap& settings) override;
 
 protected:
@@ -145,13 +145,13 @@ public:
     using ReactorSurface::ReactorSurface;
     string type() const override { return "MoleReactorSurface"; }
     void initialize(double t0=0.0) override;
-    void getState(double* y) override;
-    void updateState(double* y) override;
-    void eval(double t, double* LHS, double* RHS) override;
-    void evalSteady(double t, double* LHS, double* RHS) override;
+    void getState(span<double> y) override;
+    void updateState(span<const double> y) override;
+    void eval(double t, span<double> LHS, span<double> RHS) override;
+    void evalSteady(double t, span<double> LHS, span<double> RHS) override;
     double upperBound(size_t k) const override;
     double lowerBound(size_t k) const override;
-    void resetBadValues(double* y) override;
+    void resetBadValues(span<double> y) override;
     void getJacobianElements(vector<Eigen::Triplet<double>>& trips) override;
 
 protected:
@@ -193,9 +193,10 @@ public:
 
     bool timeIsIndependent() const override { return false; }
 
-    void evalDae(double t, double* y, double* ydot, double* residual) override;
-    void getStateDae(double* y, double* ydot) override;
-    void getConstraints(double* constraints) override;
+    void evalDae(double t, span<const double> y, span<const double> ydot,
+                 span<double> residual) override;
+    void getStateDae(span<double> y, span<double> ydot) override;
+    void getConstraints(span<double> constraints) override;
 
     //! Surface area per unit length [m]
     //! @note If unspecified by the user, this will be calculated assuming the surface

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -34,7 +34,7 @@ public:
     //! @since  Constructor signature including `reactors` and `clone` arguments
     //!     introduced in %Cantera 3.2.
     ReactorSurface(shared_ptr<Solution> soln,
-                   const vector<shared_ptr<ReactorBase>>& reactors,
+                   span<shared_ptr<ReactorBase>> reactors,
                    bool clone,
                    const string& name="(none)");
 
@@ -183,7 +183,7 @@ class FlowReactorSurface : public ReactorSurface
 public:
     //! @copydoc ReactorSurface::ReactorSurface
     FlowReactorSurface(shared_ptr<Solution> soln,
-                   const vector<shared_ptr<ReactorBase>>& reactors,
+                   span<shared_ptr<ReactorBase>> reactors,
                    bool clone,
                    const string& name="(none)");
 

--- a/interfaces/cython/cantera/_onedim.pxd
+++ b/interfaces/cython/cantera/_onedim.pxd
@@ -145,8 +145,8 @@ cdef extern from "cantera/oneD/Sim1D.h":
         int domainIndex(string) except +translate_exception
         void eval(double ) except +translate_exception
         size_t size()
-        void solveAdjoint(const double*, double*) except +translate_exception
-        void getResidual(double, double*) except +translate_exception
+        void solveAdjoint(span[const_double], span[double]) except +translate_exception
+        void getResidual(double, span[double]) except +translate_exception
         void setJacAge(int, int)
         void setTimeStepFactor(double)
         void setMinTimeStep(double)

--- a/interfaces/cython/cantera/_onedim.pxd
+++ b/interfaces/cython/cantera/_onedim.pxd
@@ -118,7 +118,7 @@ cdef extern from "cantera/oneD/Sim1D.h":
         CxxSim1D(vector[shared_ptr[CxxDomain1D]]&) except +translate_exception
         void setProfile(size_t, size_t, vector[double]&, vector[double]&) except +translate_exception
         void show() except +translate_exception
-        void setTimeStep(double, size_t, int*) except +translate_exception
+        void setTimeStep(double, span[int]) except +translate_exception
         void restoreTimeSteppingSolution() except +translate_exception
         void restoreSteadySolution() except +translate_exception
         void setMaxTimeStepCount(int)

--- a/interfaces/cython/cantera/_onedim.pxd
+++ b/interfaces/cython/cantera/_onedim.pxd
@@ -27,14 +27,14 @@ cdef extern from "cantera/oneD/Domain1D.h":
         cbool hasComponent(string&) except +translate_exception
         string info(vector[string]&, int, int) except +translate_exception
         void updateState(size_t) except +translate_exception
-        vector[double] grid() except +translate_exception
-        void setupGrid(vector[double]&) except +translate_exception
+        span[const_double] grid() except +translate_exception
+        void setupGrid(span[const_double]) except +translate_exception
         double value(string&) except +translate_exception
         void setValue(string&, double) except +translate_exception
         vector[double] values(string&) except +translate_exception
-        void setValues(string&, vector[double]&) except +translate_exception
+        void setValues(string&, span[const_double]) except +translate_exception
         vector[double] residuals(string&) except +translate_exception
-        void setProfile(string&, vector[double]&, vector[double]&) except +translate_exception
+        void setProfile(string&, span[const_double], span[const_double]) except +translate_exception
         void setFlatProfile(string&, double) except +translate_exception
         void setBounds(size_t, double, double)
         double upperBound(size_t)
@@ -63,7 +63,7 @@ cdef extern from "cantera/oneD/Boundary1D.h":
         double mdot()
         void setMdot(double)
         size_t nSpecies()
-        void setMoleFractions(double*) except +translate_exception
+        void setMoleFractions(span[const_double]) except +translate_exception
         void setMoleFractions(string) except +translate_exception
         double massFraction(size_t)
         double spreadRate()
@@ -84,7 +84,7 @@ cdef extern from "cantera/oneD/Flow1D.h":
         cbool radiationEnabled()
         double radiativeHeatLoss(size_t)
         double pressure()
-        void setFixedTempProfile(vector[double]&, vector[double]&)
+        void setFixedTempProfile(span[const_double], span[const_double])
         void solveElectricField() except +translate_exception
         void fixElectricField() except +translate_exception
         cbool doElectricField() except +translate_exception

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -1625,7 +1625,8 @@ cdef class Sim1D:
         cdef np.ndarray[np.double_t, ndim=1] gg = \
                 np.ascontiguousarray(dgdx, dtype=np.double)
 
-        self.sim.solveAdjoint(&gg[0], &L[0])
+        self.sim.solveAdjoint(span[const_double](&gg[0], gg.size),
+                              span[double](&L[0], L.size))
 
         cdef np.ndarray[np.double_t, ndim=1] dgdp = np.empty(n_params)
         cdef np.ndarray[np.double_t, ndim=2] dfdp = np.empty((n_vars, n_params))
@@ -1637,12 +1638,12 @@ cdef class Sim1D:
             perturb(self, i, dp)
             if g:
                 gplus = g(self)
-            self.sim.getResidual(0, &fplus[0])
+            self.sim.getResidual(0, span[double](&fplus[0], fplus.size))
 
             perturb(self, i, -dp)
             if g:
                 gminus = g(self)
-            self.sim.getResidual(0, &fminus[0])
+            self.sim.getResidual(0, span[double](&fminus[0], fminus.size))
 
             perturb(self, i, 0)
             dgdp[i] = (gplus - gminus)/(2*dp)

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -1088,7 +1088,7 @@ cdef class Sim1D:
         cdef vector[int] data
         for n in n_steps:
             data.push_back(n)
-        self.sim.setTimeStep(stepsize, data.size(), &data[0])
+        self.sim.setTimeStep(stepsize, span[int](data))
 
     property max_time_step_count:
         """

--- a/interfaces/cython/cantera/ctcxx.pxd
+++ b/interfaces/cython/cantera/ctcxx.pxd
@@ -16,12 +16,15 @@ from cpython cimport bool as pybool
 from cpython.ref cimport PyObject
 from cython.operator cimport dereference as deref, preincrement as inc
 
-ctypedef stdmap[string,double] Composition
-
 import numpy as np
 cimport numpy as np
 
-from libcpp.vector cimport vector
+ctypedef stdmap[string,double] Composition
+
+# TODO: Drop these after requiring Cython 3.1.0 or newer
+ctypedef const int const_int
+ctypedef const double const_double
+ctypedef const size_t const_size_t
 
 # See https://github.com/cython/cython/pull/6539
 # TODO: Replace once Cython >= 3.1.0 is required

--- a/interfaces/cython/cantera/delegator.pxd
+++ b/interfaces/cython/cantera/delegator.pxd
@@ -8,20 +8,6 @@ from .ctcxx cimport *
 from .func1 cimport *
 from .units cimport CxxUnitStack
 
-cdef extern from "<array>" namespace "std" nogil:
-    cdef cppclass size_array1 "std::array<size_t, 1>":
-        size_array1() except+
-        size_t& operator[](size_t)
-
-    cdef cppclass size_array2 "std::array<size_t, 2>":
-        size_array2() except+
-        size_t& operator[](size_t)
-
-    cdef cppclass size_array3 "std::array<size_t, 3>":
-        size_array3() except+
-        size_t& operator[](size_t)
-
-
 cdef extern from "cantera/extensions/PythonHandle.h" namespace "Cantera":
     cdef cppclass CxxExternalHandle "Cantera::ExternalHandle":
         pass
@@ -45,10 +31,10 @@ cdef extern from "cantera/base/Delegator.h" namespace "Cantera":
         void setDelegate(string&, function[void(CxxAnyMap&)], string&) except +translate_exception
         void setDelegate(string&, function[void(const CxxAnyMap&, const CxxUnitStack&)], string&) except +translate_exception
         void setDelegate(string&, function[void(const string&, void*)], string&) except +translate_exception
-        void setDelegate(string&, function[void(size_array1, span[double])], string&) except +translate_exception
-        void setDelegate(string&, function[void(size_array1, double, span[double])], string&) except +translate_exception
-        void setDelegate(string&, function[void(size_array2, double, span[double], span[double])], string&) except +translate_exception
-        void setDelegate(string&, function[void(size_array3, span[double], span[double], span[double])], string&) except +translate_exception
+        void setDelegate(string&, function[void(span[double])], string&) except +translate_exception
+        void setDelegate(string&, function[void(double, span[double])], string&) except +translate_exception
+        void setDelegate(string&, function[void(double, span[double], span[double])], string&) except +translate_exception
+        void setDelegate(string&, function[void(span[double], span[double], span[double])], string&) except +translate_exception
         void setDelegate(string&, function[int(double&, void*)], string&) except +translate_exception
         void setDelegate(string&, function[int(string&, size_t)], string&) except +translate_exception
         void setDelegate(string&, function[int(size_t&, string&)], string&) except +translate_exception
@@ -65,14 +51,14 @@ cdef extern from "cantera/cython/funcWrapper.h":
         PyObject*, void(PyFuncInfo&, const CxxAnyMap&, const CxxUnitStack&))
     cdef function[void(const string&, void*)] pyOverride(
         PyObject*, void(PyFuncInfo&, const string&, void*))
-    cdef function[void(size_array1, span[double])] pyOverride(
-        PyObject*, void(PyFuncInfo&, size_array1, span[double]))
-    cdef function[void(size_array1, double, span[double])] pyOverride(
-        PyObject*, void(PyFuncInfo&, size_array1, double, span[double]))
-    cdef function[void(size_array2, double, span[double], span[double])] pyOverride(
-        PyObject*, void(PyFuncInfo&, size_array2, double, span[double], span[double]))
-    cdef function[void(size_array3, span[double], span[double], span[double])] pyOverride(
-        PyObject*, void(PyFuncInfo&, size_array3, span[double], span[double], span[double]))
+    cdef function[void(span[double])] pyOverride(
+        PyObject*, void(PyFuncInfo&, span[double]))
+    cdef function[void(double, span[double])] pyOverride(
+        PyObject*, void(PyFuncInfo&, double, span[double]))
+    cdef function[void(double, span[double], span[double])] pyOverride(
+        PyObject*, void(PyFuncInfo&, double, span[double], span[double]))
+    cdef function[void(span[double], span[double], span[double])] pyOverride(
+        PyObject*, void(PyFuncInfo&, span[double], span[double], span[double]))
     cdef function[int(double&, void*)] pyOverride(PyObject*, int(PyFuncInfo&, double&, void*))
     cdef function[int(string&, size_t)] pyOverride(PyObject*, int(PyFuncInfo&, string&, size_t))
     cdef function[int(size_t&, const string&)] pyOverride(

--- a/interfaces/cython/cantera/delegator.pxd
+++ b/interfaces/cython/cantera/delegator.pxd
@@ -45,10 +45,10 @@ cdef extern from "cantera/base/Delegator.h" namespace "Cantera":
         void setDelegate(string&, function[void(CxxAnyMap&)], string&) except +translate_exception
         void setDelegate(string&, function[void(const CxxAnyMap&, const CxxUnitStack&)], string&) except +translate_exception
         void setDelegate(string&, function[void(const string&, void*)], string&) except +translate_exception
-        void setDelegate(string&, function[void(size_array1, double*)], string&) except +translate_exception
-        void setDelegate(string&, function[void(size_array1, double, double*)], string&) except +translate_exception
-        void setDelegate(string&, function[void(size_array2, double, double*, double*)], string&) except +translate_exception
-        void setDelegate(string&, function[void(size_array3, double*, double*, double*)], string&) except +translate_exception
+        void setDelegate(string&, function[void(size_array1, span[double])], string&) except +translate_exception
+        void setDelegate(string&, function[void(size_array1, double, span[double])], string&) except +translate_exception
+        void setDelegate(string&, function[void(size_array2, double, span[double], span[double])], string&) except +translate_exception
+        void setDelegate(string&, function[void(size_array3, span[double], span[double], span[double])], string&) except +translate_exception
         void setDelegate(string&, function[int(double&, void*)], string&) except +translate_exception
         void setDelegate(string&, function[int(string&, size_t)], string&) except +translate_exception
         void setDelegate(string&, function[int(size_t&, string&)], string&) except +translate_exception
@@ -65,14 +65,14 @@ cdef extern from "cantera/cython/funcWrapper.h":
         PyObject*, void(PyFuncInfo&, const CxxAnyMap&, const CxxUnitStack&))
     cdef function[void(const string&, void*)] pyOverride(
         PyObject*, void(PyFuncInfo&, const string&, void*))
-    cdef function[void(size_array1, double*)] pyOverride(
-        PyObject*, void(PyFuncInfo&, size_array1, double*))
-    cdef function[void(size_array1, double, double*)] pyOverride(
-        PyObject*, void(PyFuncInfo&, size_array1, double, double*))
-    cdef function[void(size_array2, double, double*, double*)] pyOverride(
-        PyObject*, void(PyFuncInfo&, size_array2, double, double*, double*))
-    cdef function[void(size_array3, double*, double*, double*)] pyOverride(
-        PyObject*, void(PyFuncInfo&, size_array3, double*, double*, double*))
+    cdef function[void(size_array1, span[double])] pyOverride(
+        PyObject*, void(PyFuncInfo&, size_array1, span[double]))
+    cdef function[void(size_array1, double, span[double])] pyOverride(
+        PyObject*, void(PyFuncInfo&, size_array1, double, span[double]))
+    cdef function[void(size_array2, double, span[double], span[double])] pyOverride(
+        PyObject*, void(PyFuncInfo&, size_array2, double, span[double], span[double]))
+    cdef function[void(size_array3, span[double], span[double], span[double])] pyOverride(
+        PyObject*, void(PyFuncInfo&, size_array3, span[double], span[double], span[double]))
     cdef function[int(double&, void*)] pyOverride(PyObject*, int(PyFuncInfo&, double&, void*))
     cdef function[int(string&, size_t)] pyOverride(PyObject*, int(PyFuncInfo&, string&, size_t))
     cdef function[int(size_t&, const string&)] pyOverride(

--- a/interfaces/cython/cantera/delegator.pyx
+++ b/interfaces/cython/cantera/delegator.pyx
@@ -150,8 +150,7 @@ cdef void callback_v_csr_vp(PyFuncInfo& funcInfo,
         funcInfo.setExceptionValue(<PyObject*>exc_value)
 
 # Wrapper for functions of type void(span<double>)
-cdef void callback_v_dp(PyFuncInfo& funcInfo, size_array1 sizes,
-                        span[double] arg) noexcept:
+cdef void callback_v_dp(PyFuncInfo& funcInfo, span[double] arg) noexcept:
     cdef double[:] view = <double[:arg.size()]>arg.data() if arg.size() else None
 
     try:
@@ -162,7 +161,7 @@ cdef void callback_v_dp(PyFuncInfo& funcInfo, size_array1 sizes,
         funcInfo.setExceptionValue(<PyObject*>exc_value)
 
 # Wrapper for functions of type void(double, span<double>)
-cdef void callback_v_d_dp(PyFuncInfo& funcInfo, size_array1 sizes, double arg1,
+cdef void callback_v_d_dp(PyFuncInfo& funcInfo, double arg1,
                           span[double] arg2) noexcept:
     cdef double[:] view = <double[:arg2.size()]>arg2.data() if arg2.size() else None
 
@@ -174,7 +173,7 @@ cdef void callback_v_d_dp(PyFuncInfo& funcInfo, size_array1 sizes, double arg1,
         funcInfo.setExceptionValue(<PyObject*>exc_value)
 
 # Wrapper for functions of type void(span<double>, span<double>, span<double>)
-cdef void callback_v_dp_dp_dp(PyFuncInfo& funcInfo, size_array3 sizes,
+cdef void callback_v_dp_dp_dp(PyFuncInfo& funcInfo,
         span[double] arg1, span[double] arg2, span[double] arg3) noexcept:
     cdef double[:] view1 = <double[:arg1.size()]>arg1.data() if arg1.size() else None
     cdef double[:] view2 = <double[:arg2.size()]>arg2.data() if arg2.size() else None
@@ -232,7 +231,7 @@ cdef int callback_sz_csr(PyFuncInfo& funcInfo, size_t& out, const string& arg) n
     return -1
 
 # Wrapper for functions of type void(double, span<double>, span<double>)
-cdef void callback_v_d_dp_dp(PyFuncInfo& funcInfo, size_array2 sizes, double arg1,
+cdef void callback_v_d_dp_dp(PyFuncInfo& funcInfo, double arg1,
                              span[double] arg2, span[double] arg3) noexcept:
     cdef double[:] view1 = <double[:arg2.size()]>arg2.data() if arg2.size() else None
     cdef double[:] view2 = <double[:arg3.size()]>arg3.data() if arg3.size() else None

--- a/interfaces/cython/cantera/delegator.pyx
+++ b/interfaces/cython/cantera/delegator.pyx
@@ -149,9 +149,10 @@ cdef void callback_v_csr_vp(PyFuncInfo& funcInfo,
         funcInfo.setExceptionType(<PyObject*>exc_type)
         funcInfo.setExceptionValue(<PyObject*>exc_value)
 
-# Wrapper for functions of type void(double*)
-cdef void callback_v_dp(PyFuncInfo& funcInfo, size_array1 sizes, double* arg) noexcept:
-    cdef double[:] view = <double[:sizes[0]]>arg if sizes[0] else None
+# Wrapper for functions of type void(span<double>)
+cdef void callback_v_dp(PyFuncInfo& funcInfo, size_array1 sizes,
+                        span[double] arg) noexcept:
+    cdef double[:] view = <double[:arg.size()]>arg.data() if arg.size() else None
 
     try:
         (<object>funcInfo.func())(view)
@@ -160,10 +161,10 @@ cdef void callback_v_dp(PyFuncInfo& funcInfo, size_array1 sizes, double* arg) no
         funcInfo.setExceptionType(<PyObject*>exc_type)
         funcInfo.setExceptionValue(<PyObject*>exc_value)
 
-# Wrapper for functions of type void(double, double*)
+# Wrapper for functions of type void(double, span<double>)
 cdef void callback_v_d_dp(PyFuncInfo& funcInfo, size_array1 sizes, double arg1,
-                          double* arg2) noexcept:
-    cdef double[:] view = <double[:sizes[0]]>arg2 if sizes[0] else None
+                          span[double] arg2) noexcept:
+    cdef double[:] view = <double[:arg2.size()]>arg2.data() if arg2.size() else None
 
     try:
         (<object>funcInfo.func())(arg1, view)
@@ -172,13 +173,12 @@ cdef void callback_v_d_dp(PyFuncInfo& funcInfo, size_array1 sizes, double arg1,
         funcInfo.setExceptionType(<PyObject*>exc_type)
         funcInfo.setExceptionValue(<PyObject*>exc_value)
 
-# Wrapper for functions of type void(double*, double*, double*)
-cdef void callback_v_dp_dp_dp(PyFuncInfo& funcInfo,
-        size_array3 sizes, double* arg1, double* arg2, double* arg3) noexcept:
-
-    cdef double[:] view1 = <double[:sizes[0]]>arg1 if sizes[0] else None
-    cdef double[:] view2 = <double[:sizes[1]]>arg2 if sizes[1] else None
-    cdef double[:] view3 = <double[:sizes[2]]>arg3 if sizes[2] else None
+# Wrapper for functions of type void(span<double>, span<double>, span<double>)
+cdef void callback_v_dp_dp_dp(PyFuncInfo& funcInfo, size_array3 sizes,
+        span[double] arg1, span[double] arg2, span[double] arg3) noexcept:
+    cdef double[:] view1 = <double[:arg1.size()]>arg1.data() if arg1.size() else None
+    cdef double[:] view2 = <double[:arg2.size()]>arg2.data() if arg2.size() else None
+    cdef double[:] view3 = <double[:arg3.size()]>arg3.data() if arg3.size() else None
     try:
         (<object>funcInfo.func())(view1, view2, view3)
     except BaseException as e:
@@ -231,11 +231,11 @@ cdef int callback_sz_csr(PyFuncInfo& funcInfo, size_t& out, const string& arg) n
         funcInfo.setExceptionValue(<PyObject*>exc_value)
     return -1
 
-# Wrapper for functions of type void(double, double*, double*)
+# Wrapper for functions of type void(double, span<double>, span<double>)
 cdef void callback_v_d_dp_dp(PyFuncInfo& funcInfo, size_array2 sizes, double arg1,
-                             double* arg2, double* arg3) noexcept:
-    cdef double[:] view1 = <double[:sizes[0]]>arg2 if sizes[0] else None
-    cdef double[:] view2 = <double[:sizes[1]]>arg3 if sizes[1] else None
+                             span[double] arg2, span[double] arg3) noexcept:
+    cdef double[:] view1 = <double[:arg2.size()]>arg2.data() if arg2.size() else None
+    cdef double[:] view2 = <double[:arg3.size()]>arg3.data() if arg3.size() else None
 
     try:
         (<object>funcInfo.func())(arg1, view1, view2)

--- a/interfaces/cython/cantera/reaction.pxd
+++ b/interfaces/cython/cantera/reaction.pxd
@@ -9,8 +9,6 @@ from .func1 cimport *
 from .delegator cimport CxxDelegator
 from libcpp.map cimport multimap
 
-# TODO: Drop after requiring Cython 3.1.0 or newer
-ctypedef const double const_double
 
 cdef extern from "cantera/kinetics/ReactionRateFactory.h" namespace "Cantera":
     cdef shared_ptr[CxxReactionRate] CxxNewReactionRate "newReactionRate" (CxxAnyMap&) except +translate_exception

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -45,7 +45,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         size_t neq()
         size_t componentIndex(string&) except +translate_exception
         string componentName(size_t) except +translate_exception
-        void getState(double*) except +translate_exception
+        void getState(span[double]) except +translate_exception
         void setInitialVolume(double) except +translate_exception
         void addSensitivityReaction(size_t) except +translate_exception
 
@@ -74,7 +74,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         double area()
         void setArea(double)
         void setKinetics(CxxKinetics*) except +translate_exception
-        void setCoverages(double*) except +translate_exception
+        void setCoverages(span[double]) except +translate_exception
         void setCoverages(Composition&) except +translate_exception
 
     cdef cppclass CxxFlowReactorSurface "Cantera::FlowReactorSurface" (CxxReactorSurface):

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -90,11 +90,12 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         void setInitialMaxErrorFailures(int) except +translate_exception
 
     cdef shared_ptr[CxxReactorBase] CxxNewReactorSurface "newReactorSurface" (
-        string, shared_ptr[CxxSolution], vector[shared_ptr[CxxReactorBase]]&,
+        string, shared_ptr[CxxSolution], span[shared_ptr[CxxReactorBase]],
         cbool, string) except +translate_exception
 
     cdef shared_ptr[CxxReactorBase] CxxNewReactorSurface "newReactorSurface" (
-        shared_ptr[CxxSolution], vector[shared_ptr[CxxReactorBase]]&, cbool, string) except +translate_exception
+        shared_ptr[CxxSolution], span[shared_ptr[CxxReactorBase]],
+        cbool, string) except +translate_exception
 
     # connectors
 
@@ -163,7 +164,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
     # reactor net
 
     cdef shared_ptr[CxxReactorNet] CxxNewReactorNet "newReactorNet" (
-        vector[shared_ptr[CxxReactorBase]]&) except +translate_exception
+        span[shared_ptr[CxxReactorBase]]) except +translate_exception
 
     cdef cppclass CxxReactorNet "Cantera::ReactorNet":
         CxxReactorNet()

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -189,10 +189,10 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         cbool verbose()
         void setVerbose(cbool)
         size_t neq()
-        void getState(double*)
-        void getDerivative(int, double *) except +translate_exception
-        void setAdvanceLimits(double*)
-        cbool getAdvanceLimits(double*)
+        void getState(span[double])
+        void getDerivative(int, span[double]) except +translate_exception
+        void setAdvanceLimits(span[double])
+        cbool getAdvanceLimits(span[double])
         string componentName(size_t) except +translate_exception
         size_t globalComponentIndex(string&, int) except +translate_exception
         void setSensitivityTolerances(double, double)

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -1958,7 +1958,7 @@ cdef class ReactorNet:
         if not self.n_vars:
             raise CanteraError('ReactorNet empty or not initialized.')
         cdef np.ndarray[np.double_t, ndim=1] y = np.zeros(self.n_vars)
-        self.net.getState(&y[0])
+        self.net.getState(span[double](&y[0], y.size))
         return y
 
     def get_derivative(self, k):
@@ -1969,7 +1969,7 @@ cdef class ReactorNet:
         if not self.n_vars:
             raise CanteraError('ReactorNet empty or not initialized.')
         cdef np.ndarray[np.double_t, ndim = 1] dky = np.zeros(self.n_vars)
-        self.net.getDerivative(k, & dky[0])
+        self.net.getDerivative(k, span[double](&dky[0], dky.size))
         return dky
 
     property advance_limits:
@@ -1981,7 +1981,7 @@ cdef class ReactorNet:
         """
         def __get__(self):
             cdef np.ndarray[np.double_t, ndim=1] limits = np.empty(self.n_vars)
-            self.net.getAdvanceLimits(&limits[0])
+            self.net.getAdvanceLimits(span[double](&limits[0], limits.size))
             return limits
 
         def __set__(self, limits):
@@ -1992,7 +1992,7 @@ cdef class ReactorNet:
 
             cdef np.ndarray[np.double_t, ndim=1] data = \
                 np.ascontiguousarray(limits, dtype=np.double)
-            self.net.setAdvanceLimits(&data[0])
+            self.net.setAdvanceLimits(span[double](&data[0], data.size))
 
     def advance_to_steady_state(self, int max_steps=10000,
                                 double residual_threshold=0., double atol=0.,

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -108,7 +108,7 @@ cdef class ReactorBase:
         if not self.n_vars:
             raise CanteraError('Reactor empty or network not initialized.')
         cdef np.ndarray[np.double_t, ndim=1] y = np.zeros(self.n_vars)
-        self.rbase.getState(&y[0])
+        self.rbase.getState(span[double](&y[0], y.size))
         return y
 
     def syncState(self):
@@ -783,7 +783,7 @@ cdef class ReactorSurface(ReactorBase):
                 raise ValueError('Incorrect number of site coverages specified')
             cdef np.ndarray[np.double_t, ndim=1] data = \
                     np.ascontiguousarray(coverages, dtype=np.double)
-            self.surface.setCoverages(&data[0])
+            self.surface.setCoverages(span[double](&data[0], data.size))
 
     @property
     def reactor(self):

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -735,14 +735,17 @@ cdef class ReactorSurface(ReactorBase):
             raise TypeError("Parameter 'r' should be a ReactorBase object or a list "
                             "of ReactorBase objects.")
 
+        cdef span[shared_ptr[CxxReactorBase]] adj_span = \
+            span[shared_ptr[CxxReactorBase]](cxx_adj)
+
         if kind is None and self.reactor_type != "ReactorSurface":
             kind = self.reactor_type
 
         if kind is not None:
-            self._rbase = CxxNewReactorSurface(stringify(kind), phase._base, cxx_adj,
+            self._rbase = CxxNewReactorSurface(stringify(kind), phase._base, adj_span,
                                                clone, stringify(name))
         else:
-            self._rbase = CxxNewReactorSurface(phase._base, cxx_adj, clone,
+            self._rbase = CxxNewReactorSurface(phase._base, adj_span, clone,
                                                stringify(name))
 
         self.rbase = self._rbase.get()
@@ -1591,7 +1594,9 @@ cdef class ReactorNet:
         for r in reactors:
             self._reactors.append(r)
             cxx_reactors.push_back(r._rbase)
-        self._net = CxxNewReactorNet(cxx_reactors)
+        cdef span[shared_ptr[CxxReactorBase]] reactors_span = \
+            span[shared_ptr[CxxReactorBase]](cxx_reactors)
+        self._net = CxxNewReactorNet(reactors_span)
         self.net = self._net.get()
 
     def advance(self, double t, pybool apply_limit=True):

--- a/interfaces/sourcegen/src/sourcegen/clib/config.yaml
+++ b/interfaces/sourcegen/src/sourcegen/clib/config.yaml
@@ -24,6 +24,7 @@ ret_type_crosswalk:
   vector<double>: double*
   span<double>: double*
   span<const double>: const double*
+  span<const int>: const int32_t*
   string: char*
 
 # Parameter type crosswalks
@@ -41,6 +42,7 @@ par_type_crosswalk:
   vector<double>: double*
   span<double>: double*
   span<const double>: const double*
+  span<const int>: const int32_t*
   string: char*
 
 # Cabinets with associated preambles (headers)

--- a/interfaces/sourcegen/src/sourcegen/clib/config.yaml
+++ b/interfaces/sourcegen/src/sourcegen/clib/config.yaml
@@ -35,6 +35,7 @@ par_type_crosswalk:
   int*: int32_t*
   vector<int>: int32_t*
   vector<shared_ptr<T>>: int32_t*
+  span<shared_ptr<T>>: int32_t*
   double: double
   double*: double*
   vector<double>: double*

--- a/interfaces/sourcegen/src/sourcegen/clib/generator.py
+++ b/interfaces/sourcegen/src/sourcegen/clib/generator.py
@@ -225,8 +225,11 @@ class CLibSourceGenerator(SourceGenerator):
             if check_array:
                 # Need to handle crosswalked parameter with length information
                 c_prev = c_args[c_ix-1].name
-                if "vector<shared_ptr" in cxx_type:
+                if "vector<shared_ptr" in cxx_type or "span<shared_ptr" in cxx_type:
                     # Example: vector<shared_ptr<Domain1D>>
+                    if "span<" in cxx_type:
+                        # Generate a vector to pass to a function taking a span
+                        cxx_type = cxx_type.replace("span<", "vector<")
                     cxx_type = cxx_type.removeprefix("const ").rstrip("&")
                     cxx_base = cxx_type.rstrip(">").split("<")[-1]
                     bases.add(cxx_base)

--- a/interfaces/sourcegen/src/sourcegen/headers/config.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/config.yaml
@@ -26,6 +26,7 @@ ret_type_crosswalk:
   vector<double>: double*
   span<double>: double*
   span<const double>: const double*
+  span<const int>: const int32_t*
 
 # Parameter type crosswalks
 par_type_crosswalk:
@@ -43,3 +44,4 @@ par_type_crosswalk:
   string: char*
   span<double>: double*
   span<const double>: const double*
+  span<const int>: const int32_t*

--- a/interfaces/sourcegen/src/sourcegen/headers/config.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/config.yaml
@@ -36,6 +36,7 @@ par_type_crosswalk:
   int*: int32_t*
   vector<int>: int32_t*
   vector<shared_ptr<T>>: int32_t*
+  span<shared_ptr<T>>: int32_t*
   double: double
   double*: double*
   vector<double>: double*

--- a/interfaces/sourcegen/src/sourcegen/headers/ctdomain.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctdomain.yaml
@@ -40,7 +40,6 @@ recipes:
 - name: rtol
 - name: atol
 - name: setupGrid  # Changed in Cantera 3.2
-  wraps: setupGrid(const vector<double>&)
 - name: setupUniformGrid  # New in Cantera 3.2
 - name: setID
 - name: grid
@@ -50,7 +49,7 @@ recipes:
 - name: setMoleFractionsByName
   wraps: setMoleFractions(const string&)
 - name: setMoleFractions
-  wraps: setMoleFractions(const double*)
+  wraps: setMoleFractions(span<const double>)
 - name: mdot
 - name: temperature
 - name: spreadRate

--- a/interfaces/sourcegen/src/sourcegen/headers/ctonedim.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctonedim.yaml
@@ -11,7 +11,7 @@ recipes:
   uses: domain
 - name: show
 - name: setTimeStep
-  wraps: setTimeStep(double, const vector<int>&)
+  wraps: setTimeStep(double, span<const int>)
 - name: getInitialSoln
 - name: solve
 - name: refine
@@ -24,7 +24,7 @@ recipes:
 - name: writeStats
 - name: domainIndex
 - name: eval
-  wraps: eval(double*, double*, double, int)
+  wraps: eval(span<const double>, span<double>, double, int)
 - name: setMaxJacAge
   wraps: setJacAge
 - name: setFixedTemperature

--- a/interfaces/sourcegen/src/sourcegen/headers/ctreactor.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctreactor.yaml
@@ -14,9 +14,9 @@ recipes:
 - name: new
   wraps: newReactorBase
 - name: newSurface
-  wraps: newReactorSurface(shared_ptr<Solution>, const vector<shared_ptr<ReactorBase>>&, bool, const string&)
+  wraps: newReactorSurface(shared_ptr<Solution>, span<shared_ptr<ReactorBase>>, bool, const string&)
 - name: newSurfaceOfType
-  wraps: newReactorSurface(const string&, shared_ptr<Solution>, const vector<shared_ptr<ReactorBase>>&, bool, const string&)
+  wraps: newReactorSurface(const string&, shared_ptr<Solution>, span<shared_ptr<ReactorBase>>, bool, const string&)
 - name: type
 - name: name
 - name: setName

--- a/interfaces/sourcegen/src/sourcegen/headers/generator.py
+++ b/interfaces/sourcegen/src/sourcegen/headers/generator.py
@@ -330,7 +330,7 @@ class HeaderGenerator:
                 handle = self._handle_crosswalk(
                     par_key, self._config.par_type_crosswalk, {})
                 par_key = par_key.replace(handle, "T")
-                if "vector<" in par_key:
+                if "vector<" in par_key or "span<" in par_key:
                     params.append(
                         Param("int32_t", f"{par.name}Len",
                               f"Length of array reserved for {par.name}.", "in"))

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -53,11 +53,12 @@ for sample in samples:
             ]
         )
 
-    # TODO: Accelerate is only used if other BLAS/LAPACK are not used
     if env["OS"] == "Darwin":
+        # TODO: Accelerate is only used if other BLAS/LAPACK are not used
         cmake_extra.append("find_library(ACCELERATE_FRAMEWORK Accelerate)")
         localenv.Append(
-            LINKFLAGS=env.subst("${RPATHPREFIX}${ct_libdir}${RPATHSUFFIX}"))
+            LINKFLAGS=env.subst(
+                f"${{RPATHPREFIX}}{localenv.Dir('#build/lib').abspath}${{RPATHSUFFIX}}"))
 
     localenv.Append(LIBS=env['cantera_shared_libs'])
     localenv.Prepend(CPPPATH=['#include'])

--- a/samples/cxx/bvp/BoundaryValueProblem.h
+++ b/samples/cxx/bvp/BoundaryValueProblem.h
@@ -17,6 +17,8 @@
 #include "cantera/onedim.h"
 #include <fstream>
 
+using std::span;
+
 /// Namespace for the boundary value problem package.
 namespace BVP
 {
@@ -84,7 +86,7 @@ public:
         for (iz = 0; iz < np; iz++) {
             z[iz] = zmin + iz*(zmax - zmin)/(np-1);
         }
-        setupGrid(np, z.data());
+        setupGrid(z);
         resize(nv, np);
 
         // Add dummy terminator domains on either side of this one.
@@ -101,7 +103,7 @@ public:
     BoundaryValueProblem(int nv, int np, double* z) :
         m_left(0), m_right(0), m_sim(0)
     {
-        setupGrid(np, z);
+        setupGrid(span<const double>(z, np));
         resize(nv, np);
 
         // Add dummy terminator domains on either side of this one.
@@ -237,7 +239,7 @@ protected:
      * @param n Component index.
      * @param j Grid point number.
      */
-    double cdif2(const double* x, int n, int j) const {
+    double cdif2(span<const double> x, int n, int j) const {
         double c1 = x[index(n,j)] - x[index(n,j-1)];
         double c2 = x[index(n,j+1)] - x[index(n,j)];
         return 2.0*(c2/(z(j+1) - z(j)) - c1/(z(j) - z(j-1)))/
@@ -251,7 +253,7 @@ protected:
      * value to the right is used, and if it is zero (default) a
      * central-differenced first derivative is computed.
     */
-    double firstDeriv(const double* x, int n, int j, int type = 0) const {
+    double firstDeriv(span<const double> x, int n, int j, int type = 0) const {
         switch (type) {
         case -1:
             return leftFirstDeriv(x, n, j);
@@ -267,7 +269,7 @@ protected:
      * is formed to the right of point j, using values at point j
      * and point j + 1.
      */
-    double rightFirstDeriv(const double* x, int n, int j) const {
+    double rightFirstDeriv(span<const double> x, int n, int j) const {
         return (x[index(n,j+1)] - x[index(n,j)])/(z(j+1) - z(j));
     }
 
@@ -277,7 +279,7 @@ protected:
      * and point j - 1.
      */
 
-    double leftFirstDeriv(const double* x, int n, int j) const {
+    double leftFirstDeriv(span<const double> x, int n, int j) const {
         return (x[index(n,j)] - x[index(n,j-1)])/(z(j) - z(j-1));
     }
 
@@ -288,7 +290,7 @@ protected:
      * @param n Component index.
      * @param j Grid point number.
      */
-    double centralFirstDeriv(const double* x, int n, int j) const {
+    double centralFirstDeriv(span<const double> x, int n, int j) const {
         double c1 = x[index(n,j+1)] - x[index(n,j-1)];
         return c1/(z(j+1) - z(j-1));
     }

--- a/samples/cxx/bvp/blasius.cpp
+++ b/samples/cxx/bvp/blasius.cpp
@@ -77,7 +77,8 @@ public:
     // Specify the residual function. This is where the ODE system and boundary
     // conditions are specified. The solver will attempt to find a solution
     // x so that rsd is zero.
-    void eval(size_t jg, double* x, double* rsd, int* diag, double rdt) override {
+    void eval(size_t jg, span<const double> x, span<double> rsd,
+              span<int> diag, double rdt) override {
         size_t jpt = jg - firstPoint();
         size_t jmin, jmax;
         if (jg == npos) {  // evaluate all points
@@ -106,10 +107,10 @@ public:
 
 private:
     // for convenience only. Note that the compiler will inline these.
-    double zeta(double* x, int j) {
+    double zeta(span<const double> x, int j) {
         return x[index(0,j)];
     }
-    double u(double* x, int j) {
+    double u(span<const double> x, int j) {
         return x[index(1,j)];
     }
 };

--- a/samples/cxx/custom/custom.cpp
+++ b/samples/cxx/custom/custom.cpp
@@ -200,7 +200,7 @@ int main() {
         // ODE system time-integration capability. a pointer to the resulting system state vector
         // is fetched in order to access the solution components.
         integrator->integrate(tnow);
-        double *solution = integrator->solution();
+        auto solution = integrator->solution();
 
         // output the current absolute time and solution state vector to the csv file. you can view
         // these results by opening the "custom_cxx.csv" file that appears in this program's directory

--- a/samples/cxx/custom/custom.cpp
+++ b/samples/cxx/custom/custom.cpp
@@ -68,7 +68,8 @@ public:
      *
      * note: sensitivity analysis isn't implemented in this example
      */
-    void eval(double t, double* y, double* ydot, double* p) override {
+    void eval(double t, span<const double> y, span<double> ydot,
+              span<const double> p) override {
         // the solution vector *y* is [T, Y_1, Y_2, ... Y_K], where T is the
         // system temperature, and Y_k is the mass fraction of species k.
         // similarly, the time derivative of the solution vector, *ydot*, is
@@ -76,7 +77,7 @@ public:
         // the following variables are defined for clear and convenient access
         // to these vectors:
         double temperature = y[0];
-        span<double> massFracs(y + 1, m_nSpecies);
+        auto massFracs = y.subspan(1, m_nSpecies);
         double *dTdt = &ydot[0];
         double *dYdt = &ydot[1];
 
@@ -128,11 +129,11 @@ public:
      *   - overridden from FuncEval, called by the integrator during initialization.
      * @param[out] y solution vector, length neq()
      */
-    void getState(double* y) override {
+    void getState(span<double> y) override {
         // the solution vector *y* is [T, Y_1, Y_2, ... Y_K], where T is the
         // system temperature, and Y_k is the mass fraction of species k.
         y[0] = m_gas->temperature();
-        m_gas->getMassFractions(span<double>(y + 1, m_nSpecies));
+        m_gas->getMassFractions(y.subspan(1, m_nSpecies));
     }
 
 private:

--- a/samples/cxx/flamespeed/flamespeed.cpp
+++ b/samples/cxx/flamespeed/flamespeed.cpp
@@ -68,14 +68,14 @@ int flamespeed(double phi, bool refine_grid, int loglevel)
             z[iz] = ((double)iz)*dz;
         }
 
-        flow->setupGrid(nz, &z[0]);
+        flow->setupGrid(z);
         flow->setSteadyTolerances(1e-5, 1e-11);
 
         //------- step 2: create the inlet  -----------------------
 
         auto inlet = newDomain<Inlet1D>("inlet", sol);
 
-        inlet->setMoleFractions(x.data());
+        inlet->setMoleFractions(x);
         double mdot = uin * rho_in;
         inlet->setMdot(mdot);
         inlet->setTemperature(temp);

--- a/src/base/checkFinite.cpp
+++ b/src/base/checkFinite.cpp
@@ -25,12 +25,12 @@ void checkFinite(const double tmp)
     }
 }
 
-void checkFinite(const string& name, const double* values, size_t N)
+void checkFinite(const string& name, span<const double> values)
 {
-    for (size_t i = 0; i < N; i++) {
+    for (size_t i = 0; i < values.size(); i++) {
         if (!std::isfinite(values[i])) {
             string message = name + " contains non-finite elements:\n\n";
-            for (size_t j = 0; j < N; j++) {
+            for (size_t j = 0; j < values.size(); j++) {
                 if (!std::isfinite(values[j])) {
                     message += fmt::format("{}[{}] = {}\n", name, j, values[j]);
                 }

--- a/src/numerics/AdaptivePreconditioner.cpp
+++ b/src/numerics/AdaptivePreconditioner.cpp
@@ -65,12 +65,11 @@ void AdaptivePreconditioner::prunePreconditioner()
     }
 }
 
-void AdaptivePreconditioner::solve(const size_t stateSize, double* rhs_vector, double*
-    output)
+void AdaptivePreconditioner::solve(span<const double> rhs_vector, span<double> output)
 {
     // creating vectors in the form of Ax=b
-    Eigen::Map<Eigen::VectorXd> bVector(rhs_vector, stateSize);
-    Eigen::Map<Eigen::VectorXd> xVector(output, stateSize);
+    Eigen::Map<const Eigen::VectorXd> bVector(rhs_vector.data(), rhs_vector.size());
+    Eigen::Map<Eigen::VectorXd> xVector(output.data(), output.size());
     // solve for xVector
     xVector = m_solver.solve(bVector);
     if (m_solver.info() != Eigen::Success) {

--- a/src/numerics/CVodesIntegrator.cpp
+++ b/src/numerics/CVodesIntegrator.cpp
@@ -142,13 +142,14 @@ double& CVodesIntegrator::solution(size_t k)
     return NV_Ith_S(m_y, k);
 }
 
-double* CVodesIntegrator::solution()
+span<double> CVodesIntegrator::solution()
 {
-    return NV_DATA_S(m_y);
+    return asSpan(m_y);
 }
 
-void CVodesIntegrator::setTolerances(double reltol, size_t n, double* abstol)
+void CVodesIntegrator::setTolerances(double reltol, span<const double> abstol)
 {
+    size_t n = abstol.size();
     m_itol = CV_SV;
     m_nabs = n;
     if (n != m_neq) {
@@ -547,11 +548,11 @@ double CVodesIntegrator::step(double tout)
     return m_time;
 }
 
-double* CVodesIntegrator::derivative(double tout, int n)
+span<double> CVodesIntegrator::derivative(double tout, int n)
 {
     int flag = CVodeGetDky(m_cvode_mem, tout, n, m_dky);
     checkError(flag, "derivative", "CVodeGetDky");
-    return NV_DATA_S(m_dky);
+    return asSpan(m_dky);
 }
 
 int CVodesIntegrator::lastOrder() const

--- a/src/numerics/EigenSparseDirectJacobian.cpp
+++ b/src/numerics/EigenSparseDirectJacobian.cpp
@@ -21,9 +21,9 @@ void EigenSparseDirectJacobian::factorize()
     }
 }
 
-void EigenSparseDirectJacobian::solve(const size_t stateSize, double* b, double* x)
+void EigenSparseDirectJacobian::solve(span<const double> b, span<double> x)
 {
-    MappedVector(x, m_dim) = m_solver.solve(MappedVector(b, m_dim));
+    MappedVector(x.data(), m_dim) = m_solver.solve(ConstMappedVector(b.data(), m_dim));
     // check for errors
     if (m_solver.info() != Eigen::Success) {
         throw CanteraError("EigenSparseDirectJacobian::solve",

--- a/src/numerics/EigenSparseJacobian.cpp
+++ b/src/numerics/EigenSparseJacobian.cpp
@@ -48,12 +48,12 @@ void EigenSparseJacobian::updatePreconditioner()
     factorize();
 }
 
-void EigenSparseJacobian::updateTransient(double rdt, int* mask)
+void EigenSparseJacobian::updateTransient(double rdt, span<const int> mask)
 {
     // set matrix to steady Jacobian
     m_matrix.setFromTriplets(m_jac_trips.begin(), m_jac_trips.end());
     // update transient diagonal terms
-    Eigen::VectorXd diag = Eigen::Map<Eigen::VectorXi>(mask, m_dim).cast<double>();
+    Eigen::VectorXd diag = Eigen::Map<const Eigen::VectorXi>(mask.data(), m_dim).cast<double>();
     m_matrix -= rdt * diag.matrix().asDiagonal();
     factorize();
 }

--- a/src/numerics/FuncEval.cpp
+++ b/src/numerics/FuncEval.cpp
@@ -4,10 +4,10 @@
 namespace Cantera
 {
 
-int FuncEval::evalNoThrow(double t, double* y, double* ydot)
+int FuncEval::evalNoThrow(double t, span<const double> y, span<double> ydot)
 {
     try {
-        eval(t, y, ydot, m_sens_params.data());
+        eval(t, y, ydot, m_sens_params);
     } catch (CanteraError& err) {
         if (suppressErrors()) {
             m_errors.push_back(err.what());
@@ -36,10 +36,11 @@ int FuncEval::evalNoThrow(double t, double* y, double* ydot)
     return 0; // successful evaluation
 }
 
-int FuncEval::evalDaeNoThrow(double t, double* y, double* ydot, double* r)
+int FuncEval::evalDaeNoThrow(double t, span<const double> y, span<const double> ydot,
+                             span<double> r)
 {
     try {
-        evalDae(t, y, ydot, m_sens_params.data(), r);
+        evalDae(t, y, ydot, m_sens_params, r);
     } catch (CanteraError& err) {
         if (suppressErrors()) {
             m_errors.push_back(err.what());
@@ -77,7 +78,7 @@ string FuncEval::getErrors() const {
     return errs.str();
 }
 
-int FuncEval::preconditioner_setup_nothrow(double t, double* y, double gamma)
+int FuncEval::preconditioner_setup_nothrow(double t, span<const double> y, double gamma)
 {
     try {
         preconditionerSetup(t, y, gamma);
@@ -110,7 +111,7 @@ int FuncEval::preconditioner_setup_nothrow(double t, double* y, double gamma)
     return 0; // successful evaluation
 }
 
-int FuncEval::preconditioner_solve_nothrow(double* rhs, double* output)
+int FuncEval::preconditioner_solve_nothrow(span<const double> rhs, span<double> output)
 {
     try {
         preconditionerSolve(rhs, output); // perform preconditioner solve
@@ -143,7 +144,7 @@ int FuncEval::preconditioner_solve_nothrow(double* rhs, double* output)
     return 0; // successful evaluation
 }
 
-int FuncEval::evalRootFunctionsNoThrow(double t, const double* y, double* gout)
+int FuncEval::evalRootFunctionsNoThrow(double t, span<const double> y, span<double> gout)
 {
     try {
         evalRootFunctions(t, y, gout);

--- a/src/numerics/IdasIntegrator.cpp
+++ b/src/numerics/IdasIntegrator.cpp
@@ -36,7 +36,7 @@ extern "C" {
 static int ida_rhs(sunrealtype t, N_Vector y, N_Vector ydot, N_Vector r, void* f_data)
 {
     FuncEval* f = (FuncEval*) f_data;
-    return f->evalDaeNoThrow(t, NV_DATA_S(y), NV_DATA_S(ydot), NV_DATA_S(r));
+    return f->evalDaeNoThrow(t, asSpan(y), asSpan(ydot), asSpan(r));
 }
 
 #if SUNDIALS_VERSION_MAJOR >= 7
@@ -257,10 +257,10 @@ void IdasIntegrator::initialize(double t0, FuncEval& func)
     }
     m_constraints = newNVector(static_cast<sd_size_t>(m_neq), m_sundials_ctx);
     // set the constraints
-    func.getConstraints(NV_DATA_S(m_constraints));
+    func.getConstraints(asSpan(m_constraints));
 
     // get the initial conditions
-    func.getStateDae(NV_DATA_S(m_y), NV_DATA_S(m_ydot));
+    func.getStateDae(asSpan(m_y), asSpan(m_ydot));
 
     if (m_ida_mem) {
         IDAFree(&m_ida_mem);
@@ -322,7 +322,7 @@ void IdasIntegrator::reinitialize(double t0, FuncEval& func)
     m_t0 = t0;
     m_time = t0;
     m_tInteg = t0;
-    func.getStateDae(NV_DATA_S(m_y), NV_DATA_S(m_ydot));
+    func.getStateDae(asSpan(m_y), asSpan(m_ydot));
     m_func = &func;
     func.clearErrors();
 

--- a/src/numerics/IdasIntegrator.cpp
+++ b/src/numerics/IdasIntegrator.cpp
@@ -95,13 +95,14 @@ double& IdasIntegrator::solution(size_t k)
     return NV_Ith_S(m_y, k);
 }
 
-double* IdasIntegrator::solution()
+span<double> IdasIntegrator::solution()
 {
-    return NV_DATA_S(m_y);
+    return asSpan(m_y);
 }
 
-void IdasIntegrator::setTolerances(double reltol, size_t n, double* abstol)
+void IdasIntegrator::setTolerances(double reltol, span<const double> abstol)
 {
+    size_t n = abstol.size();
     m_itol = IDA_SV;
     if (n != m_nabs) {
         m_nabs = n;

--- a/src/numerics/SteadyStateSystem.cpp
+++ b/src/numerics/SteadyStateSystem.cpp
@@ -52,7 +52,7 @@ void SteadyStateSystem::solve(int loglevel)
         if (!m_jac_ok) {
             evalJacobian(*m_state);
             try {
-                m_jac->updateTransient(m_rdt, m_mask.data());
+                m_jac->updateTransient(m_rdt, m_mask);
                 m_jac_ok = true;
             } catch (CanteraError& err) {
                 // Allow solver to continue after failure to factorize the steady-state
@@ -260,7 +260,7 @@ void SteadyStateSystem::initTimeInteg(double dt, span<const double> x)
 
     // if the stepsize has changed, then update the transient part of the Jacobian
     if (fabs(rdt_old - m_rdt) > Tiny) {
-        m_jac->updateTransient(m_rdt, m_mask.data());
+        m_jac->updateTransient(m_rdt, m_mask);
     }
 }
 
@@ -271,7 +271,7 @@ void SteadyStateSystem::setSteadyMode()
     }
 
     m_rdt = 0.0;
-    m_jac->updateTransient(m_rdt, m_mask.data());
+    m_jac->updateTransient(m_rdt, m_mask);
 }
 
 void SteadyStateSystem::setJacAge(int ss_age, int ts_age)

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -204,19 +204,11 @@ void Domain1D::locate()
     }
 }
 
-void Domain1D::setupGrid(const vector<double>& grid)
+void Domain1D::setupGrid(span<const double> z)
 {
-    setupGrid(grid.size(), grid.data());
-}
-
-void Domain1D::setupGrid(size_t n, const double* z)
-{
-    if (n > 1) {
-        resize(m_nv, n);
-        for (size_t j = 0; j < m_points; j++) {
-            m_z[j] = z[j];
-        }
-    }
+    m_z.assign(z.begin(), z.end());
+    m_points = z.size();
+    m_slast.resize(m_nv * m_points, 0.0);
 }
 
 void Domain1D::setupUniformGrid(size_t points, double length, double start)
@@ -229,7 +221,7 @@ void Domain1D::setupUniformGrid(size_t points, double length, double start)
     setupGrid(grid);
 }
 
-void Domain1D::show(const double* x)
+void Domain1D::show(span<const double> x)
 {
     size_t nn = m_nv/5;
     for (size_t i = 0; i < nn; i++) {
@@ -273,7 +265,7 @@ vector<double> Domain1D::getRefineCriteria()
     return m_refiner->getCriteria();
 }
 
-void Domain1D::_getInitialSoln(double* x)
+void Domain1D::_getInitialSoln(span<double> x)
 {
     for (size_t j = 0; j < m_points; j++) {
         for (size_t n = 0; n < m_nv; n++) {

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -91,7 +91,7 @@ bool IonFlow::componentActive(size_t n) const
     }
 }
 
-void IonFlow::updateTransport(double* x, size_t j0, size_t j1)
+void IonFlow::updateTransport(span<const double> x, size_t j0, size_t j1)
 {
     Flow1D::updateTransport(x,j0,j1);
     for (size_t j = j0; j < j1; j++) {
@@ -108,7 +108,7 @@ void IonFlow::updateTransport(double* x, size_t j0, size_t j1)
     }
 }
 
-void IonFlow::updateDiffFluxes(const double* x, size_t j0, size_t j1)
+void IonFlow::updateDiffFluxes(span<const double> x, size_t j0, size_t j1)
 {
     if (m_do_electric_field) {
         electricFieldMethod(x,j0,j1);
@@ -117,7 +117,7 @@ void IonFlow::updateDiffFluxes(const double* x, size_t j0, size_t j1)
     }
 }
 
-void IonFlow::frozenIonMethod(const double* x, size_t j0, size_t j1)
+void IonFlow::frozenIonMethod(span<const double> x, size_t j0, size_t j1)
 {
     for (size_t j = j0; j < j1; j++) {
         double dz = z(j+1) - z(j);
@@ -142,7 +142,7 @@ void IonFlow::frozenIonMethod(const double* x, size_t j0, size_t j1)
     }
 }
 
-void IonFlow::electricFieldMethod(const double* x, size_t j0, size_t j1)
+void IonFlow::electricFieldMethod(span<const double> x, size_t j0, size_t j1)
 {
     for (size_t j = j0; j < j1; j++) {
         double rho = density(j);
@@ -180,7 +180,7 @@ void IonFlow::electricFieldMethod(const double* x, size_t j0, size_t j1)
 }
 
 //! Evaluate the electric field equation residual
-void IonFlow::evalElectricField(double* x, double* rsd, int* diag,
+void IonFlow::evalElectricField(span<const double> x, span<double> rsd, span<int> diag,
                                 double rdt, size_t jmin, size_t jmax)
 {
     Flow1D::evalElectricField(x, rsd, diag, rdt, jmin, jmax);
@@ -205,7 +205,7 @@ void IonFlow::evalElectricField(double* x, double* rsd, int* diag,
     }
 }
 
-void IonFlow::evalSpecies(double* x, double* rsd, int* diag,
+void IonFlow::evalSpecies(span<const double> x, span<double> rsd, span<int> diag,
                           double rdt, size_t jmin, size_t jmax)
 {
     Flow1D::evalSpecies(x, rsd, diag, rdt, jmin, jmax);
@@ -247,8 +247,8 @@ void IonFlow::fixElectricField()
     m_do_electric_field = false;
 }
 
-void IonFlow::setElectronTransport(vector<double>& tfix, vector<double>& diff_e,
-                                   vector<double>& mobi_e)
+void IonFlow::setElectronTransport(span<const double> tfix, span<const double> diff_e,
+                                   span<const double> mobi_e)
 {
     m_import_electron_transport = true;
     size_t degree = 5;

--- a/src/oneD/MultiJac.cpp
+++ b/src/oneD/MultiJac.cpp
@@ -35,7 +35,7 @@ void MultiJac::setValue(size_t row, size_t col, double value)
     }
 }
 
-void MultiJac::updateTransient(double rdt, integer* mask)
+void MultiJac::updateTransient(double rdt, span<const int> mask)
 {
     for (size_t n = 0; n < m_dim; n++) {
         m_mat.value(n,n) = m_ssdiag[n] - mask[n]*rdt;

--- a/src/oneD/MultiNewton.cpp
+++ b/src/oneD/MultiNewton.cpp
@@ -36,7 +36,7 @@ void MultiNewton::step(span<const double> x, span<double> step,
 
     auto jac = r.linearSolver();
     try {
-        jac->solve(r.size(), step.data(), step.data());
+        jac->solve(step, step);
     } catch (CanteraError&) {
         if (jac->info() > 0) {
             // Positive value for "info" indicates the row where factorization failed
@@ -224,7 +224,7 @@ int MultiNewton::solve(span<const double> x0, span<double> x1,
         if (forceNewJac) {
             r.evalJacobian(m_x);
             try {
-                jac->updateTransient(rdt, r.transientMask().data());
+                jac->updateTransient(rdt, r.transientMask());
             } catch (CanteraError& err) {
                 // Allow solver to continue after failure to factorize the steady-state
                 // Jacobian by returning to time stepping mode

--- a/src/oneD/OneDim.cpp
+++ b/src/oneD/OneDim.cpp
@@ -182,6 +182,10 @@ void OneDim::resize()
     m_componentInfo.clear();
     size_t lc = 0;
 
+    if (left()) {
+        left()->locate();
+    }
+
     // save the statistics for the last grid
     saveStats();
     m_pts = 0;
@@ -252,16 +256,15 @@ void OneDim::eval(size_t j, span<const double> x, span<double> r, double rdt, in
     if (rdt < 0.0) {
         rdt = m_rdt;
     }
-    double* xdata = const_cast<double*>(x.data());
 
     // iterate over the bulk domains first
     for (const auto& d : m_bulk) {
-        d->eval(j, xdata, r.data(), m_mask.data(), rdt);
+        d->eval(j, x, r, m_mask, rdt);
     }
 
     // then over the connector domains
     for (const auto& d : m_connect) {
-        d->eval(j, xdata, r.data(), m_mask.data(), rdt);
+        d->eval(j, x, r, m_mask, rdt);
     }
 
     // increment counter and time
@@ -325,7 +328,7 @@ void OneDim::initTimeInteg(double dt, span<const double> x)
     // iterate over all domains, preparing each one to begin time stepping
     Domain1D* d = left();
     while (d) {
-        d->initTimeInteg(dt, x.data());
+        d->initTimeInteg(dt, x);
         d = d->right();
     }
 }
@@ -359,7 +362,7 @@ void OneDim::init()
 void OneDim::resetBadValues(span<double> x)
 {
     for (auto dom : m_dom) {
-        dom->resetBadValues(x.data());
+        dom->resetBadValues(x);
     }
 }
 

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -776,7 +776,7 @@ void Sim1D::evalSSJacobian()
     OneDim::evalSSJacobian(*m_state);
 }
 
-void Sim1D::solveAdjoint(const double* b, double* lambda)
+void Sim1D::solveAdjoint(span<const double> b, span<double> lambda)
 {
     for (auto& D : m_dom) {
         D->forceFullUpdate(true);
@@ -801,7 +801,7 @@ void Sim1D::solveAdjoint(const double* b, double* lambda)
         }
     }
 
-    Jt.solve(b, lambda);
+    Jt.solve(b.data(), lambda.data());
 }
 
 void Sim1D::resize()

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -111,7 +111,7 @@ void Sim1D::saveResidual(const string& fname, const string& name,
                          const string& desc, bool overwrite, int compression)
 {
     vector<double> res(m_state->size(), -999);
-    OneDim::eval(npos, m_state->data(), &res[0], 0.0);
+    OneDim::eval(npos, *m_state, res, 0.0);
     // Temporarily put the residual into m_state, since this is the vector that the
     // save() function reads.
     vector<double> backup(*m_state);
@@ -765,7 +765,7 @@ size_t Sim1D::maxGridPoints(size_t dom)
 
 void Sim1D::evalSSJacobian()
 {
-    OneDim::evalSSJacobian(m_state->data(), m_xnew.data());
+    OneDim::evalSSJacobian(*m_state);
 }
 
 void Sim1D::solveAdjoint(const double* b, double* lambda)

--- a/src/oneD/refine.cpp
+++ b/src/oneD/refine.cpp
@@ -40,7 +40,7 @@ void Refiner::setCriteria(double ratio, double slope, double curve, double prune
     m_prune = prune;
 }
 
-int Refiner::analyze(size_t n, const double* z, const double* x)
+int Refiner::analyze(size_t n, span<const double> z, span<const double> x)
 {
     if (n >= m_npmax) {
         throw CanteraError("Refiner::analyze", "max number of grid points reached ({}).", m_npmax);
@@ -208,7 +208,7 @@ int Refiner::analyze(size_t n, const double* z, const double* x)
     return int(m_insertPts.size());
 }
 
-double Refiner::value(const double* x, size_t n, size_t j)
+double Refiner::value(span<const double> x, size_t n, size_t j)
 {
     return x[m_domain->index(n,j)];
 }

--- a/src/thermo/EEDFTwoTermApproximation.cpp
+++ b/src/thermo/EEDFTwoTermApproximation.cpp
@@ -107,7 +107,7 @@ void EEDFTwoTermApproximation::converge(Eigen::VectorXd& f0)
 
         Eigen::VectorXd f0_old = f0;
         f0 = iterate(f0_old, delta);
-        checkFinite("EEDFTwoTermApproximation::converge: f0", f0.data(), f0.size());
+        checkFinite("EEDFTwoTermApproximation::converge: f0", asSpan(f0));
 
         err0 = err1;
         Eigen::VectorXd Df0 = (f0_old - f0).cwiseAbs();
@@ -166,7 +166,7 @@ Eigen::VectorXd EEDFTwoTermApproximation::iterate(const Eigen::VectorXd& f0, dou
         return f0;
     }
 
-    checkFinite("EEDFTwoTermApproximation::converge: f0", f1.data(), f1.size());
+    checkFinite("EEDFTwoTermApproximation::converge: f0", asSpan(f1));
     f1 /= norm(f1, m_gridCenter);
     return f1;
 }
@@ -371,7 +371,7 @@ double EEDFTwoTermApproximation::netProductionFrequency(const Eigen::VectorXd& f
                               m_X_targets[m_klocTargets[k]];
             Eigen::VectorXd s = PQ * f0;
             checkFinite("EEDFTwoTermApproximation::netProductionFrequency: s",
-                        s.data(), s.size());
+                        asSpan(s));
             nu += s.sum();
         }
     }

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -206,9 +206,9 @@ double ReactorBase::temperature() const
     return m_thermo->temperature();
 }
 
-const double* ReactorBase::massFractions() const
+span<const double> ReactorBase::massFractions() const
 {
-    return m_thermo->massFractions().data();
+    return m_thermo->massFractions();
 }
 
 double ReactorBase::massFraction(size_t k) const

--- a/src/zeroD/ReactorFactory.cpp
+++ b/src/zeroD/ReactorFactory.cpp
@@ -116,27 +116,27 @@ void ReactorSurfaceFactory::deleteFactory() {
 ReactorSurfaceFactory::ReactorSurfaceFactory()
 {
     reg("ReactorSurface",
-        [](shared_ptr<Solution> surf, const vector<shared_ptr<ReactorBase>>& reactors,
+        [](shared_ptr<Solution> surf, span<shared_ptr<ReactorBase>> reactors,
            bool clone, const string& name)
         { return new ReactorSurface(surf, reactors, clone, name); });
     reg("MoleReactorSurface",
-        [](shared_ptr<Solution> surf, const vector<shared_ptr<ReactorBase>>& reactors,
+        [](shared_ptr<Solution> surf, span<shared_ptr<ReactorBase>> reactors,
            bool clone, const string& name)
         { return new MoleReactorSurface(surf, reactors, clone, name); });
     reg("FlowReactorSurface",
-        [](shared_ptr<Solution> surf, const vector<shared_ptr<ReactorBase>>& reactors,
+        [](shared_ptr<Solution> surf, span<shared_ptr<ReactorBase>> reactors,
            bool clone, const string& name)
         { return new FlowReactorSurface(surf, reactors, clone, name); });
     reg("ExtensibleReactorSurface",
-        [](shared_ptr<Solution> surf, const vector<shared_ptr<ReactorBase>>& reactors,
+        [](shared_ptr<Solution> surf, span<shared_ptr<ReactorBase>> reactors,
            bool clone, const string& name)
         { return new ReactorDelegator<ReactorSurface>(surf, reactors, clone, name); });
     reg("ExtensibleMoleReactorSurface",
-        [](shared_ptr<Solution> surf, const vector<shared_ptr<ReactorBase>>& reactors,
+        [](shared_ptr<Solution> surf, span<shared_ptr<ReactorBase>> reactors,
            bool clone, const string& name)
         { return new ReactorDelegator<MoleReactorSurface>(surf, reactors, clone, name); });
     reg("ExtensibleFlowReactorSurface",
-        [](shared_ptr<Solution> surf, const vector<shared_ptr<ReactorBase>>& reactors,
+        [](shared_ptr<Solution> surf, span<shared_ptr<ReactorBase>> reactors,
            bool clone, const string& name)
         { return new ReactorDelegator<FlowReactorSurface>(surf, reactors, clone, name); });
 }
@@ -175,7 +175,7 @@ shared_ptr<Reservoir> newReservoir(
 }
 
 shared_ptr<ReactorSurface> newReactorSurface(shared_ptr<Solution> phase,
-    const vector<shared_ptr<ReactorBase>>& reactors, bool clone, const string& name)
+    span<shared_ptr<ReactorBase>> reactors, bool clone, const string& name)
 {
     if (reactors.empty()) {
         throw CanteraError("newReactorSurface",
@@ -196,7 +196,7 @@ shared_ptr<ReactorSurface> newReactorSurface(shared_ptr<Solution> phase,
 }
 
 shared_ptr<ReactorSurface> newReactorSurface(const string& model,
-    shared_ptr<Solution> phase, const vector<shared_ptr<ReactorBase>>& reactors,
+    shared_ptr<Solution> phase, span<shared_ptr<ReactorBase>> reactors,
     bool clone, const string& name)
 {
     return shared_ptr<ReactorSurface>(ReactorSurfaceFactory::factory()->create(

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -408,7 +408,7 @@ Eigen::SparseMatrix<double> ReactorNet::steadyJacobian(double rdt)
     SteadyReactorSolver solver(this, y0);
     solver.evalJacobian(y0);
     if (rdt) {
-        solver.linearSolver()->updateTransient(rdt, solver.transientMask().data());
+        solver.linearSolver()->updateTransient(rdt, solver.transientMask());
     }
     return std::dynamic_pointer_cast<EigenSparseJacobian>(solver.linearSolver())->jacobian();
 }
@@ -784,7 +784,7 @@ void ReactorNet::preconditionerSolve(span<const double> rhs, span<double> output
         throw CanteraError("ReactorNet::preconditionerSolve",
                            "Must only be called after ReactorNet is initialized.");
     }
-    m_integ->preconditionerSolve(m_nv, const_cast<double*>(rhs.data()), output.data());
+    m_integ->preconditionerSolve(rhs, output);
 }
 
 void ReactorNet::preconditionerSetup(double t, span<const double> y, double gamma)

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -970,7 +970,7 @@ void SteadyReactorSolver::writeDebugInfo(const string& header_suffix,
     }
 }
 
-shared_ptr<ReactorNet> newReactorNet(vector<shared_ptr<ReactorBase>>& reactors)
+shared_ptr<ReactorNet> newReactorNet(span<shared_ptr<ReactorBase>> reactors)
 {
     return make_shared<ReactorNet>(reactors);
 }

--- a/src/zeroD/ReactorSurface.cpp
+++ b/src/zeroD/ReactorSurface.cpp
@@ -14,7 +14,7 @@ namespace Cantera
 {
 
 ReactorSurface::ReactorSurface(shared_ptr<Solution> soln,
-                               const vector<shared_ptr<ReactorBase>>& reactors,
+                               span<shared_ptr<ReactorBase>> reactors,
                                bool clone,
                                const string& name)
     : ReactorBase(name)
@@ -319,7 +319,7 @@ void MoleReactorSurface::getJacobianElements(vector<Eigen::Triplet<double>>& tri
 // ------ FlowReactorSurface methods ------
 
 FlowReactorSurface::FlowReactorSurface(shared_ptr<Solution> soln,
-                                       const vector<shared_ptr<ReactorBase>>& reactors,
+                                       span<shared_ptr<ReactorBase>> reactors,
                                        bool clone,
                                        const string& name)
     : ReactorSurface(soln, reactors, clone, name)

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -182,8 +182,8 @@ TEST(zerodim, test_individual_reactor_initialization)
     // get state of reactors
     vector<double> state1(reactor1->neq());
     vector<double> state2(reactor2->neq());
-    reactor1->getState(state1.data());
-    reactor2->getState(state2.data());
+    reactor1->getState(state1);
+    reactor2->getState(state2);
     // compare the reactors.
     EXPECT_EQ(reactor1->neq(), reactor2->neq());
     for (size_t i = 0; i < reactor1->neq(); i++) {
@@ -238,7 +238,7 @@ TEST(MoleReactorTestSet, test_mole_reactor_get_state)
     double O2_Moles = imw[O2I] * 0.5 * mass;
     double  H2_Moles = imw[H2I] * 0.5 * mass;
     // test getState
-    reactor.getState(state.data());
+    reactor.getState(state);
     EXPECT_NEAR(state[reactor.componentIndex("H2")], H2_Moles, tol);
     EXPECT_NEAR(state[reactor.componentIndex("O2")], O2_Moles, tol);
     EXPECT_NEAR(reactor.volume(), 0.5, tol);

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -272,7 +272,7 @@ TEST(AdaptivePreconditionerTests, test_adaptive_precon_utils)
     // test solve
     vector<double> output(testSize, 0);
     vector<double> rhs_vector(testSize, 10);
-    precon.solve(testSize, rhs_vector.data(), output.data());
+    precon.solve(rhs_vector, output);
     for (size_t i = 0; i < testSize; i++) {
         EXPECT_NEAR(rhs_vector[i], output[i], tol);
     }


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

This PR continues the work started in #2077 and #2085 toward implementing Cantera/enhancements#237, updating the reactor network and 1D flame modules, along with the associated solver-related classes.

**AI Statement (required)**

- **Extensive use of generative AI.** Significant portions of code or documentation were generated with AI, including logic and implementation decisions. All generated code and documentation were reviewed and understood by the contributor. *The code in this PR was written with the assistance of ChatGPT Codex 5.3*.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
