### PR TITLE
Convert Transport, numerics and various utilities to using std::span

### DIFF
--- a/doc/sphinx/develop/style-guidelines.md
+++ b/doc/sphinx/develop/style-guidelines.md
@@ -42,12 +42,16 @@ it easier for others to understand your code in the context of Cantera as a whol
   GCC 13.2, Clang 18.0, Visual Studio 2019 version 16.11 and Intel 2023.1.
 * Cantera moves frequently used C++ standard namespace types and functions into the
   declarative region, meaning that the `std` scope resolution can be omitted. This
-  applies to the following: `string`, `vector`, `map`, `set`, `pair`, `shared_ptr`,
-  `make_shared`, `unique_ptr`, `make_unique` and `function`. Example: use `string`
-  instead of `std::string`; a `using namespace std;` declaration is not required.
+  applies to the following: `string`, `vector`, `span`, `map`, `set`, `pair`,
+  `shared_ptr`, `make_shared`, `unique_ptr`, `make_unique` and `function`. Example: use
+  `string` instead of `std::string`; a `using namespace std;` declaration is not
+  required.
 * Avoid manual memory management (that is, `new` and `delete`), preferring to use
   standard library containers, as well as `unique_ptr` and `shared_ptr` when dynamic
   allocation is required.
+* Methods which take array arguments should use `span<double>` or `span<const double>`
+  instead of bare pointers that do not provide size information, and instead of specific
+  types that require the user to use a particular container like `std::vector<double>&`.
 * Portions of Boost which are "header only" may be used. If possible, include Boost
   header files only within .cpp files rather than other header files to avoid
   unnecessary increases in compilation time. Boost should not be added to the public

--- a/doc/sphinx/reference/releasenotes/index.md
+++ b/doc/sphinx/reference/releasenotes/index.md
@@ -3,6 +3,7 @@
 ```{toctree}
 :maxdepth: 1
 
+v4.0
 v3.2
 v3.1
 v3.0

--- a/doc/sphinx/reference/releasenotes/v4.0.md
+++ b/doc/sphinx/reference/releasenotes/v4.0.md
@@ -1,0 +1,54 @@
+# Cantera 4.0.0
+
+*Under development*
+
+## Breaking Changes
+
+As a new major version, Cantera 4.0 includes a number of backwards-incompatible changes
+which may require updates to user code. These changes are summarized here, along with
+some guidance on how to migrate existing code.
+
+### C++: Transition to `std::span` for array arguments
+
+Methods operating on arrays have been modified to take `std::span` arguments instead of
+pointers to unsized arrays or references to `std::vector`. This approach provides the
+opportunity to ensure array sizes are correct while providing compatibility with
+different data containers. For example, `Phase::getMoleFractions(double* x)` has been
+replaced with `Phase::getMoleFractions(span<double> x)`.
+
+The following code demonstrates how to use different container types with Cantera's
+methods that take `span` arguments:
+
+```{code-block} C++
+using namespace Cantera;
+
+auto soln = newSolution("mech.yaml");
+auto phase = soln->thermo();
+vector<double> x1(phase->nSpecies());
+Eigen::ArrayXd x2 = Eigen::ArrayXd::Zero(phase->nSpecies());
+
+// custom user container for multiple states
+MyVector x3(4 * phase->nSpecies());
+size_t offset = 2 * phase->nSpecies();
+
+// Old call signatures (Cantera 3.2 and older)
+phase->getMoleFractions(x1.data());
+phase->getMoleFractions(x2.data());
+phase->getMoleFractions(&x3[offset]);
+
+// New call signatures (Cantera 4.0 and newer)
+phase->getMoleFractions(x1);
+phase->getMoleFractions(asSpan(x2)); // Eigen 3.4.0
+phase->getMoleFractions(x2); // Eigen 5.0
+phase->getMoleFractions(span<const double>(&x3[offset], phase->nSpecies()));
+```
+
+For methods that had an extra argument specifying array sizes, this argument has
+been removed. For example,
+`PlasmaPhase::setElectronEnergyLevels(const double* levels, size_t length)` is now just
+`PlasmaPhase::setElectronEnergyLevels(span<const double> levels)`.
+
+Additionally, a number of methods which previously returned references to `std::vector`
+have been updated to return `std::span` instead. For example,
+`const std::vector<double> Phase::molecularWeights()` has been replaced with
+`span<const double> Phase::molecularWeights()`.

--- a/include/cantera/base/Array.h
+++ b/include/cantera/base/Array.h
@@ -56,7 +56,7 @@ public:
      * @param values Initial values of the array. Must be of length m*n, and
      *     stored in column-major order.
      */
-    Array2D(const size_t m, const size_t n, const double* values);
+    Array2D(const size_t m, const size_t n, span<const double> values);
 
     Array2D(const Array2D& y);
 
@@ -79,23 +79,14 @@ public:
      * @param c  This vector is the entries in the column to be added. It must
      *           have a length equal to m_nrows or greater.
      */
-    void appendColumn(const vector<double>& c);
-
-    //! Append a column to the existing matrix
-    /*!
-     * This operation will add a column onto the existing matrix.
-     *
-     * @param c  This vector of doubles is the entries in the column to be
-     *           added. It must have a length equal to m_nrows or greater.
-     */
-    void appendColumn(const double* const c);
+    void appendColumn(span<const double> c);
 
     //! Set the nth row to array rw
     /*!
      * @param  n   Index of the row to be changed
      * @param  rw  Vector for the row. Must have a length of m_ncols.
      */
-    void setRow(size_t n, const double* const rw);
+    void setRow(size_t n, span<const double> rw);
 
     //! Get the nth row and return it in a vector
     /*!
@@ -103,7 +94,7 @@ public:
      * @param rw   Return Vector for the operation. Must have a length of
      *             m_ncols.
      */
-    void getRow(size_t n, double* const rw);
+    void getRow(size_t n, span<double> rw) const;
 
     //! Set the values in column m to those in array col
     /*!
@@ -112,7 +103,7 @@ public:
      * @param m   Column to set
      * @param col pointer to a col vector. Vector must have a length of m_nrows.
      */
-    void setColumn(size_t m, double* const col);
+    void setColumn(size_t m, span<const double> col);
 
     //! Get the values in column m
     /*!
@@ -121,7 +112,7 @@ public:
      * @param m    Column to set
      * @param col  pointer to a col vector that will be returned
      */
-    void getColumn(size_t m, double* const col);
+    void getColumn(size_t m, span<double> col) const;
 
     //! Set all of the entries to zero
     void zero() {
@@ -194,24 +185,14 @@ public:
 
     void operator*=(double a);
 
-    //! Return a pointer to the top of column j, columns are contiguous
-    //! in memory
-    /*!
-     * @param j   Value of the column
-     * @returns a pointer to the top of the column
-     */
-    double* ptrColumn(size_t j) {
-        return &m_data[m_nrows*j];
+    //! Return a writable span over column `j`.
+    span<double> col(size_t j) {
+        return span<double>(m_data.data() + m_nrows * j, m_nrows);
     }
 
-    //! Return a const pointer to the top of column j, columns are contiguous
-    //! in memory
-    /*!
-     * @param j   Value of the column
-     * @returns a const pointer to the top of the column
-     */
-    const double* ptrColumn(size_t j) const {
-        return &m_data[m_nrows*j];
+    //! Return a read-only span over column `j`.
+    span<const double> col(size_t j) const {
+        return span<const double>(m_data.data() + m_nrows * j, m_nrows);
     }
 
 protected:

--- a/include/cantera/base/ct_defs.h
+++ b/include/cantera/base/ct_defs.h
@@ -28,7 +28,7 @@
 #include <algorithm>
 #include <memory>
 #include <functional>
-#include <span>
+#include <array>
 
 /**
  * Namespace for the Cantera kernel.

--- a/include/cantera/base/stringUtils.h
+++ b/include/cantera/base/stringUtils.h
@@ -101,9 +101,9 @@ double fpValueCheck(const string& val);
  * The separate tokens are returned in a string vector, v.
  *
  * @param oval   String to be broken up
- * @param v     Output vector of tokens.
+ * @returns      Vector of tokens.
  */
-void tokenizeString(const string& oval, vector<string>& v);
+vector<string> tokenizeString(const string& oval);
 
 //! This function separates a string up into tokens according to the location of
 //! path separators.
@@ -111,11 +111,11 @@ void tokenizeString(const string& oval, vector<string>& v);
  * The separate tokens are returned in a string vector, v.
  *
  * @param oval   String to be broken up
- * @param v     Output vector of tokens.
+ * @returns      Vector of tokens.
  *
  * @since New in %Cantera 3.0.
  */
-void tokenizePath(const string& oval, vector<string>& v);
+vector<string> tokenizePath(const string& oval);
 
 //! Copy the contents of a string into a char array of a given length
 /*!

--- a/include/cantera/base/utilities.h
+++ b/include/cantera/base/utilities.h
@@ -20,7 +20,9 @@
 #define CT_UTILITIES_H
 
 #include "ct_defs.h"
+#include "cantera/base/ctexceptions.h"
 #include <numeric>
+#include <iterator>
 
 namespace Cantera
 {
@@ -36,10 +38,16 @@ namespace Cantera
  * @param y   second reference to the templated class V
  * @return This class returns a hard-coded type, double.
  */
-template<class V>
-inline double dot4(const V& x, const V& y)
+template<class X, class Y>
+inline auto dot4(const X& x, const Y& y)
 {
-    return x[0]*y[0] + x[1]*y[1] + x[2]*y[2] + x[3]*y[3];
+    auto x_ = span{std::data(x), std::size(x)};
+    auto y_ = span{std::data(y), std::size(y)};
+#ifndef NDEBUG
+    checkArraySize("dot4: x", x_.size(), 4);
+    checkArraySize("dot4: y", y_.size(), 4);
+#endif
+    return x_[0]*y_[0] + x_[1]*y_[1] + x_[2]*y_[2] + x_[3]*y_[3];
 }
 
 //! Templated Inner product of two vectors of length 5
@@ -51,11 +59,17 @@ inline double dot4(const V& x, const V& y)
  * @param y   second reference to the templated class V
  * @return This class returns a hard-coded type, double.
  */
-template<class V>
-inline double dot5(const V& x, const V& y)
+template<class X, class Y>
+inline auto dot5(const X& x, const Y& y)
 {
-    return x[0]*y[0] + x[1]*y[1] + x[2]*y[2] + x[3]*y[3] +
-           x[4]*y[4];
+    auto x_ = span{std::data(x), std::size(x)};
+    auto y_ = span{std::data(y), std::size(y)};
+#ifndef NDEBUG
+    checkArraySize("dot5: x", x_.size(), 5);
+    checkArraySize("dot5: y", y_.size(), 5);
+#endif
+    return x_[0]*y_[0] + x_[1]*y_[1] + x_[2]*y_[2] + x_[3]*y_[3] +
+           x_[4]*y_[4];
 }
 
 //! Function that calculates a templated inner product.
@@ -113,11 +127,15 @@ inline void scale(InputIter begin, InputIter end,
  * @param x   Value of the independent variable - First template parameter
  * @param c   Pointer to the polynomial - Second template parameter
  */
-template<class D, class R>
-R poly6(D x, R* c)
+template<class D, class C>
+auto poly6(D x, const C& c)
 {
-    return ((((((c[6]*x + c[5])*x + c[4])*x + c[3])*x +
-              c[2])*x + c[1])*x + c[0]);
+    auto c_ = span{std::data(c), std::size(c)};
+#ifndef NDEBUG
+    checkArraySize("poly6: c", c_.size(), 7);
+#endif
+    return ((((((c_[6]*x + c_[5])*x + c_[4])*x + c_[3])*x +
+              c_[2])*x + c_[1])*x + c_[0]);
 }
 
 //! Templated evaluation of a polynomial of order 8
@@ -125,11 +143,15 @@ R poly6(D x, R* c)
  * @param x   Value of the independent variable - First template parameter
  * @param c   Pointer to the polynomial - Second template parameter
  */
-template<class D, class R>
-R poly8(D x, R* c)
+template<class D, class C>
+auto poly8(D x, const C& c)
 {
-    return ((((((((c[8]*x + c[7])*x + c[6])*x + c[5])*x + c[4])*x + c[3])*x +
-              c[2])*x + c[1])*x + c[0]);
+    auto c_ = span{std::data(c), std::size(c)};
+#ifndef NDEBUG
+    checkArraySize("poly8: c", c_.size(), 9);
+#endif
+    return ((((((((c_[8]*x + c_[7])*x + c_[6])*x + c_[5])*x + c_[4])*x + c_[3])*x +
+              c_[2])*x + c_[1])*x + c_[0]);
 }
 
 //! Templated evaluation of a polynomial of order 5
@@ -137,11 +159,15 @@ R poly8(D x, R* c)
  * @param x   Value of the independent variable - First template parameter
  * @param c   Pointer to the polynomial - Second template parameter
  */
-template<class D, class R>
-R poly5(D x, R* c)
+template<class D, class C>
+auto poly5(D x, const C& c)
 {
-    return (((((c[5]*x + c[4])*x + c[3])*x +
-              c[2])*x + c[1])*x + c[0]);
+    auto c_ = span{std::data(c), std::size(c)};
+#ifndef NDEBUG
+    checkArraySize("poly5: c", c_.size(), 6);
+#endif
+    return (((((c_[5]*x + c_[4])*x + c_[3])*x +
+              c_[2])*x + c_[1])*x + c_[0]);
 }
 
 //! Evaluates a polynomial of order 4.
@@ -149,11 +175,15 @@ R poly5(D x, R* c)
  * @param x   Value of the independent variable.
  * @param c   Pointer to the polynomial coefficient array.
  */
-template<class D, class R>
-R poly4(D x, R* c)
+template<class D, class C>
+auto poly4(D x, const C& c)
 {
-    return ((((c[4]*x + c[3])*x +
-              c[2])*x + c[1])*x + c[0]);
+    auto c_ = span{std::data(c), std::size(c)};
+#ifndef NDEBUG
+    checkArraySize("poly4: c", c_.size(), 5);
+#endif
+    return ((((c_[4]*x + c_[3])*x +
+              c_[2])*x + c_[1])*x + c_[0]);
 }
 
 //! Templated evaluation of a polynomial of order 3
@@ -161,10 +191,14 @@ R poly4(D x, R* c)
  * @param x   Value of the independent variable - First template parameter
  * @param c   Pointer to the polynomial - Second template parameter
  */
-template<class D, class R>
-R poly3(D x, R* c)
+template<class D, class C>
+auto poly3(D x, const C& c)
 {
-    return (((c[3]*x + c[2])*x + c[1])*x + c[0]);
+    auto c_ = span{std::data(c), std::size(c)};
+#ifndef NDEBUG
+    checkArraySize("poly3: c", c_.size(), 4);
+#endif
+    return (((c_[3]*x + c_[2])*x + c_[1])*x + c_[0]);
 }
 
 //! @}

--- a/include/cantera/cython/thermo_utils.h
+++ b/include/cantera/cython/thermo_utils.h
@@ -5,12 +5,9 @@
 #define CT_PY_THERMO_UTILS_H
 
 #include "cantera/thermo/ThermoPhase.h"
+#include "wrappers.h"
 
-using std::span;
-
-#define THERMO_1D(FUNC_NAME) \
-    inline void thermo_ ## FUNC_NAME(Cantera::ThermoPhase* object, span<double> data) \
-    { object->FUNC_NAME(data); }
+#define THERMO_1D(FUNC_NAME) ARRAY_FUNC(thermo, ThermoPhase, FUNC_NAME)
 
 THERMO_1D(getMassFractions)
 THERMO_1D(setMassFractions)

--- a/include/cantera/cython/wrappers.h
+++ b/include/cantera/cython/wrappers.h
@@ -15,21 +15,21 @@ inline void CxxArray2D_set(Cantera::Array2D& array, size_t i, size_t j, double v
 
 // Function which populates a 1D array
 #define ARRAY_FUNC(PREFIX, CLASS_NAME, FUNC_NAME) \
-    inline void PREFIX ## _ ## FUNC_NAME(Cantera::CLASS_NAME* object, double* data) \
+    inline void PREFIX ## _ ## FUNC_NAME(Cantera::CLASS_NAME* object, std::span<double> data) \
     { object->FUNC_NAME(data); }
 
 // function which takes a stride as the first argument and populates a 2D array
 #define ARRAY_FUNC2(PREFIX, CLASS_NAME, FUNC_NAME) \
-    inline void PREFIX ## _ ## FUNC_NAME(Cantera::CLASS_NAME* object, size_t dim, double* data) \
+    inline void PREFIX ## _ ## FUNC_NAME(Cantera::CLASS_NAME* object, size_t dim, std::span<double> data) \
     { object->FUNC_NAME(dim, data); }
 
 // Function which populates a 1D array, extra arguments
 #define ARRAY_POLY(PREFIX, CLASS_NAME, FUNC_NAME) \
-    inline void PREFIX ## _ ## FUNC_NAME(Cantera::CLASS_NAME* object, size_t i, double* data) \
+    inline void PREFIX ## _ ## FUNC_NAME(Cantera::CLASS_NAME* object, size_t i, std::span<double> data) \
     { object->FUNC_NAME(i, data); }
 
 #define ARRAY_POLY_BINARY(PREFIX, CLASS_NAME, FUNC_NAME) \
-    inline void PREFIX ## _ ## FUNC_NAME(Cantera::CLASS_NAME* object, size_t i, size_t j, double* data) \
+    inline void PREFIX ## _ ## FUNC_NAME(Cantera::CLASS_NAME* object, size_t i, size_t j, std::span<double> data) \
     { object->FUNC_NAME(i, j, data); }
 
 #endif

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -723,7 +723,7 @@ std::ostream& operator<<(std::ostream& s, MultiPhase& x);
  *
  * @ingroup equilGroup
  */
-size_t BasisOptimize(int* usedZeroedSpecies, bool doFormRxn, MultiPhase* mphase,
+size_t BasisOptimize(bool& usedZeroedSpecies, bool doFormRxn, MultiPhase* mphase,
                      span<size_t> orderVectorSpecies, span<size_t> orderVectorElements,
                      span<double> formRxnMatrix);
 

--- a/include/cantera/equil/vcs_solve.h
+++ b/include/cantera/equil/vcs_solve.h
@@ -280,12 +280,10 @@ public:
 
     //! Decision as to whether a phase pops back into existence
     /*!
-     * @param  phasePopPhaseIDs Vector containing the phase ids of the phases
-     *         that will be popped this step.
      * @returns the phase id of the phase that pops back into existence. Returns
      *         -1 if there are no phases
      */
-    size_t vcs_popPhaseID(vector<size_t> &phasePopPhaseIDs);
+    size_t vcs_popPhaseID();
 
     //! Calculates the deltas of the reactions due to phases popping
     //! into existence
@@ -719,7 +717,7 @@ private:
      *                         branch to the section that deletes a species
      *                         from the current set of active species.
      */
-    double vcs_minor_alt_calc(size_t kspec, size_t irxn, bool* do_delete) const;
+    double vcs_minor_alt_calc(size_t kspec, size_t irxn, bool& do_delete) const;
 
     //! This routine optimizes the minimization of the total Gibbs free energy
     //! by making sure the slope of the following functional stays negative:

--- a/include/cantera/equil/vcs_solve.h
+++ b/include/cantera/equil/vcs_solve.h
@@ -568,7 +568,7 @@ public:
      *
      *  Still need to check out when we do loops over nc vs. ne.
      */
-    int vcs_elcorr(double aa[], double x[]);
+    int vcs_elcorr(span<double> aa, span<double> x);
 
     //! Create an initial estimate of the solution to the equilibrium problem.
     void vcs_inest();
@@ -749,7 +749,7 @@ private:
      *
      * @param dg Vector of local delta G's.
      */
-    double l2normdg(double dg[]) const;
+    double l2normdg(span<const double> dg) const;
 
     void checkDelta1(span<const double> ds, span<const double> delTPhMoles,
                      size_t kspec);

--- a/include/cantera/numerics/AdaptivePreconditioner.h
+++ b/include/cantera/numerics/AdaptivePreconditioner.h
@@ -29,7 +29,7 @@ public:
     const string type() const override { return "Adaptive"; }
     void factorize() override;
     void solve(span<const double> rhs_vector, span<double> output) override;
-    void stateAdjustment(vector<double>& state) override;
+    void stateAdjustment(span<double> state) override;
 
     int info() const override {
         return static_cast<int>(m_solver.info());

--- a/include/cantera/numerics/BandMatrix.h
+++ b/include/cantera/numerics/BandMatrix.h
@@ -173,31 +173,6 @@ public:
     //! Returns the one norm of the matrix
     double oneNorm() const override;
 
-    //! Return a writable span over column `j`.
-    /*!
-     * Column values are assumed to be contiguous in memory (LAPACK band matrix
-     * structure)
-     *
-     * On entry, the matrix A in band storage, in rows KL+1 to 2*KL+KU+1; rows 1
-     * to KL of the array need not be set. The j-th column of A is stored in the
-     * j-th column of the array AB as follows:
-     *
-     * AB(KL + KU + 1 + i - j,j) = A(i,j) for max(1, j - KU) <= i <= min(m, j + KL)
-     *
-     * This routine returns a span starting at the position of AB(1,j)
-     * (fortran-1 indexing) in the above format.
-     *
-     * So to address the (i,j) position, you use the following indexing:
-     *
-     *     auto col_j = matrix.col(j);
-     *     double a_i_j = col_j[kl + ku + i - j];
-     *
-     *  @param j   Value of the column
-     *  @returns   A span over the entire stored column
-     */
-    span<double> col(size_t j) override;
-    span<const double> col(size_t j) const override;
-
     //! Check to see if we have any zero rows in the Jacobian
     /*!
      * This utility routine checks to see if any rows are zero. The smallest row
@@ -227,6 +202,8 @@ protected:
 
     //! Factorized data
     vector<double> ludata;
+    //! Pointers into #ludata used by the SUNDIALS solver
+    vector<double*> m_lu_col_ptrs;
 
     //! Number of rows and columns of the matrix
     size_t m_n = 0;
@@ -245,15 +222,12 @@ protected:
     //! Pivot vector
     unique_ptr<PivData> m_ipiv;
 
-    //! Vector of column pointers
-    vector<double*> m_colPtrs;
-    vector<double*> m_lu_col_ptrs;
-
     //! Extra work array needed - size = n
     vector<int> iwork_;
 
     //! Extra dp work array needed - size = 3n
     vector<double> work_;
+
 
     int m_info = 0;
 };

--- a/include/cantera/numerics/BandMatrix.h
+++ b/include/cantera/numerics/BandMatrix.h
@@ -132,8 +132,8 @@ public:
     size_t ldim() const;
 
     //! Multiply A*b and write result to @c prod.
-    void mult(const double* b, double* prod) const override;
-    void leftMult(const double* const b, double* const prod) const override;
+    void mult(span<const double> b, span<double> prod) const override;
+    void leftMult(span<const double> b, span<double> prod) const override;
 
     //! Perform an LU decomposition, the LAPACK routine DGBTRF is used.
     //! The factorization is saved in ludata.
@@ -144,7 +144,7 @@ public:
      * @param b  INPUT RHS of the problem
      * @param x  OUTPUT solution to the problem
      */
-    void solve(const double* const b, double* const x);
+    void solve(span<const double> b, span<double> x);
 
     //! Solve the matrix problem Ax = b
     /*!
@@ -153,7 +153,7 @@ public:
      * @param nrhs  Number of right hand sides to solve
      * @param ldb   Leading dimension of `b`. Default is nColumns()
      */
-    void solve(double* b, size_t nrhs=1, size_t ldb=0) override;
+    void solve(span<double> b, size_t nrhs=1, size_t ldb=0) override;
 
     void zero() override;
 
@@ -173,7 +173,7 @@ public:
     //! Returns the one norm of the matrix
     double oneNorm() const override;
 
-    //! Return a pointer to the top of column j
+    //! Return a writable span over column `j`.
     /*!
      * Column values are assumed to be contiguous in memory (LAPACK band matrix
      * structure)
@@ -184,27 +184,19 @@ public:
      *
      * AB(KL + KU + 1 + i - j,j) = A(i,j) for max(1, j - KU) <= i <= min(m, j + KL)
      *
-     * This routine returns the position of AB(1,j) (fortran-1 indexing) in the
-     * above format
+     * This routine returns a span starting at the position of AB(1,j)
+     * (fortran-1 indexing) in the above format.
      *
      * So to address the (i,j) position, you use the following indexing:
      *
-     *     double *colP_j = matrix.ptrColumn(j);
-     *     double a_i_j = colP_j[kl + ku + i - j];
+     *     auto col_j = matrix.col(j);
+     *     double a_i_j = col_j[kl + ku + i - j];
      *
      *  @param j   Value of the column
-     *  @returns a pointer to the top of the column
+     *  @returns   A span over the entire stored column
      */
-    double* ptrColumn(size_t j) override;
-
-    //! Return a vector of const pointers to the columns
-    /*!
-     * Note the value of the pointers are protected by their being const.
-     * However, the value of the matrix is open to being changed.
-     *
-     * @returns a vector of pointers to the top of the columns of the matrices.
-     */
-    double* const* colPts() override;
+    span<double> col(size_t j) override;
+    span<const double> col(size_t j) const override;
 
     //! Check to see if we have any zero rows in the Jacobian
     /*!

--- a/include/cantera/numerics/DenseMatrix.h
+++ b/include/cantera/numerics/DenseMatrix.h
@@ -67,18 +67,7 @@ public:
      */
     void resize(size_t n, size_t m, double v=0.0) override;
 
-    virtual double* const* colPts();
-
-    //! Return a const vector of const pointers to the columns
-    /*!
-     * Note, the Jacobian can not be altered by this routine, and therefore the
-     * member function is const.
-     *
-     * @returns a vector of pointers to the top of the columns of the matrices.
-     */
-    const double* const* const_colPts() const;
-
-    virtual void mult(const double* b, double* prod) const;
+    virtual void mult(span<const double> b, span<double> prod) const;
 
     //! Multiply A*B and write result to @c prod.
     /*!
@@ -95,7 +84,7 @@ public:
      * @param prod  Resulting vector. This is of length m, the number of columns
      *              in the matrix
      */
-    virtual void leftMult(const double* const b, double* const prod) const;
+    virtual void leftMult(span<const double> b, span<double> prod) const;
 
     //! Return a changeable value of the pivot vector
     /*!
@@ -114,9 +103,6 @@ public:
 protected:
     //! Vector of pivots. Length is equal to the max of m and n.
     vector<int> m_ipiv;
-
-    //! Vector of column pointers
-    vector<double*> m_colPts;
 };
 
 
@@ -139,7 +125,7 @@ protected:
  * @param nrhs Number of right hand sides to solve
  * @param ldb  Leading dimension of b, if nrhs > 1
  */
-void solve(DenseMatrix& A, double* b, size_t nrhs=1, size_t ldb=0);
+void solve(DenseMatrix& A, span<double> b, size_t nrhs=1, size_t ldb=0);
 
 //! Solve Ax = b for multiple right-hand-side vectors.
 /*!
@@ -158,7 +144,7 @@ void solve(DenseMatrix& A, DenseMatrix& b);
  * @param[in]  b     vector b with length N
  * @param[out] prod  vector prod length = M
  */
-void multiply(const DenseMatrix& A, const double* const b, double* const prod);
+void multiply(const DenseMatrix& A, span<const double> b, span<double> prod);
 
 //! Multiply @c A*b and add it to the result in @c prod. Uses BLAS routine DGEMV.
 /*!
@@ -170,7 +156,7 @@ void multiply(const DenseMatrix& A, const double* const b, double* const prod);
  * @param[in]  b     vector b with length N
  * @param[out] prod  vector prod length = M
  */
-void increment(const DenseMatrix& A, const double* const b, double* const prod);
+void increment(const DenseMatrix& A, span<const double> b, span<double> prod);
 
 //! invert A. A is overwritten with A^-1.
 /*!

--- a/include/cantera/numerics/GeneralMatrix.h
+++ b/include/cantera/numerics/GeneralMatrix.h
@@ -118,10 +118,14 @@ public:
     }
 
     //! Return a writable span over column `j`.
-    virtual span<double> col(size_t j) = 0;
+    virtual span<double> col(size_t j) {
+        throw NotImplementedError("GeneralMatrix::col");
+    };
 
     //! Return a read-only span over column `j`.
-    virtual span<const double> col(size_t j) const = 0;
+    virtual span<const double> col(size_t j) const {
+        throw NotImplementedError("GeneralMatrix::col");
+    };
 
     //! Index into the (i,j) element
     /*!

--- a/include/cantera/numerics/GeneralMatrix.h
+++ b/include/cantera/numerics/GeneralMatrix.h
@@ -35,14 +35,14 @@ public:
      * @param b    Vector to do the rh multiplication
      * @param prod OUTPUT vector to receive the result
      */
-    virtual void mult(const double* b, double* prod) const = 0;
+    virtual void mult(span<const double> b, span<double> prod) const = 0;
 
     //! Multiply b*A and write result to prod.
     /*!
      * @param b    Vector to do the lh multiplication
      * @param prod OUTPUT vector to receive the result
      */
-    virtual void leftMult(const double* const b, double* const prod) const = 0;
+    virtual void leftMult(span<const double> b, span<double> prod) const = 0;
 
     //! Factors the A matrix, overwriting A.
     /*!
@@ -110,20 +110,18 @@ public:
      * @param ldb  Leading dimension of the right-hand side array. Defaults to
      *              nRows()
      */
-    virtual void solve(double* b, size_t nrhs=1, size_t ldb=0) = 0;
+    virtual void solve(span<double> b, size_t nrhs=1, size_t ldb=0) = 0;
 
     //! true if the current factorization is up to date with the matrix
     virtual bool factored() const {
         return (m_factored != 0);
     }
 
-    //! Return a pointer to the top of column j, columns are assumed to be
-    //! contiguous in memory
-    /*!
-     * @param j   Value of the column
-     * @returns a pointer to the top of the column
-     */
-    virtual double* ptrColumn(size_t j) = 0;
+    //! Return a writable span over column `j`.
+    virtual span<double> col(size_t j) = 0;
+
+    //! Return a read-only span over column `j`.
+    virtual span<const double> col(size_t j) const = 0;
 
     //! Index into the (i,j) element
     /*!
@@ -140,15 +138,6 @@ public:
      * @returns an unchangeable reference to the matrix entry
      */
     virtual double operator()(size_t i, size_t j) const = 0;
-
-    //! Return a vector of const pointers to the columns
-    /*!
-     * Note the value of the pointers are protected by their being const.
-     * However, the value of the matrix is open to being changed.
-     *
-     * @returns a vector of pointers to the top of the columns of the matrices.
-     */
-    virtual double* const* colPts() = 0;
 
     //! Check to see if we have any zero rows in the Jacobian
     /*!

--- a/include/cantera/numerics/SteadyStateSystem.h
+++ b/include/cantera/numerics/SteadyStateSystem.h
@@ -171,7 +171,6 @@ public:
     //! Set the number of time steps to try when the steady Newton solver is
     //! unsuccessful.
     //! @param stepsize  Initial time step size [s]
-    //! @param n  Length of `tsteps` array
     //! @param tsteps  A sequence of time step counts to take after subsequent failures
     //!     of the steady-state solver. The last value in `tsteps` will be used again
     //!     after further unsuccessful solution attempts.

--- a/include/cantera/numerics/SystemJacobian.h
+++ b/include/cantera/numerics/SystemJacobian.h
@@ -61,8 +61,8 @@ public:
     //! Adjust the state vector based on the preconditioner, e.g., Adaptive
     //! preconditioning uses a strictly positive composition when preconditioning which
     //! is handled by this function
-    //! @param state a vector containing the state to be updated
-    virtual void stateAdjustment(vector<double>& state) {
+    //! @param state a mutable span containing the state to be updated
+    virtual void stateAdjustment(span<double> state) {
         throw NotImplementedError("SystemJacobian::stateAdjustment");
     }
 

--- a/include/cantera/numerics/polyfit.h
+++ b/include/cantera/numerics/polyfit.h
@@ -19,19 +19,18 @@ namespace Cantera
  *
  * @f[ f(x) = p[0] + p[1] x + p[2] x^2 + \cdots + p[deg] x^deg @f]
  *
- * @param n    The number of points at which the function is evaluated
- * @param deg  The degree of the polynomial fit to be computed. deg <= n - 1.
- * @param x    Array of points at which the function is evaluated. Length *n*.
- * @param y    Array of function values at the points in *x*. Length *n*.
- * @param w    Array of weights. If w == nullptr or w[0] < 0, then all the
+ * @param deg  The degree of the polynomial fit to be computed. `deg <= x.size() - 1`.
+ * @param x    Array of points at which the function is evaluated.
+ * @param y    Array of function values at the points in *x*.
+ * @param w    Array of weights. If empty or `w[0] < 0`, then all the
  *     weights will be set to 1.0.
  * @param[out] p  Array of polynomial coefficients, starting with the constant
  *     term. Length *deg+1*.
  * @returns the root mean squared error of the fit at the input points.
  * @ingroup mathUtils
  */
-double polyfit(size_t n, size_t deg, const double* x, const double* y,
-               const double* w, double* p);
+double polyfit(size_t deg, span<const double> x, span<const double> y,
+               span<const double> w, span<double> p);
 
 }
 #endif

--- a/include/cantera/oneD/MultiJac.h
+++ b/include/cantera/oneD/MultiJac.h
@@ -44,7 +44,7 @@ public:
     }
 
     void solve(span<const double> b, span<double> x) override {
-        m_mat.solve(b.data(), x.data());
+        m_mat.solve(b, x);
     }
 
     int info() const override {

--- a/include/cantera/oneD/OneDim.h
+++ b/include/cantera/oneD/OneDim.h
@@ -29,7 +29,7 @@ public:
     OneDim() = default;
 
     //! Construct a OneDim container for the domains in the list *domains*.
-    OneDim(vector<shared_ptr<Domain1D>>& domains);
+    OneDim(span<const shared_ptr<Domain1D>> domains);
 
     //! Add a domain. Domains are added left-to-right.
     void addDomain(shared_ptr<Domain1D> d);

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -35,7 +35,7 @@ public:
      *     the pointer to the leftmost domain is domain[0], the pointer to the
      *     domain to its right is domain[1], etc.
      */
-    Sim1D(vector<shared_ptr<Domain1D>>& domains);
+    Sim1D(span<const shared_ptr<Domain1D>> domains);
 
     //! @name Setting initial values
     //!

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -1418,9 +1418,8 @@ private:
 
     //! Array of coefficients for Beta0, a variable in Pitzer's papers
     /*!
-     * Column index is counterIJ. m_Beta0MX_ij_coeff.ptrColumn(counterIJ) is a
-     * double* containing the vector of coefficients for the counterIJ
-     * interaction.
+     * Column index is counterIJ. m_Beta0MX_ij_coeff.col(counterIJ) is a
+     * `span` containing the coefficients for the counterIJ interaction.
      */
     mutable Array2D m_Beta0MX_ij_coeff;
 
@@ -1442,9 +1441,8 @@ private:
 
     //! Array of coefficients for Beta1, a variable in Pitzer's papers
     /*!
-     * Column index is counterIJ. m_Beta1MX_ij_coeff.ptrColumn(counterIJ) is a
-     * double* containing the vector of coefficients for the counterIJ
-     * interaction.
+     * Column index is counterIJ. m_Beta1MX_ij_coeff.col(counterIJ) is a
+     * `span` containing the vector of coefficients for the counterIJ interaction.
      */
     mutable Array2D m_Beta1MX_ij_coeff;
 
@@ -1466,8 +1464,8 @@ private:
 
     //! Array of coefficients for Beta2, a variable in Pitzer's papers
     /*!
-     * column index is counterIJ. m_Beta2MX_ij_coeff.ptrColumn(counterIJ) is a
-     *  double* containing the vector of coefficients for the counterIJ
+     * column index is counterIJ. m_Beta2MX_ij_coeff.col(counterIJ) is a
+     *  `span` containing the vector of coefficients for the counterIJ
      *  interaction. This was added for the YMP database version of the code
      *  since it contains temperature-dependent parameters for some 2-2
      *  electrolytes.
@@ -1508,8 +1506,8 @@ private:
     //! Array of coefficients for CphiMX, a parameter in the activity
     //! coefficient formulation
     /*!
-     *  Column index is counterIJ. m_CphiMX_ij_coeff.ptrColumn(counterIJ) is a
-     *  double* containing the vector of coefficients for the counterIJ
+     *  Column index is counterIJ. m_CphiMX_ij_coeff.col(counterIJ) is a
+     *  `span` containing the vector of coefficients for the counterIJ
      *  interaction.
      */
     mutable Array2D m_CphiMX_ij_coeff;
@@ -1542,8 +1540,8 @@ private:
      *  is symmetric. Column index is counterIJ. counterIJ where counterIJ =
      *  m_counterIJ[i][j] is used to access this array.
      *
-     *  m_Theta_ij_coeff.ptrColumn(counterIJ) is a double* containing
-     *  the vector of coefficients for the counterIJ interaction.
+     *  m_Theta_ij_coeff.col(counterIJ) is a `span` containing the vector of
+     *  coefficients for the counterIJ interaction.
      */
     Array2D m_Theta_ij_coeff;
 
@@ -1583,8 +1581,8 @@ private:
      * symmetric wrt cations, and the last two coordinates are symmetric wrt
      * anions.
      *
-     *  m_Psi_ijk_coeff.ptrColumn(n) is a double* containing the vector of
-     *  coefficients for the n interaction.
+     *  m_Psi_ijk_coeff.col(n) is a `span` containing the vector of coefficients
+     *  for the n interaction.
      */
     Array2D m_Psi_ijk_coeff;
 
@@ -1617,7 +1615,7 @@ private:
      *
      *      n = j + m_kk * i
      *
-     * m_Lambda_ij_coeff.ptrColumn(n) is a double* containing the vector of
+     * m_Lambda_nj_coeff.col(n) is a `span` containing the vector of
      * coefficients for the (i,j) interaction.
      */
     Array2D m_Lambda_nj_coeff;

--- a/include/cantera/thermo/MixtureFugacityTP.h
+++ b/include/cantera/thermo/MixtureFugacityTP.h
@@ -464,7 +464,7 @@ protected:
      * @returns the number of solutions found
      */
     int solveCubic(double T, double pres, double a, double b,
-                   double aAlpha, double Vroot[3], double an,
+                   double aAlpha, span<double> Vroot, double an,
                    double bn, double cn, double dn, double tc, double vc) const;
 
     //! @}

--- a/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
+++ b/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
@@ -49,7 +49,7 @@ public:
      * Note, after the constructor, we will own the underlying Nasa9Poly1
      * objects and be responsible for owning them.
      */
-    Nasa9PolyMultiTempRegion(vector<Nasa9Poly1*> &regionPts);
+    Nasa9PolyMultiTempRegion(span<Nasa9Poly1*> regionPts);
 
     //! Constructor with all input data
     /*!

--- a/include/cantera/thermo/PengRobinson.h
+++ b/include/cantera/thermo/PengRobinson.h
@@ -242,7 +242,7 @@ public:
 
     //! Prepare variables and call the function to solve the cubic equation of state
     int solveCubic(double T, double pres, double a, double b, double aAlpha,
-                   double Vroot[3]) const;
+                   span<double> Vroot) const;
 protected:
     //! Value of @f$ b @f$ in the equation of state
     /*!

--- a/include/cantera/thermo/RedlichKwongMFTP.h
+++ b/include/cantera/thermo/RedlichKwongMFTP.h
@@ -189,7 +189,7 @@ public:
     void calcCriticalConditions(double& pc, double& tc, double& vc) const override;
 
     //! Prepare variables and call the function to solve the cubic equation of state
-    int solveCubic(double T, double pres, double a, double b, double Vroot[3]) const;
+    int solveCubic(double T, double pres, double a, double b, span<double> Vroot) const;
 
 protected:
     //! Form of the temperature parameterization

--- a/include/cantera/transport/DustyGasTransport.h
+++ b/include/cantera/transport/DustyGasTransport.h
@@ -61,7 +61,7 @@ public:
         return "DustyGas";
     }
 
-    void getMultiDiffCoeffs(const size_t ld, double* const d) override;
+    void getMultiDiffCoeffs(const size_t ld, span<double> d) override;
 
     //! Get the molar fluxes [kmol/m²/s], given the thermodynamic state at two nearby points.
     /*!
@@ -76,8 +76,8 @@ public:
      * @param fluxes   Vector of species molar fluxes due to diffusional driving force;
      *     length is the number of species.
      */
-    void getMolarFluxes(const double* const state1, const double* const state2,
-                        const double delta, double* const fluxes) override;
+    void getMolarFluxes(span<const double> state1, span<const double> state2,
+                        const double delta, span<double> fluxes) override;
 
     // new methods added in this class
 

--- a/include/cantera/transport/GasTransport.h
+++ b/include/cantera/transport/GasTransport.h
@@ -46,6 +46,7 @@ public:
 
     //! Get the pure-species viscosities [Pa·s]
     void getSpeciesViscosities(span<double> visc) override {
+        checkArraySize("GasTransport::getSpeciesViscosities", visc.size(), m_nsp);
         update_T();
         updateViscosity_T();
         std::copy(m_visc.begin(), m_visc.end(), visc.begin());

--- a/include/cantera/transport/GasTransport.h
+++ b/include/cantera/transport/GasTransport.h
@@ -45,13 +45,13 @@ public:
     double viscosity() override;
 
     //! Get the pure-species viscosities [Pa·s]
-    void getSpeciesViscosities(double* const visc) override {
+    void getSpeciesViscosities(span<double> visc) override {
         update_T();
         updateViscosity_T();
-        std::copy(m_visc.begin(), m_visc.end(), visc);
+        std::copy(m_visc.begin(), m_visc.end(), visc.begin());
     }
 
-    void getBinaryDiffCoeffs(const size_t ld, double* const d) override;
+    void getBinaryDiffCoeffs(const size_t ld, span<double> d) override;
 
     //! Returns the Mixture-averaged diffusion coefficients [m²/s].
     /*!
@@ -72,7 +72,7 @@ public:
      * @param[out] d  Vector of mixture diffusion coefficients, @f$ D_{km}' @f$ ,
      *     for each species; length is the number of species.
      */
-    void getMixDiffCoeffs(double* const d) override;
+    void getMixDiffCoeffs(span<double> d) override;
 
     //! Returns the mixture-averaged diffusion coefficients [m²/s].
     //! These are the coefficients for calculating the molar diffusive fluxes
@@ -83,7 +83,7 @@ public:
     //!
     //! @param[out] d vector of mixture-averaged diffusion coefficients for
     //!     each species, length #m_nsp.
-    void getMixDiffCoeffsMole(double* const d) override;
+    void getMixDiffCoeffsMole(span<double> d) override;
 
     //! Returns the mixture-averaged diffusion coefficients [m²/s].
     /*!
@@ -99,45 +99,43 @@ public:
      * @param[out] d vector of mixture-averaged diffusion coefficients for
      *     each species, length #m_nsp.
      */
-    void getMixDiffCoeffsMass(double* const d) override;
+    void getMixDiffCoeffsMass(span<double> d) override;
 
     //! Return the polynomial fits to the viscosity of species `i`.
     //! @see fitProperties()
-    void getViscosityPolynomial(size_t i, double* coeffs) const override;
+    void getViscosityPolynomial(size_t i, span<double> coeffs) const override;
 
     //! Return the temperature fits of the heat conductivity of species `i`.
     //! @see fitProperties()
-    void getConductivityPolynomial(size_t i, double* coeffs) const override;
+    void getConductivityPolynomial(size_t i, span<double> coeffs) const override;
 
     //! Return the polynomial fits to the binary diffusivity of species pair (i, j)
     //! @see fitDiffCoeffs()
-    void getBinDiffusivityPolynomial(size_t i, size_t j, double* coeffs) const override;
+    void getBinDiffusivityPolynomial(size_t i, size_t j, span<double> coeffs) const override;
 
     //! Return the polynomial fits to the collision integral of species pair (i, j)
     //! @see fitCollisionIntegrals()
     void getCollisionIntegralPolynomial(size_t i, size_t j,
-                                        double* astar_coeffs,
-                                        double* bstar_coeffs,
-                                        double* cstar_coeffs) const override;
+                                        span<double> astar_coeffs,
+                                        span<double> bstar_coeffs,
+                                        span<double> cstar_coeffs) const override;
 
     //! Modify the polynomial fits to the viscosity of species `i`
     //! @see fitProperties()
-    void setViscosityPolynomial(size_t i, double* coeffs) override;
+    void setViscosityPolynomial(size_t i, span<double> coeffs) override;
 
     //! Modify the temperature fits of the heat conductivity of species `i`
     //! @see fitProperties()
-    void setConductivityPolynomial(size_t i, double* coeffs) override;
+    void setConductivityPolynomial(size_t i, span<double> coeffs) override;
 
     //! Modify the polynomial fits to the binary diffusivity of species pair (i, j)
     //! @see fitDiffCoeffs()
-    void setBinDiffusivityPolynomial(size_t i, size_t j, double* coeffs) override;
+    void setBinDiffusivityPolynomial(size_t i, size_t j, span<double> coeffs) override;
 
     //! Modify the polynomial fits to the collision integral of species pair (i, j)
     //! @see fitCollisionIntegrals()
-    void setCollisionIntegralPolynomial(size_t i, size_t j,
-                                        double* astar_coeffs,
-                                        double* bstar_coeffs,
-                                        double* cstar_coeffs, bool actualT) override;
+    void setCollisionIntegralPolynomial(size_t i, size_t j, span<double> astar_coeffs,
+        span<double> bstar_coeffs, span<double> cstar_coeffs, bool actualT) override;
 
     void init(shared_ptr<ThermoPhase> thermo, int mode=0) override;
 

--- a/include/cantera/transport/HighPressureGasTransport.h
+++ b/include/cantera/transport/HighPressureGasTransport.h
@@ -42,7 +42,7 @@ public:
      *                be at least `ld` times the number of species in length.
      * @see GasTransport::fitDiffCoeffs()
      */
-    void getBinaryDiffCoeffs(const size_t ld, double* const d) override;
+    void getBinaryDiffCoeffs(const size_t ld, span<double> d) override;
 
     /**
      * Returns the mixture-averaged diffusion coefficients [m²/s].
@@ -54,7 +54,7 @@ public:
      * @param[out] d  Vector of mixture diffusion coefficients, @f$ D_{km}' @f$ ,
      *                for each species. length #m_nsp.
      */
-    void getMixDiffCoeffs(double* const d) override;
+    void getMixDiffCoeffs(span<double> d) override;
 
     /**
      *  Returns the mixture-averaged diffusion coefficients [m²/s].
@@ -66,7 +66,7 @@ public:
      * @param[out] d vector of mixture-averaged diffusion coefficients for
      *               each species, length #m_nsp.
      */
-    void getMixDiffCoeffsMole(double* const d) override;
+    void getMixDiffCoeffsMole(span<double> d) override;
 
     /**
      * Returns the mixture-averaged diffusion coefficients [m²/s].
@@ -78,7 +78,7 @@ public:
      * @param[out] d vector of mixture-averaged diffusion coefficients for
      *               each species, length #m_nsp.
      */
-    void getMixDiffCoeffsMass(double* const d) override;
+    void getMixDiffCoeffsMass(span<double> d) override;
 
     /**
      * Updates the matrix of species-pair Takahashi correction factors for use in

--- a/include/cantera/transport/IonGasTransport.h
+++ b/include/cantera/transport/IonGasTransport.h
@@ -52,11 +52,11 @@ public:
 
     //! The mobilities for ions in gas.
     //! The ion mobilities are calculated by Blanc's law.
-    void getMobilities(double* const mobi) override;
+    void getMobilities(span<double> mobi) override;
 
     //! The mixture transport for ionized gas.
     //! The binary transport between two charged species is neglected.
-    void getMixDiffCoeffs(double* const d) override;
+    void getMixDiffCoeffs(span<double> d) override;
 
     /**
      * The electrical conductivity [siemens/m].

--- a/include/cantera/transport/MixTransport.h
+++ b/include/cantera/transport/MixTransport.h
@@ -70,7 +70,7 @@ public:
      *
      * @param[out] dt  Vector of thermal diffusion coefficients
      */
-    void getThermalDiffCoeffs(double* const dt) override;
+    void getThermalDiffCoeffs(span<double> dt) override;
 
     //! Returns the mixture thermal conductivity [W/m/K]
     /*!
@@ -100,7 +100,7 @@ public:
      *               The array must be dimensioned at least as large as the
      *               number of species.
      */
-    void getMobilities(double* const mobil) override;
+    void getMobilities(span<double> mobil) override;
 
     //! Update the internal parameters whenever the temperature has changed
     /*!
@@ -137,9 +137,9 @@ public:
      *     @f$ j_{kn} = \tt{ fluxes[n*ldf+k]} @f$ is the flux of species *k*
      *     in dimension *n*. Length is `ldf` * `ndim`.
      */
-    void getSpeciesFluxes(size_t ndim, const double* const grad_T,
-                          size_t ldx, const double* const grad_X,
-                          size_t ldf, double* const fluxes) override;
+    void getSpeciesFluxes(size_t ndim, span<const double> grad_T,
+                          size_t ldx, span<const double> grad_X,
+                          size_t ldf, span<double> fluxes) override;
 
     void init(shared_ptr<ThermoPhase> thermo, int mode=0) override;
 

--- a/include/cantera/transport/MultiTransport.h
+++ b/include/cantera/transport/MultiTransport.h
@@ -42,11 +42,11 @@ public:
      *
      * @param dt  Vector of thermal diffusion coefficients.
      */
-    void getThermalDiffCoeffs(double* const dt) override;
+    void getThermalDiffCoeffs(span<double> dt) override;
 
     double thermalConductivity() override;
 
-    void getMultiDiffCoeffs(const size_t ld, double* const d) override;
+    void getMultiDiffCoeffs(const size_t ld, span<double> d) override;
 
     //! Get the species diffusive mass fluxes [kg/m²/s] with respect to the mass
     //! averaged velocity, given the gradients in mole fraction and temperature
@@ -64,9 +64,9 @@ public:
      *     @f$ j_{kn} = \tt{ fluxes[n*ldf+k]} @f$ is the flux of species *k*
      *     in dimension *n*. Length is `ldf` * `ndim`.
      */
-    void getSpeciesFluxes(size_t ndim, const double* const grad_T,
-                          size_t ldx, const double* const grad_X,
-                          size_t ldf, double* const fluxes) override;
+    void getSpeciesFluxes(size_t ndim, span<const double> grad_T,
+                          size_t ldx, span<const double> grad_X,
+                          size_t ldf, span<double> fluxes) override;
 
     //! Get the molar diffusional fluxes [kmol/m²/s] of the species, given the
     //! thermodynamic state at two nearby points.
@@ -82,8 +82,8 @@ public:
      * @param fluxes Array containing the diffusive molar fluxes of species from
      *     `state1` to `state2`; Length is number of species.
      */
-    void getMolarFluxes(const double* const state1, const double* const state2,
-                        const double delta, double* const fluxes) override;
+    void getMolarFluxes(span<const double> state1, span<const double> state2,
+                        const double delta, span<double> fluxes) override;
 
     //! Get the mass diffusional fluxes [kg/m²/s] of the species, given the
     //! thermodynamic state at two nearby points.
@@ -99,8 +99,8 @@ public:
      * @param fluxes Array containing the diffusive mass fluxes of species from
      *     `state1` to `state2`; length is number of species.
      */
-    void getMassFluxes(const double* state1, const double* state2, double delta,
-                       double* fluxes) override;
+    void getMassFluxes(span<const double> state1, span<const double> state2,
+                       double delta, span<double> fluxes) override;
 
     void init(shared_ptr<ThermoPhase> thermo, int mode=0) override;
 
@@ -160,23 +160,23 @@ protected:
      *  Evaluate the upper-left block of the L matrix.
      *  @param x vector of species mole fractions
      */
-    void eval_L0000(const double* const x);
+    void eval_L0000(span<const double> x);
 
     //! Evaluate the L0010 matrices
     /*!
      *  @param x vector of species mole fractions
      */
-    void eval_L0010(const double* const x);
+    void eval_L0010(span<const double> x);
 
     //! Evaluate the L1000 matrices
     void eval_L1000();
 
     void eval_L0100();
     void eval_L0001();
-    void eval_L1010(const double* x);
-    void eval_L1001(const double* x);
+    void eval_L1010(span<const double> x);
+    void eval_L1001(span<const double> x);
     void eval_L0110();
-    void eval_L0101(const double* x);
+    void eval_L0101(span<const double> x);
     bool hasInternalModes(size_t j);
 
     double pressure_ig();

--- a/include/cantera/transport/Transport.h
+++ b/include/cantera/transport/Transport.h
@@ -132,7 +132,7 @@ public:
     /*!
      * @param visc   Vector of viscosities; length is the number of species
      */
-    virtual void getSpeciesViscosities(double* const visc) {
+    virtual void getSpeciesViscosities(span<double> visc) {
         throw NotImplementedError("Transport::getSpeciesViscosities",
             "Not implemented for transport model '{}'.", transportModel());
     }
@@ -176,7 +176,7 @@ public:
      *               mobil_e. The array must be dimensioned at least as large as
      *               the number of species.
      */
-    virtual void getMobilities(double* const mobil_e) {
+    virtual void getMobilities(span<double> mobil_e) {
         throw NotImplementedError("Transport::getMobilities",
             "Not implemented for transport model '{}'.", transportModel());
     }
@@ -202,9 +202,9 @@ public:
      *     @f$ j_{kn} = \tt{ fluxes[n*ldf+k]} @f$ is the flux of species *k*
      *     in dimension *n*. Length is `ldf` * `ndim`.
      */
-    virtual void getSpeciesFluxes(size_t ndim, const double* const grad_T,
-                                  size_t ldx, const double* const grad_X,
-                                  size_t ldf, double* const fluxes) {
+    virtual void getSpeciesFluxes(size_t ndim, span<const double> grad_T,
+                                  size_t ldx, span<const double> grad_X,
+                                  size_t ldf, span<double> fluxes) {
         throw NotImplementedError("Transport::getSpeciesFluxes",
             "Not implemented for transport model '{}'.", transportModel());
     }
@@ -220,9 +220,8 @@ public:
      * @param[out] cfluxes  Array containing the diffusive molar fluxes of species from
      *     `state1` to `state2`; Length is number of species.
      */
-    virtual void getMolarFluxes(const double* const state1,
-                                const double* const state2, const double delta,
-                                double* const cfluxes) {
+    virtual void getMolarFluxes(span<const double> state1, span<const double> state2,
+                                const double delta, span<double> cfluxes) {
         throw NotImplementedError("Transport::getMolarFluxes",
             "Not implemented for transport model '{}'.", transportModel());
     }
@@ -238,9 +237,8 @@ public:
      * @param[out] mfluxes  Array containing the diffusive mass fluxes of species from
      *     `state1` to `state2`; length is number of species.
      */
-    virtual void getMassFluxes(const double* state1,
-                               const double* state2, double delta,
-                               double* mfluxes) {
+    virtual void getMassFluxes(span<const double> state1, span<const double> state2,
+                               double delta, span<double> mfluxes) {
         throw NotImplementedError("Transport::getMassFluxes",
             "Not implemented for transport model '{}'.", transportModel());
     }
@@ -260,7 +258,7 @@ public:
      * @param dt On return, dt will contain the species thermal diffusion coefficients.
      *           Dimension dt at least as large as the number of species.
      */
-    virtual void getThermalDiffCoeffs(double* const dt) {
+    virtual void getThermalDiffCoeffs(span<double> dt) {
         throw NotImplementedError("Transport::getThermalDiffCoeffs",
             "Not implemented for transport model '{}'.", transportModel());
     }
@@ -275,7 +273,7 @@ public:
      *                be at least `ld` times the number of species in length.
      * @see GasTransport::fitDiffCoeffs()
      */
-    virtual void getBinaryDiffCoeffs(const size_t ld, double* const d) {
+    virtual void getBinaryDiffCoeffs(const size_t ld, span<double> d) {
         throw NotImplementedError("Transport::getBinaryDiffCoeffs",
             "Not implemented for transport model '{}'.", transportModel());
     }
@@ -295,7 +293,7 @@ public:
      *                gradients in species *j*; must be at least `ld` times the number
      *                of species in length.
      */
-    virtual void getMultiDiffCoeffs(const size_t ld, double* const d) {
+    virtual void getMultiDiffCoeffs(const size_t ld, span<double> d) {
         throw NotImplementedError("Transport::getMultiDiffCoeffs",
             "Not implemented for transport model '{}'.", transportModel());
     }
@@ -310,73 +308,73 @@ public:
      * @param d  Return vector of mixture averaged diffusion coefficients; length is
      *     the number of species.
      */
-    virtual void getMixDiffCoeffs(double* const d) {
+    virtual void getMixDiffCoeffs(span<double> d) {
         throw NotImplementedError("Transport::getMixDiffCoeffs",
             "Not implemented for transport model '{}'.", transportModel());
     }
 
     //! Returns a vector of mixture averaged diffusion coefficients [m²/s].
-    virtual void getMixDiffCoeffsMole(double* const d) {
+    virtual void getMixDiffCoeffsMole(span<double> d) {
         throw NotImplementedError("Transport::getMixDiffCoeffsMole",
             "Not implemented for transport model '{}'.", transportModel());
     }
 
     //! Returns a vector of mixture averaged diffusion coefficients [m²/s].
-    virtual void getMixDiffCoeffsMass(double* const d) {
+    virtual void getMixDiffCoeffsMass(span<double> d) {
         throw NotImplementedError("Transport::getMixDiffCoeffsMass",
             "Not implemented for transport model '{}'.", transportModel());
     }
 
     //! Return the polynomial fits to the viscosity of species `i`.
-    virtual void getViscosityPolynomial(size_t i, double* coeffs) const{
+    virtual void getViscosityPolynomial(size_t i, span<double> coeffs) const {
         throw NotImplementedError("Transport::getViscosityPolynomial",
             "Not implemented for transport model '{}'.", transportModel());
     }
 
     //! Return the temperature fits of the heat conductivity of species `i`.
-    virtual void getConductivityPolynomial(size_t i, double* coeffs) const{
+    virtual void getConductivityPolynomial(size_t i, span<double> coeffs) const {
         throw NotImplementedError("Transport::getConductivityPolynomial",
             "Not implemented for transport model '{}'.", transportModel());
     }
 
     //! Return the polynomial fits to the binary diffusivity of species pair (i, j)
-    virtual void getBinDiffusivityPolynomial(size_t i, size_t j, double* coeffs) const{
+    virtual void getBinDiffusivityPolynomial(size_t i, size_t j, span<double> coeffs) const {
         throw NotImplementedError("Transport::getBinDiffusivityPolynomial",
             "Not implemented for transport model '{}'.", transportModel());
     }
 
     //! Return the polynomial fits to the collision integral of species pair (i, j)
     virtual void getCollisionIntegralPolynomial(size_t i, size_t j,
-                                                double* astar_coeffs,
-                                                double* bstar_coeffs,
-                                                double* cstar_coeffs) const{
+        span<double> astar_coeffs, span<double> bstar_coeffs,
+        span<double> cstar_coeffs) const
+    {
         throw NotImplementedError("Transport::getCollisionIntegralPolynomial",
             "Not implemented for transport model '{}'.", transportModel());
     }
 
     //! Modify the polynomial fits to the viscosity of species `i`
-    virtual void setViscosityPolynomial(size_t i, double* coeffs){
+    virtual void setViscosityPolynomial(size_t i, span<double> coeffs) {
         throw NotImplementedError("Transport::setViscosityPolynomial",
             "Not implemented for transport model '{}'.", transportModel());
     }
 
     //! Modify the temperature fits of the heat conductivity of species `i`
-    virtual void setConductivityPolynomial(size_t i, double* coeffs){
+    virtual void setConductivityPolynomial(size_t i, span<double> coeffs) {
         throw NotImplementedError("Transport::setConductivityPolynomial",
             "Not implemented for transport model '{}'.", transportModel());
     }
 
     //! Modify the polynomial fits to the binary diffusivity of species pair (i, j)
-    virtual void setBinDiffusivityPolynomial(size_t i, size_t j, double* coeffs){
+    virtual void setBinDiffusivityPolynomial(size_t i, size_t j, span<double> coeffs) {
         throw NotImplementedError("Transport::setBinDiffusivityPolynomial",
             "Not implemented for transport model '{}'.", transportModel());
     }
 
     //! Modify the polynomial fits to the collision integral of species pair (i, j)
     virtual void setCollisionIntegralPolynomial(size_t i, size_t j,
-                                                double* astar_coeffs,
-                                                double* bstar_coeffs,
-                                                double* cstar_coeffs, bool flag){
+        span<double> astar_coeffs, span<double> bstar_coeffs,
+        span<double> cstar_coeffs, bool flag)
+    {
         throw NotImplementedError("Transport::setCollisionIntegralPolynomial",
             "Not implemented for transport model '{}'.", transportModel());
     }

--- a/include/cantera/transport/UnityLewisTransport.h
+++ b/include/cantera/transport/UnityLewisTransport.h
@@ -52,7 +52,7 @@ public:
      *
      * @param[out] d  Vector of diffusion coefficients for each species. length #m_nsp.
      */
-    void getMixDiffCoeffs(double* const d) override {
+    void getMixDiffCoeffs(span<double> d) override {
         double Dm = thermalConductivity() / (m_thermo->density() * m_thermo->cp_mass());
         for (size_t k = 0; k < m_nsp; k++) {
             d[k] = Dm;
@@ -63,14 +63,14 @@ public:
     /*!
      * @param[out] dt  Thermal diffusion coefficients all set to zero.
      */
-    void getThermalDiffCoeffs(double* const dt) override {
+    void getThermalDiffCoeffs(span<double> dt) override {
         for (size_t k = 0; k < m_nsp; k++) {
             dt[k] = 0.0;
         }
     }
 
     //! Not implemented for unity Lewis number approximation
-    void getMixDiffCoeffsMole(double* const d) override {
+    void getMixDiffCoeffsMole(span<double> d) override {
         throw NotImplementedError("UnityLewisTransport::getMixDiffCoeffsMole");
     }
 
@@ -86,7 +86,7 @@ public:
      *
      * @param[out] d  Vector of diffusion coefficients for each species; length #m_nsp.
      */
-    void getMixDiffCoeffsMass(double* const d) override {
+    void getMixDiffCoeffsMass(span<double> d) override {
         double Dm = thermalConductivity() / (m_thermo->density() * m_thermo->cp_mass());
         for (size_t k = 0; k < m_nsp; k++) {
             d[k] = Dm;

--- a/include/cantera/transport/UnityLewisTransport.h
+++ b/include/cantera/transport/UnityLewisTransport.h
@@ -53,6 +53,7 @@ public:
      * @param[out] d  Vector of diffusion coefficients for each species. length #m_nsp.
      */
     void getMixDiffCoeffs(span<double> d) override {
+        checkArraySize("UnityLewisTransport::getMixDiffCoeffs", d.size(), m_nsp);
         double Dm = thermalConductivity() / (m_thermo->density() * m_thermo->cp_mass());
         for (size_t k = 0; k < m_nsp; k++) {
             d[k] = Dm;
@@ -64,6 +65,7 @@ public:
      * @param[out] dt  Thermal diffusion coefficients all set to zero.
      */
     void getThermalDiffCoeffs(span<double> dt) override {
+        checkArraySize("UnityLewisTransport::getThermalDiffCoeffs", dt.size(), m_nsp);
         for (size_t k = 0; k < m_nsp; k++) {
             dt[k] = 0.0;
         }
@@ -87,6 +89,7 @@ public:
      * @param[out] d  Vector of diffusion coefficients for each species; length #m_nsp.
      */
     void getMixDiffCoeffsMass(span<double> d) override {
+        checkArraySize("UnityLewisTransport::getMixDiffCoeffsMass", d.size(), m_nsp);
         double Dm = thermalConductivity() / (m_thermo->density() * m_thermo->cp_mass());
         for (size_t k = 0; k < m_nsp; k++) {
             d[k] = Dm;

--- a/interfaces/cython/cantera/solutionbase.pxd
+++ b/interfaces/cython/cantera/solutionbase.pxd
@@ -90,10 +90,10 @@ cdef extern from "cantera/base/SolutionArray.h" namespace "Cantera":
         shared_ptr[CxxSolution], int, CxxAnyMap&) except +translate_exception
 
 
-ctypedef void (*transportMethod1d)(CxxTransport*, double*) except +translate_exception
-ctypedef void (*transportMethod2d)(CxxTransport*, size_t, double*) except +translate_exception
-ctypedef void (*transportPolyMethod1i)(CxxTransport*, size_t, double*) except +translate_exception
-ctypedef void (*transportPolyMethod2i)(CxxTransport*, size_t, size_t, double*) except +translate_exception
+ctypedef void (*transportMethod1d)(CxxTransport*, span[double]) except +translate_exception
+ctypedef void (*transportMethod2d)(CxxTransport*, size_t, span[double]) except +translate_exception
+ctypedef void (*transportPolyMethod1i)(CxxTransport*, size_t, span[double]) except +translate_exception
+ctypedef void (*transportPolyMethod2i)(CxxTransport*, size_t, size_t, span[double]) except +translate_exception
 
 cdef _assign_Solution(_SolutionBase soln, shared_ptr[CxxSolution] cxx_soln,
                       pybool reset_adjacent, pybool weak=?, pybool hold=?)

--- a/interfaces/cython/cantera/transport.pxd
+++ b/interfaces/cython/cantera/transport.pxd
@@ -15,8 +15,10 @@ cdef extern from "cantera/transport/Transport.h" namespace "Cantera":
         double viscosity() except +translate_exception
         double thermalConductivity() except +translate_exception
         double electricalConductivity() except +translate_exception
-        void getCollisionIntegralPolynomial(size_t i, size_t j, double* dataA, double* dataB, double* dataC) except +translate_exception
-        void setCollisionIntegralPolynomial(size_t i, size_t j, double* dataA, double* dataB, double* dataC, cbool flag) except +translate_exception
+        void getCollisionIntegralPolynomial(size_t i, size_t j, span[double] dataA,
+            span[double] dataB, span[double] dataC) except +translate_exception
+        void setCollisionIntegralPolynomial(size_t i, size_t j, span[double] dataA,
+            span[double] dataB, span[double] dataC, cbool flag) except +translate_exception
         CxxAnyMap fittingErrors()
 
 cdef extern from "cantera/transport/DustyGasTransport.h" namespace "Cantera":
@@ -26,7 +28,8 @@ cdef extern from "cantera/transport/DustyGasTransport.h" namespace "Cantera":
         void setMeanPoreRadius(double) except +translate_exception
         void setMeanParticleDiameter(double) except +translate_exception
         void setPermeability(double) except +translate_exception
-        void getMolarFluxes(double*, double*, double, double*) except +translate_exception
+        void getMolarFluxes(span[const_double], span[const_double], double,
+                            span[double]) except +translate_exception
         CxxTransport& gasTransport() except +translate_exception
 
 
@@ -53,23 +56,23 @@ cdef extern from "cantera/transport/TransportData.h" namespace "Cantera":
 
 
 cdef extern from "cantera/cython/transport_utils.h":
-    cdef void tran_getMixDiffCoeffs(CxxTransport*, double*) except +translate_exception
-    cdef void tran_getMixDiffCoeffsMass(CxxTransport*, double*) except +translate_exception
-    cdef void tran_getMixDiffCoeffsMole(CxxTransport*, double*) except +translate_exception
-    cdef void tran_getThermalDiffCoeffs(CxxTransport*, double*) except +translate_exception
-    cdef void tran_getSpeciesViscosities(CxxTransport*, double*) except +translate_exception
-    cdef void tran_getMobilities(CxxTransport*, double*) except +translate_exception
+    cdef void tran_getMixDiffCoeffs(CxxTransport*, span[double]) except +translate_exception
+    cdef void tran_getMixDiffCoeffsMass(CxxTransport*, span[double]) except +translate_exception
+    cdef void tran_getMixDiffCoeffsMole(CxxTransport*, span[double]) except +translate_exception
+    cdef void tran_getThermalDiffCoeffs(CxxTransport*, span[double]) except +translate_exception
+    cdef void tran_getSpeciesViscosities(CxxTransport*, span[double]) except +translate_exception
+    cdef void tran_getMobilities(CxxTransport*, span[double]) except +translate_exception
 
-    cdef void tran_getMultiDiffCoeffs(CxxTransport*, size_t, double*) except +translate_exception
-    cdef void tran_getBinaryDiffCoeffs(CxxTransport*, size_t, double*) except +translate_exception
+    cdef void tran_getMultiDiffCoeffs(CxxTransport*, size_t, span[double]) except +translate_exception
+    cdef void tran_getBinaryDiffCoeffs(CxxTransport*, size_t, span[double]) except +translate_exception
 
-    cdef void tran_getViscosityPolynomial(CxxTransport*, size_t, double*) except +translate_exception
-    cdef void tran_getConductivityPolynomial(CxxTransport*, size_t, double*) except +translate_exception
-    cdef void tran_getBinDiffusivityPolynomial(CxxTransport*, size_t, size_t, double*) except +translate_exception
+    cdef void tran_getViscosityPolynomial(CxxTransport*, size_t, span[double]) except +translate_exception
+    cdef void tran_getConductivityPolynomial(CxxTransport*, size_t, span[double]) except +translate_exception
+    cdef void tran_getBinDiffusivityPolynomial(CxxTransport*, size_t, size_t, span[double]) except +translate_exception
 
-    cdef void tran_setViscosityPolynomial(CxxTransport*, size_t, double*) except +translate_exception
-    cdef void tran_setConductivityPolynomial(CxxTransport*, size_t, double*) except +translate_exception
-    cdef void tran_setBinDiffusivityPolynomial(CxxTransport*, size_t, size_t, double*) except +translate_exception
+    cdef void tran_setViscosityPolynomial(CxxTransport*, size_t, span[double]) except +translate_exception
+    cdef void tran_setConductivityPolynomial(CxxTransport*, size_t, span[double]) except +translate_exception
+    cdef void tran_setBinDiffusivityPolynomial(CxxTransport*, size_t, size_t, span[double]) except +translate_exception
 
 
 cdef class GasTransportData:

--- a/samples/cxx/demo/demo.cpp
+++ b/samples/cxx/demo/demo.cpp
@@ -107,7 +107,7 @@ void demoprog()
 
     int nsp = gas->nSpecies();
     vector<double> diff(nsp);
-    tr->getMixDiffCoeffs(&diff[0]);
+    tr->getMixDiffCoeffs(diff);
     int k;
     writelog("\n\n{:20s}  {:21s}\n", "Species", "Diffusion Coefficient");
     for (k = 0; k < nsp; k++) {

--- a/samples/cxx/gas_transport/gas_transport.cpp
+++ b/samples/cxx/gas_transport/gas_transport.cpp
@@ -65,7 +65,7 @@ void transport_example()
         output(0,i) = temp;
         output(1,i) = sol->transport()->viscosity();
         output(2,i) = sol->transport()->thermalConductivity();
-        sol->transport()->getMixDiffCoeffs(&output(3,i));
+        sol->transport()->getMixDiffCoeffs(span<double>(&output(3,i), nsp));
     }
 
     // Create a list of labels for the CSV output file
@@ -91,7 +91,7 @@ void transport_example()
         output(0,i) = temp;
         output(1,i) = sol->transport()->viscosity();
         output(2,i) = sol->transport()->thermalConductivity();
-        sol->transport()->getThermalDiffCoeffs(&output(3,i));
+        sol->transport()->getThermalDiffCoeffs(span<double>(&output(3,i), nsp));
     }
 
     // Save transport properties to a file

--- a/samples/f77/demo_ftnlib.cpp
+++ b/samples/f77/demo_ftnlib.cpp
@@ -342,7 +342,7 @@ extern "C" {
     void getmixdiffcoeffs_(double* diff)
     {
         try {
-            _trans->getMixDiffCoeffs(diff);
+            _trans->getMixDiffCoeffs(span<double>(diff, _gas->nSpecies()));
         } catch (CanteraError& err) {
             handleError(err);
         }
@@ -351,7 +351,7 @@ extern "C" {
     void getthermaldiffcoeffs_(double* dt)
     {
         try {
-            _trans->getThermalDiffCoeffs(dt);
+            _trans->getThermalDiffCoeffs(span<double>(dt, _gas->nSpecies()));
         } catch (CanteraError& err) {
             handleError(err);
         }

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -984,8 +984,7 @@ AnyMap& openField(AnyMap& root, const string& name)
     }
 
     // locate field based on 'name'
-    vector<string> tokens;
-    tokenizePath(name, tokens);
+    vector<string> tokens = tokenizePath(name);
     AnyMap* ptr = &root; // use raw pointer to avoid copying
     string path = "";
     for (auto& field : tokens) {
@@ -1409,8 +1408,7 @@ const AnyMap& locateField(const AnyMap& root, const string& name)
     }
 
     // locate field based on 'name'
-    vector<string> tokens;
-    tokenizePath(name, tokens);
+    vector<string> tokens = tokenizePath(name);
     const AnyMap* ptr = &root; // use raw pointer to avoid copying
     string path = "";
     for (auto& field : tokens) {

--- a/src/base/Storage.cpp
+++ b/src/base/Storage.cpp
@@ -66,8 +66,7 @@ bool Storage::hasGroup(const string& id) const
 
 bool Storage::checkGroupRead(const string& id) const
 {
-    vector<string> tokens;
-    tokenizePath(id, tokens);
+    vector<string> tokens = tokenizePath(id);
     string grp = tokens[0];
     if (!hasGroup(grp)) {
         throw CanteraError("Storage::checkGroupRead",

--- a/src/base/stringUtils.cpp
+++ b/src/base/stringUtils.cpp
@@ -182,23 +182,25 @@ double fpValueCheck(const string& val)
     return fpValue(str);
 }
 
-void tokenizeString(const string& in_val, vector<string>& v)
+vector<string> tokenizeString(const string& in_val)
 {
     string val = ba::trim_copy(in_val);
-    v.clear();
+    vector<string> v;
     if (val.empty()) {
         // In this case, prefer v to be empty instead of split's behavior of
         // returning a vector with one element that is the empty string.
-        return;
+        return v;
     }
     ba::split(v, val, ba::is_space(), ba::token_compress_on);
+    return v;
 }
 
-void tokenizePath(const string& in_val, vector<string>& v)
+vector<string> tokenizePath(const string& in_val)
 {
     string val = ba::trim_copy(in_val);
-    v.clear();
+    vector<string> v;
     ba::split(v, val, ba::is_any_of("/\\"), ba::token_compress_on);
+    return v;
 }
 
 size_t copyString(const string& source, char* dest, size_t length)

--- a/src/equil/BasisOptimize.cpp
+++ b/src/equil/BasisOptimize.cpp
@@ -15,7 +15,7 @@ namespace Cantera
 int BasisOptimize_print_lvl = 0;
 static const double USEDBEFORE = -1;
 
-size_t BasisOptimize(int* usedZeroedSpecies, bool doFormRxn, MultiPhase* mphase,
+size_t BasisOptimize(bool& usedZeroedSpecies, bool doFormRxn, MultiPhase* mphase,
                      span<size_t> orderVectorSpecies, span<size_t> orderVectorElements,
                      span<double> formRxnMatrix)
 {
@@ -67,7 +67,7 @@ size_t BasisOptimize(int* usedZeroedSpecies, bool doFormRxn, MultiPhase* mphase,
     size_t nNonComponents = nspecies - nComponents;
 
     // Set this return variable to false
-    *usedZeroedSpecies = false;
+    usedZeroedSpecies = false;
 
     // Create an array of mole numbers
     vector<double> molNum(nspecies,0.0);
@@ -107,7 +107,7 @@ size_t BasisOptimize(int* usedZeroedSpecies, bool doFormRxn, MultiPhase* mphase,
             }
 
             if (molNum[kk] == 0.0) {
-                *usedZeroedSpecies = true;
+                usedZeroedSpecies = true;
             }
             // If the largest molNum is negative, then we are done.
             if (molNum[kk] == USEDBEFORE) {

--- a/src/equil/BasisOptimize.cpp
+++ b/src/equil/BasisOptimize.cpp
@@ -235,7 +235,7 @@ size_t BasisOptimize(int* usedZeroedSpecies, bool doFormRxn, MultiPhase* mphase,
     }
 
     // // Use LU factorization to calculate the reaction matrix
-    solve(sm, formRxnMatrix.data(), nNonComponents, ne);
+    solve(sm, formRxnMatrix, nNonComponents, ne);
 
     if (BasisOptimize_print_lvl >= 1) {
         writelog("   ---\n");

--- a/src/equil/ChemEquil.cpp
+++ b/src/equil/ChemEquil.cpp
@@ -214,9 +214,9 @@ int ChemEquil::estimateElementPotentials(ThermoPhase& s, span<double> lambda_RT,
     MultiPhase mp;
     mp.addPhase(&s, 1.0);
     mp.init();
-    int usedZeroedSpecies = 0;
+    bool usedZeroedSpecies = false;
     vector<double> formRxnMatrix(mp.nSpecies() * mp.nElements());
-    m_nComponents = BasisOptimize(&usedZeroedSpecies, false,
+    m_nComponents = BasisOptimize(usedZeroedSpecies, false,
                                   &mp, m_orderVectorSpecies,
                                   m_orderVectorElements, formRxnMatrix);
 

--- a/src/equil/ChemEquil.cpp
+++ b/src/equil/ChemEquil.cpp
@@ -258,7 +258,7 @@ int ChemEquil::estimateElementPotentials(ThermoPhase& s, span<double> lambda_RT,
 
     int info = 0;
     try {
-        solve(aa, b.data());
+        solve(aa, b);
     } catch (CanteraError&) {
         info = -2;
     }
@@ -610,7 +610,7 @@ int ChemEquil::equilibrate(ThermoPhase& s, const char* XYstr,
 
         // Solve the system
         try {
-            solve(jac, res_trial.data());
+            solve(jac, res_trial);
         } catch (CanteraError& err) {
             s.restoreState(state);
             throw CanteraError("ChemEquil::equilibrate",
@@ -1235,7 +1235,7 @@ int ChemEquil::estimateEP_Brinkley(ThermoPhase& s, span<double> x, span<double> 
             }
 
             try {
-                solve(a1, resid.data());
+                solve(a1, resid);
             } catch (CanteraError& err) {
                 s.restoreState(state);
                 throw CanteraError("ChemEquil::estimateEP_Brinkley",

--- a/src/equil/MultiPhaseEquil.cpp
+++ b/src/equil/MultiPhaseEquil.cpp
@@ -131,7 +131,7 @@ MultiPhaseEquil::MultiPhaseEquil(MultiPhase* mix, bool start, int loglevel) : m_
     // species has precisely zero moles.
     vector<double> dxi(nFree(), 1.0e-20);
     if (!dxi.empty()) {
-        multiply(m_N, dxi.data(), m_work.data());
+        multiply(m_N, dxi, m_work);
         unsort(m_work);
     }
 
@@ -434,7 +434,7 @@ double MultiPhaseEquil::stepComposition(int loglevel)
 
     // compute the mole fraction changes.
     if (nFree()) {
-        multiply(m_N, m_dxi.data(), m_work.data());
+        multiply(m_N, m_dxi, m_work);
     }
 
     // change to sequential form

--- a/src/equil/vcs_VolPhase.cpp
+++ b/src/equil/vcs_VolPhase.cpp
@@ -424,7 +424,7 @@ void vcs_VolPhase::_updateLnActCoeffJac()
         span<double>(&np_dLnActCoeffdMolNumber(0, 0), m_numSpecies * m_numSpecies));
     for (size_t j = 0; j < m_numSpecies; j++) {
         double moles_j_base = phaseTotalMoles * Xmol_[j];
-        double* const np_lnActCoeffCol = np_dLnActCoeffdMolNumber.ptrColumn(j);
+        auto np_lnActCoeffCol = np_dLnActCoeffdMolNumber.col(j);
         if (moles_j_base < 1.0E-200) {
             moles_j_base = 1.0E-7 * moles_j_base + 1.0E-13 * phaseTotalMoles + 1.0E-150;
         }

--- a/src/equil/vcs_solve.cpp
+++ b/src/equil/vcs_solve.cpp
@@ -417,7 +417,7 @@ bool VCS_SOLVE::vcs_popPhasePossible(const size_t iphasePop) const
     return false;
 }
 
-size_t VCS_SOLVE::vcs_popPhaseID(vector<size_t> & phasePopPhaseIDs)
+size_t VCS_SOLVE::vcs_popPhaseID()
 {
     size_t iphasePop = npos;
     double FephaseMax = -1.0E30;
@@ -491,11 +491,6 @@ size_t VCS_SOLVE::vcs_popPhaseID(vector<size_t> & phasePopPhaseIDs)
             }
         }
     }
-    phasePopPhaseIDs.resize(0);
-    if (iphasePop != npos) {
-        phasePopPhaseIDs.push_back(iphasePop);
-    }
-
     // Insert logic here to figure out if phase pops are linked together. Only
     // do one linked pop at a time.
     if (m_debug_print_lvl >= 2) {

--- a/src/equil/vcs_solve_TP.cpp
+++ b/src/equil/vcs_solve_TP.cpp
@@ -401,8 +401,7 @@ void VCS_SOLVE::solve_tp_inner(size_t& iti, size_t& it1,
     //
     // First step is a major branch in the algorithm. We first determine if a
     // phase pops into existence.
-    vector<size_t> phasePopPhaseIDs(0);
-    size_t iphasePop = vcs_popPhaseID(phasePopPhaseIDs);
+    size_t iphasePop = vcs_popPhaseID();
     if (iphasePop != npos) {
         int soldel = vcs_popPhaseRxnStepSizes(iphasePop);
         if (soldel == 3) {
@@ -506,7 +505,7 @@ void VCS_SOLVE::solve_tp_inner(size_t& iti, size_t& it1,
             } else if (m_speciesStatus[kspec] == VCS_SPECIES_INTERFACIALVOLTAGE) {
                 // VOLTAGE SPECIES
                 bool soldel_ret;
-                dx = vcs_minor_alt_calc(kspec, irxn, &soldel_ret);
+                dx = vcs_minor_alt_calc(kspec, irxn, soldel_ret);
                 m_deltaMolNumSpecies[kspec] = dx;
             } else if (m_speciesStatus[kspec] < VCS_SPECIES_MINOR) {
                 // ZEROED OUT SPECIES
@@ -597,7 +596,7 @@ void VCS_SOLVE::solve_tp_inner(size_t& iti, size_t& it1,
                 // If soldel is true on return, then we branch to the section
                 // that deletes a species from the current set of active species.
                 bool soldel_ret;
-                dx = vcs_minor_alt_calc(kspec, irxn, &soldel_ret);
+                dx = vcs_minor_alt_calc(kspec, irxn, soldel_ret);
                 m_deltaMolNumSpecies[kspec] = dx;
                 m_molNumSpecies_new[kspec] = m_molNumSpecies_old[kspec] + dx;
                 if (soldel_ret) {
@@ -1336,13 +1335,13 @@ void VCS_SOLVE::solve_tp_elem_abund_check(size_t& iti, int& stage, bool& lec,
     stage = EQUILIB_CHECK;
 }
 
-double VCS_SOLVE::vcs_minor_alt_calc(size_t kspec, size_t irxn, bool* do_delete) const
+double VCS_SOLVE::vcs_minor_alt_calc(size_t kspec, size_t irxn, bool& do_delete) const
 {
     double w_kspec = m_molNumSpecies_old[kspec];
     double dg_irxn = m_deltaGRxn_old[irxn];
     size_t iph = m_phaseID[kspec];
 
-    *do_delete = false;
+    do_delete = false;
     if (m_speciesUnknownType[kspec] != VCS_SPECIES_TYPE_INTERFACIALVOLTAGE) {
         if (w_kspec <= 0.0) {
             w_kspec = VCS_DELETE_MINORSPECIES_CUTOFF;
@@ -1353,7 +1352,7 @@ double VCS_SOLVE::vcs_minor_alt_calc(size_t kspec, size_t irxn, bool* do_delete)
             if (w_kspec < VCS_DELETE_MINORSPECIES_CUTOFF) {
                 // delete the species from the current list of active species,
                 // because its concentration has gotten too small.
-                *do_delete = true;
+                do_delete = true;
                 return - w_kspec;
             }
             return molNum_kspec_new - w_kspec;
@@ -1399,7 +1398,7 @@ double VCS_SOLVE::vcs_minor_alt_calc(size_t kspec, size_t irxn, bool* do_delete)
         if ((molNum_kspec_new) < VCS_DELETE_MINORSPECIES_CUTOFF) {
             // delete the species from the current list of active species,
             // because its concentration has gotten too small.
-            *do_delete = true;
+            do_delete = true;
             return - w_kspec;
         }
         return molNum_kspec_new - w_kspec;

--- a/src/fortran/fct.cpp
+++ b/src/fortran/fct.cpp
@@ -998,7 +998,8 @@ extern "C" {
     status_t trans_getthermaldiffcoeffs_(const integer* n, double* dt)
     {
         try {
-            _ftrans(n)->getThermalDiffCoeffs(dt);
+            auto tr = _ftrans(n);
+            tr->getThermalDiffCoeffs(span<double>(dt, tr->thermo().nSpecies()));
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1008,7 +1009,8 @@ extern "C" {
     status_t trans_getmixdiffcoeffs_(const integer* n, double* d)
     {
         try {
-            _ftrans(n)->getMixDiffCoeffs(d);
+            auto tr = _ftrans(n);
+            tr->getMixDiffCoeffs(span<double>(d, tr->thermo().nSpecies()));
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1018,7 +1020,8 @@ extern "C" {
     status_t trans_getmixdiffcoeffsmass_(const integer* n, double* d)
     {
         try {
-            _ftrans(n)->getMixDiffCoeffsMass(d);
+            auto tr = _ftrans(n);
+            tr->getMixDiffCoeffsMass(span<double>(d, tr->thermo().nSpecies()));
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1028,7 +1031,8 @@ extern "C" {
     status_t trans_getmixdiffcoeffsmole_(const integer* n, double* d)
     {
         try {
-            _ftrans(n)->getMixDiffCoeffsMole(d);
+            auto tr = _ftrans(n);
+            tr->getMixDiffCoeffsMole(span<double>(d, tr->thermo().nSpecies()));
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1038,7 +1042,8 @@ extern "C" {
     status_t trans_getbindiffcoeffs_(const integer* n, integer* ld, double* d)
     {
         try {
-            _ftrans(n)->getBinaryDiffCoeffs(*ld,d);
+            auto tr = _ftrans(n);
+            tr->getBinaryDiffCoeffs(*ld, span<double>(d, *ld * tr->thermo().nSpecies()));
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1048,7 +1053,8 @@ extern "C" {
     status_t trans_getmultidiffcoeffs_(const integer* n, integer* ld, double* d)
     {
         try {
-            _ftrans(n)->getMultiDiffCoeffs(*ld,d);
+            auto tr = _ftrans(n);
+            tr->getMultiDiffCoeffs(*ld, span<double>(d, *ld * tr->thermo().nSpecies()));
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);

--- a/src/kinetics/InterfaceRate.cpp
+++ b/src/kinetics/InterfaceRate.cpp
@@ -257,7 +257,7 @@ void InterfaceRateBase::updateFromStruct(const InterfaceData& shared_data) {
         if (m_lindep[iCov]) {
             m_ecov += m_ec[iCov][1] * shared_data.coverages[iKin];
         } else {
-            m_ecov += poly4(shared_data.coverages[iKin], m_ec[iCov].data());
+            m_ecov += poly4(shared_data.coverages[iKin], m_ec[iCov]);
         }
         m_mcov += m_mc[iCov] * shared_data.logCoverages[iKin];
     }

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -891,8 +891,7 @@ void parseReactionEquation(Reaction& R, const string& equation,
 {
     // Parse the reaction equation to determine participating species and
     // stoichiometric coefficients
-    vector<string> tokens;
-    tokenizeString(equation, tokens);
+    vector<string> tokens = tokenizeString(equation);
     tokens.push_back("+"); // makes parsing last species not a special case
 
     size_t last_used = npos; // index of last-used token

--- a/src/numerics/AdaptivePreconditioner.cpp
+++ b/src/numerics/AdaptivePreconditioner.cpp
@@ -14,7 +14,7 @@ AdaptivePreconditioner::AdaptivePreconditioner()
     setPreconditionerSide("right");
 }
 
-void AdaptivePreconditioner::stateAdjustment(vector<double>& state) {
+void AdaptivePreconditioner::stateAdjustment(span<double> state) {
     // Only keep positive composition based on given tol
     for (size_t i = 0; i < state.size(); i++) {
         state[i] = std::max(state[i], m_atol);

--- a/src/numerics/BandMatrix.cpp
+++ b/src/numerics/BandMatrix.cpp
@@ -52,11 +52,9 @@ BandMatrix::BandMatrix(size_t n, size_t kl, size_t ku, double v)   :
     fill(data.begin(), data.end(), v);
     fill(ludata.begin(), ludata.end(), 0.0);
     m_ipiv->data.resize(m_n);
-    m_colPtrs.resize(n);
     m_lu_col_ptrs.resize(n);
     size_t ldab = (2*kl + ku + 1);
     for (size_t j = 0; j < n; j++) {
-        m_colPtrs[j] = &data[ldab * j];
         m_lu_col_ptrs[j] = &ludata[ldab * j];
     }
 }
@@ -72,11 +70,9 @@ BandMatrix::BandMatrix(const BandMatrix& y) :
     m_info(y.m_info)
 {
     m_ipiv->data = y.m_ipiv->data;
-    m_colPtrs.resize(m_n);
     m_lu_col_ptrs.resize(m_n);
-    size_t ldab = (2 *m_kl + m_ku + 1);
+    size_t ldab = (2*m_kl + m_ku + 1);
     for (size_t j = 0; j < m_n; j++) {
-        m_colPtrs[j] = &data[ldab * j];
         m_lu_col_ptrs[j] = &ludata[ldab * j];
     }
 }
@@ -93,11 +89,9 @@ BandMatrix& BandMatrix::operator=(const BandMatrix& y)
     m_ipiv->data = y.m_ipiv->data;
     data = y.data;
     ludata = y.ludata;
-    m_colPtrs.resize(m_n);
     m_lu_col_ptrs.resize(m_n);
-    size_t ldab = (2 * m_kl + m_ku + 1);
+    size_t ldab = (2*m_kl + m_ku + 1);
     for (size_t j = 0; j < m_n; j++) {
-        m_colPtrs[j] = &data[ldab * j];
         m_lu_col_ptrs[j] = &ludata[ldab * j];
     }
     m_info = y.m_info;
@@ -111,15 +105,13 @@ void BandMatrix::resize(size_t n, size_t kl, size_t ku, double v)
     m_ku = ku;
     data.resize(n*(2*kl + ku + 1));
     ludata.resize(n*(2*kl + ku + 1));
-    m_ipiv->data.resize(m_n);
-    fill(data.begin(), data.end(), v);
-    m_colPtrs.resize(m_n);
     m_lu_col_ptrs.resize(m_n);
-    size_t ldab = (2 * m_kl + m_ku + 1);
-    for (size_t j = 0; j < n; j++) {
-        m_colPtrs[j] = &data[ldab * j];
+    size_t ldab = (2*m_kl + m_ku + 1);
+    for (size_t j = 0; j < m_n; j++) {
         m_lu_col_ptrs[j] = &ludata[ldab * j];
     }
+    m_ipiv->data.resize(m_n);
+    fill(data.begin(), data.end(), v);
     m_factored = false;
 }
 
@@ -381,16 +373,6 @@ size_t BandMatrix::checkColumns(double& valueSmall) const
         }
     }
     return jSmall;
-}
-
-span<double> BandMatrix::col(size_t j)
-{
-    return span<double>(m_colPtrs[j], ldim());
-}
-
-span<const double> BandMatrix::col(size_t j) const
-{
-    return span<const double>(m_colPtrs[j], ldim());
 }
 
 }

--- a/src/numerics/DenseMatrix.cpp
+++ b/src/numerics/DenseMatrix.cpp
@@ -21,24 +21,12 @@ DenseMatrix::DenseMatrix(size_t n, size_t m, double v) :
     Array2D(n, m, v)
 {
     m_ipiv.resize(std::max(n, m));
-    m_colPts.resize(m);
-    if (!m_data.empty()) {
-        for (size_t j = 0; j < m; j++) {
-            m_colPts[j] = &m_data[m_nrows*j];
-        }
-    }
 }
 
 DenseMatrix::DenseMatrix(const DenseMatrix& y) :
     Array2D(y)
 {
     m_ipiv = y.ipiv();
-    m_colPts.resize(m_ncols);
-    if (!m_data.empty()) {
-        for (size_t j = 0; j < m_ncols; j++) {
-            m_colPts[j] = &m_data[m_nrows*j];
-        }
-    }
 }
 
 DenseMatrix& DenseMatrix::operator=(const DenseMatrix& y)
@@ -48,10 +36,6 @@ DenseMatrix& DenseMatrix::operator=(const DenseMatrix& y)
     }
     Array2D::operator=(y);
     m_ipiv = y.ipiv();
-    m_colPts.resize(m_ncols);
-    for (size_t j = 0; j < m_ncols; j++) {
-        m_colPts[j] = &m_data[m_nrows*j];
-    }
     return *this;
 }
 
@@ -59,35 +43,21 @@ void DenseMatrix::resize(size_t n, size_t m, double v)
 {
     Array2D::resize(n,m,v);
     m_ipiv.resize(std::max(n,m));
-    m_colPts.resize(m_ncols);
-    if (!m_data.empty()) {
-        for (size_t j = 0; j < m_ncols; j++) {
-            m_colPts[j] = &m_data[m_nrows*j];
-        }
-    }
 }
 
-double* const* DenseMatrix::colPts()
+void DenseMatrix::mult(span<const double> b, span<double> prod) const
 {
-    return &m_colPts[0];
-}
-
-const double* const* DenseMatrix::const_colPts() const
-{
-    return &m_colPts[0];
-}
-
-void DenseMatrix::mult(const double* b, double* prod) const
-{
+    checkArraySize("DenseMatrix::mult", b.size(), nColumns());
+    checkArraySize("DenseMatrix::mult", prod.size(), nRows());
 #if CT_USE_LAPACK
     ct_dgemv(ctlapack::ColMajor, ctlapack::NoTranspose,
              static_cast<int>(nRows()),
-             static_cast<int>(nColumns()), 1.0, ptrColumn(0),
-             static_cast<int>(nRows()), b, 1, 0.0, prod, 1);
+             static_cast<int>(nColumns()), 1.0, col(0).data(),
+             static_cast<int>(nRows()), b.data(), 1, 0.0, prod.data(), 1);
 #else
     MappedMatrix mat(const_cast<double*>(m_data.data()), nRows(), nColumns());
-    MappedVector bm(const_cast<double*>(b), nColumns());
-    MappedVector pm(prod, nRows());
+    MappedVector bm(const_cast<double*>(b.data()), nColumns());
+    MappedVector pm(prod.data(), nRows());
     pm = mat * bm;
 #endif
 }
@@ -103,17 +73,17 @@ void DenseMatrix::mult(const DenseMatrix& B, DenseMatrix& prod) const
             "Output matrix has wrong dimensions: {}x{} != {}x{}",
             prod.nRows(), prod.nColumns(), nRows(), B.nColumns());
     }
-    const double* const* bcols = B.const_colPts();
-    double* const* prodcols = prod.colPts();
     for (size_t col=0; col < B.nColumns(); ++col) {
         // Loop over ncols multiplying A*column of B and storing in
         // corresponding prod column
-        mult(bcols[col], prodcols[col]);
+        mult(B.col(col), prod.col(col));
     }
 }
 
-void DenseMatrix::leftMult(const double* const b, double* const prod) const
+void DenseMatrix::leftMult(span<const double> b, span<double> prod) const
 {
+    checkArraySize("DenseMatrix::leftMult", b.size(), nRows());
+    checkArraySize("DenseMatrix::leftMult", prod.size(), nColumns());
     for (size_t n = 0; n < nColumns(); n++) {
         double sum = 0.0;
         for (size_t i = 0; i < nRows(); i++) {
@@ -128,33 +98,35 @@ vector<int>& DenseMatrix::ipiv()
     return m_ipiv;
 }
 
-void solve(DenseMatrix& A, double* b, size_t nrhs, size_t ldb)
+void solve(DenseMatrix& A, span<double> b, size_t nrhs, size_t ldb)
 {
     if (A.nColumns() != A.nRows()) {
-        throw CanteraError("solve(DenseMatrix& A, double* b)", "Can only solve a square matrix");
+        throw CanteraError("solve(DenseMatrix& A, span<double> b)",
+            "Can only solve a square matrix");
     }
 
     int info = 0;
     if (ldb == 0) {
         ldb = A.nColumns();
     }
+    checkArraySize("solve(DenseMatrix& A, span<double> b)", b.size(), ldb * nrhs);
     #if CT_USE_LAPACK
-        ct_dgetrf(A.nRows(), A.nColumns(), A.ptrColumn(0),
+        ct_dgetrf(A.nRows(), A.nColumns(), A.data().data(),
                   A.nRows(), &A.ipiv()[0], info);
         if (info > 0) {
-            throw CanteraError("solve(DenseMatrix& A, double* b)",
+            throw CanteraError("solve(DenseMatrix& A, span<double> b)",
                                 "DGETRF returned INFO = {}. U(i,i) is exactly zero. The factorization has"
                                 " been completed, but the factor U is exactly singular, and division by zero will occur if "
                                 "it is used to solve a system of equations.", info);
         } else if (info < 0) {
-            throw CanteraError("solve(DenseMatrix& A, double* b)",
+            throw CanteraError("solve(DenseMatrix& A, span<double> b)",
                                "DGETRF returned INFO = {}. The argument i has an illegal value", info);
         }
 
-        ct_dgetrs(ctlapack::NoTranspose, A.nRows(), nrhs, A.ptrColumn(0),
-                  A.nRows(), &A.ipiv()[0], b, ldb, info);
+        ct_dgetrs(ctlapack::NoTranspose, A.nRows(), nrhs, A.data().data(),
+                  A.nRows(), &A.ipiv()[0], b.data(), ldb, info);
         if (info != 0) {
-            throw CanteraError("solve(DenseMatrix& A, double* b)",
+            throw CanteraError("solve(DenseMatrix& A, span<double> b)",
                                 "DGETRS returned INFO = {}", info);
         }
     #else
@@ -164,13 +136,13 @@ void solve(DenseMatrix& A, double* b, size_t nrhs, size_t ldb)
         #else
             auto lu = Am.fullPivLu();
             if (lu.nonzeroPivots() < static_cast<long int>(A.nColumns())) {
-                throw CanteraError("solve(DenseMatrix& A, double* b)",
+                throw CanteraError("solve(DenseMatrix& A, span<double> b)",
                     "Matrix appears to be rank-deficient: non-zero pivots = {}; columns = {}",
                     lu.nonzeroPivots(), A.nColumns());
             }
         #endif
         for (size_t i = 0; i < nrhs; i++) {
-            MappedVector bm(b + ldb*i, A.nColumns());
+            MappedVector bm(b.data() + ldb*i, A.nColumns());
             bm = lu.solve(bm);
         }
     #endif
@@ -178,24 +150,26 @@ void solve(DenseMatrix& A, double* b, size_t nrhs, size_t ldb)
 
 void solve(DenseMatrix& A, DenseMatrix& b)
 {
-    solve(A, b.ptrColumn(0), b.nColumns(), b.nRows());
+    solve(A, b.data(), b.nColumns(), b.nRows());
 }
 
-void multiply(const DenseMatrix& A, const double* const b, double* const prod)
+void multiply(const DenseMatrix& A, span<const double> b, span<double> prod)
 {
     A.mult(b, prod);
 }
 
-void increment(const DenseMatrix& A, const double* b, double* prod)
+void increment(const DenseMatrix& A, span<const double> b, span<double> prod)
 {
+    checkArraySize("increment", b.size(), A.nColumns());
+    checkArraySize("increment", prod.size(), A.nRows());
     #if CT_USE_LAPACK
         ct_dgemv(ctlapack::ColMajor, ctlapack::NoTranspose,
                  static_cast<int>(A.nRows()), static_cast<int>(A.nColumns()), 1.0,
-                 A.ptrColumn(0), static_cast<int>(A.nRows()), b, 1, 1.0, prod, 1);
+                 A.data().data(), static_cast<int>(A.nRows()), b.data(), 1, 1.0, prod.data(), 1);
     #else
         MappedMatrix Am(&const_cast<DenseMatrix&>(A)(0,0), A.nRows(), A.nColumns());
-        MappedVector bm(const_cast<double*>(b), A.nColumns());
-        MappedVector pm(prod, A.nRows());
+        MappedVector bm(const_cast<double*>(b.data()), A.nColumns());
+        MappedVector pm(prod.data(), A.nRows());
         pm += Am * bm;
     #endif
 }
@@ -205,15 +179,15 @@ void invert(DenseMatrix& A, size_t nn)
     int info=0;
     #if CT_USE_LAPACK
         integer n = static_cast<int>(nn != npos ? nn : A.nRows());
-        ct_dgetrf(n, n, A.ptrColumn(0), static_cast<int>(A.nRows()),
+        ct_dgetrf(n, n, A.data().data(), static_cast<int>(A.nRows()),
                   &A.ipiv()[0], info);
         if (info != 0) {
-            throw CanteraError("invert(DenseMatrix& A, size_t nn)", "DGETRS returned INFO = {}", info);
+            throw CanteraError("invert(DenseMatrix& A, size_t nn)", "DGETRF returned INFO = {}", info);
         }
 
         vector<double> work(n);
         integer lwork = static_cast<int>(work.size());
-        ct_dgetri(n, A.ptrColumn(0), static_cast<int>(A.nRows()),
+        ct_dgetri(n, A.data().data(), static_cast<int>(A.nRows()),
                   &A.ipiv()[0], &work[0], lwork, info);
         if (info != 0) {
             throw CanteraError("invert(DenseMatrix& A, size_t nn)", "DGETRI returned INFO={}", info);

--- a/src/numerics/polyfit.cpp
+++ b/src/numerics/polyfit.cpp
@@ -11,17 +11,24 @@
 namespace Cantera
 {
 
-double polyfit(size_t n, size_t deg, const double* xp, const double* yp,
-               const double* wp, double* pp)
+double polyfit(size_t deg, span<const double> x, span<const double> y,
+               span<const double> w, span<double> p)
 {
-    ConstMappedVector x(xp, n);
-    Eigen::VectorXd y = ConstMappedVector(yp, n);
-    MappedVector p(pp, deg+1);
+    size_t n = x.size();
+    checkArraySize("polyfit", y.size(), n);
+    checkArraySize("polyfit", p.size(), deg + 1);
+    if (!w.empty()) {
+        checkArraySize("polyfit", w.size(), n);
+    }
 
     if (deg >= n) {
         throw CanteraError("polyfit", "Polynomial degree ({}) must be less "
             "than number of input data points ({})", deg, n);
     }
+
+    ConstMappedVector xx(x.data(), n);
+    Eigen::VectorXd yy = ConstMappedVector(y.data(), n);
+    MappedVector pp(p.data(), deg + 1);
 
     // Construct A such that each row i of A has the elements
     // 1, x[i], x[i]^2, x[i]^3 ... + x[i]^deg
@@ -29,28 +36,28 @@ double polyfit(size_t n, size_t deg, const double* xp, const double* yp,
     A.col(0).setConstant(1.0);
 
     if (deg > 0) {
-        A.col(1) = x;
+        A.col(1) = xx;
     }
     for (size_t i = 1; i < deg; i++) {
-        A.col(i+1) = A.col(i).array() * x.array();
+        A.col(i+1) = A.col(i).array() * xx.array();
     }
 
-    if (wp != nullptr && wp[0] > 0) {
+    if (!w.empty() && w[0] > 0) {
         // For compatibility with old Fortran dpolft, input weights are the
         // squares of the weight vector used in this algorithm
-        Eigen::VectorXd w = ConstMappedVector(wp, n).cwiseSqrt().eval();
+        Eigen::VectorXd ww = ConstMappedVector(w.data(), n).cwiseSqrt().eval();
 
         // Multiply by the weights on both sides
-        A = w.asDiagonal() * A;
-        y.array() *= w.array();
+        A = ww.asDiagonal() * A;
+        yy.array() *= ww.array();
     }
 
     // Solve W*A*p = W*y to find the polynomial coefficients
-    p = A.colPivHouseholderQr().solve(y);
+    pp = A.colPivHouseholderQr().solve(yy);
 
     // Evaluate the computed polynomial at the input x coordinates to compute
     // the RMS error as the return value
-    return (A*p - y).eval().norm() / sqrt(n);
+    return (A * pp - yy).eval().norm() / sqrt(n);
 }
 
 }

--- a/src/oneD/Flow1D.cpp
+++ b/src/oneD/Flow1D.cpp
@@ -382,8 +382,7 @@ void Flow1D::updateTransport(span<const double> x, size_t j0, size_t j1)
 
             m_tcon[j] = m_trans->thermalConductivity();
             if (m_do_soret) {
-                m_trans->getThermalDiffCoeffs(
-                    span<double>(m_dthermal.ptrColumn(0) + j*m_nsp, m_nsp));
+                m_trans->getThermalDiffCoeffs(m_dthermal.col(j));
             }
         }
     } else { // mixture averaged transport
@@ -411,8 +410,7 @@ void Flow1D::updateTransport(span<const double> x, size_t j0, size_t j1)
             }
             m_tcon[j] = m_trans->thermalConductivity();
             if (m_do_soret) {
-                m_trans->getThermalDiffCoeffs(
-                    span<double>(m_dthermal.ptrColumn(0) + j*m_nsp, m_nsp));
+                m_trans->getThermalDiffCoeffs(m_dthermal.col(j));
             }
         }
     }

--- a/src/oneD/Flow1D.cpp
+++ b/src/oneD/Flow1D.cpp
@@ -372,7 +372,8 @@ void Flow1D::updateTransport(span<const double> x, size_t j0, size_t j1)
             double wtm = m_thermo->meanMolecularWeight();
             double rho = m_thermo->density();
             m_visc[j] = (m_dovisc ? m_trans->viscosity() : 0.0);
-            m_trans->getMultiDiffCoeffs(m_nsp, &m_multidiff[mindex(0,0,j)]);
+            m_trans->getMultiDiffCoeffs(m_nsp,
+                span<double>(&m_multidiff[mindex(0,0,j)], m_nsp * m_nsp));
 
             // Use m_diff as storage for the factor outside the summation
             for (size_t k = 0; k < m_nsp; k++) {
@@ -381,7 +382,8 @@ void Flow1D::updateTransport(span<const double> x, size_t j0, size_t j1)
 
             m_tcon[j] = m_trans->thermalConductivity();
             if (m_do_soret) {
-                m_trans->getThermalDiffCoeffs(m_dthermal.ptrColumn(0) + j*m_nsp);
+                m_trans->getThermalDiffCoeffs(
+                    span<double>(m_dthermal.ptrColumn(0) + j*m_nsp, m_nsp));
             }
         }
     } else { // mixture averaged transport
@@ -390,9 +392,9 @@ void Flow1D::updateTransport(span<const double> x, size_t j0, size_t j1)
             m_visc[j] = (m_dovisc ? m_trans->viscosity() : 0.0);
 
             if (m_fluxGradientBasis == ThermoBasis::molar) {
-                m_trans->getMixDiffCoeffs(&m_diff[j*m_nsp]);
+                m_trans->getMixDiffCoeffs(span<double>(&m_diff[j*m_nsp], m_nsp));
             } else {
-                m_trans->getMixDiffCoeffsMass(&m_diff[j*m_nsp]);
+                m_trans->getMixDiffCoeffsMass(span<double>(&m_diff[j*m_nsp], m_nsp));
             }
 
             double rho = m_thermo->density();
@@ -409,7 +411,8 @@ void Flow1D::updateTransport(span<const double> x, size_t j0, size_t j1)
             }
             m_tcon[j] = m_trans->thermalConductivity();
             if (m_do_soret) {
-                m_trans->getThermalDiffCoeffs(m_dthermal.ptrColumn(0) + j*m_nsp);
+                m_trans->getThermalDiffCoeffs(
+                    span<double>(m_dthermal.ptrColumn(0) + j*m_nsp, m_nsp));
             }
         }
     }

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -96,7 +96,7 @@ void IonFlow::updateTransport(span<const double> x, size_t j0, size_t j1)
     Flow1D::updateTransport(x,j0,j1);
     for (size_t j = j0; j < j1; j++) {
         setGasAtMidpoint(x,j);
-        m_trans->getMobilities(&m_mobility[j*m_nsp]);
+        m_trans->getMobilities(span<double>(&m_mobility[j*m_nsp], m_nsp));
         if (m_import_electron_transport) {
             size_t k = m_kElectron;
             double tlog = log(m_thermo->temperature());

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -257,11 +257,10 @@ void IonFlow::setElectronTransport(span<const double> tfix, span<const double> d
     for (size_t i = 0; i < n; i++) {
         tlog.push_back(log(tfix[i]));
     }
-    vector<double> w(n, -1.0);
     m_diff_e_fix.resize(degree + 1);
     m_mobi_e_fix.resize(degree + 1);
-    polyfit(n, degree, tlog.data(), diff_e.data(), w.data(), m_diff_e_fix.data());
-    polyfit(n, degree, tlog.data(), mobi_e.data(), w.data(), m_mobi_e_fix.data());
+    polyfit(degree, tlog, diff_e, {}, m_diff_e_fix);
+    polyfit(degree, tlog, mobi_e, {}, m_mobi_e_fix);
 }
 
 }

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -100,10 +100,10 @@ void IonFlow::updateTransport(span<const double> x, size_t j0, size_t j1)
         if (m_import_electron_transport) {
             size_t k = m_kElectron;
             double tlog = log(m_thermo->temperature());
-            m_mobility[k+m_nsp*j] = poly5(tlog, m_mobi_e_fix.data());
+            m_mobility[k+m_nsp*j] = poly5(tlog, m_mobi_e_fix);
             double rho = m_thermo->density();
             double wtm = m_thermo->meanMolecularWeight();
-            m_diff[k+m_nsp*j] = m_wt[k]*rho*poly5(tlog, m_diff_e_fix.data())/wtm;
+            m_diff[k+m_nsp*j] = m_wt[k]*rho*poly5(tlog, m_diff_e_fix)/wtm;
         }
     }
 }

--- a/src/oneD/OneDim.cpp
+++ b/src/oneD/OneDim.cpp
@@ -17,9 +17,9 @@ using namespace std;
 namespace Cantera
 {
 
-OneDim::OneDim(vector<shared_ptr<Domain1D>>& domains)
+OneDim::OneDim(span<const shared_ptr<Domain1D>> domains)
 {
-    for (auto& dom : domains) {
+    for (const auto& dom : domains) {
         addDomain(dom);
     }
     init();

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -22,7 +22,7 @@ using namespace std;
 namespace Cantera
 {
 
-Sim1D::Sim1D(vector<shared_ptr<Domain1D>>& domains) :
+Sim1D::Sim1D(span<const shared_ptr<Domain1D>> domains) :
     OneDim(domains),
     m_steady_callback(0)
 {

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -801,7 +801,7 @@ void Sim1D::solveAdjoint(span<const double> b, span<double> lambda)
         }
     }
 
-    Jt.solve(b.data(), lambda.data());
+    Jt.solve(b, lambda);
 }
 
 void Sim1D::resize()

--- a/src/pch/system.h
+++ b/src/pch/system.h
@@ -8,6 +8,8 @@
 #include <sstream>
 #include <cstdlib>
 #include <vector>
+#include <span>
+#include <array>
 #include <map>
 #include <set>
 #include <string>

--- a/src/thermo/CoverageDependentSurfPhase.cpp
+++ b/src/thermo/CoverageDependentSurfPhase.cpp
@@ -475,8 +475,8 @@ void CoverageDependentSurfPhase::_updateCovDepThermo() const
 
         // For linear and polynomial model
         for (auto& item : m_PolynomialDependency) {
-            m_h_cov[item.k] += poly4(m_cov[item.j], item.enthalpy_coeffs.data());
-            m_s_cov[item.k] += poly4(m_cov[item.j], item.entropy_coeffs.data());
+            m_h_cov[item.k] += poly4(m_cov[item.j], item.enthalpy_coeffs);
+            m_s_cov[item.k] += poly4(m_cov[item.j], item.entropy_coeffs);
         }
 
         // For piecewise-linear and interpolative model

--- a/src/thermo/HMWSoln.cpp
+++ b/src/thermo/HMWSoln.cpp
@@ -1531,11 +1531,11 @@ void HMWSoln::s_updatePitzer_CoeffWRTemp(int doDerivs) const
             size_t n = m_kk*i + j;
             size_t counterIJ = m_CounterIJ[n];
 
-            const double* beta0MX_coeff = m_Beta0MX_ij_coeff.ptrColumn(counterIJ);
-            const double* beta1MX_coeff = m_Beta1MX_ij_coeff.ptrColumn(counterIJ);
-            const double* beta2MX_coeff = m_Beta2MX_ij_coeff.ptrColumn(counterIJ);
-            const double* CphiMX_coeff = m_CphiMX_ij_coeff.ptrColumn(counterIJ);
-            const double* Theta_coeff = m_Theta_ij_coeff.ptrColumn(counterIJ);
+            auto beta0MX_coeff = m_Beta0MX_ij_coeff.col(counterIJ);
+            auto beta1MX_coeff = m_Beta1MX_ij_coeff.col(counterIJ);
+            auto beta2MX_coeff = m_Beta2MX_ij_coeff.col(counterIJ);
+            auto CphiMX_coeff = m_CphiMX_ij_coeff.col(counterIJ);
+            auto Theta_coeff = m_Theta_ij_coeff.col(counterIJ);
 
             switch (m_formPitzerTemp) {
             case PITZER_TEMP_CONSTANT:
@@ -1644,7 +1644,7 @@ void HMWSoln::s_updatePitzer_CoeffWRTemp(int doDerivs) const
         if (charge(i) == 0.0) {
             for (size_t j = 1; j < m_kk; j++) {
                 size_t n = i * m_kk + j;
-                const double* Lambda_coeff = m_Lambda_nj_coeff.ptrColumn(n);
+                auto Lambda_coeff = m_Lambda_nj_coeff.col(n);
                 switch (m_formPitzerTemp) {
                 case PITZER_TEMP_CONSTANT:
                     m_Lambda_nj(i,j) = Lambda_coeff[0];
@@ -1673,7 +1673,7 @@ void HMWSoln::s_updatePitzer_CoeffWRTemp(int doDerivs) const
                 }
 
                 if (j == i) {
-                    const double* Mu_coeff = m_Mu_nnn_coeff.ptrColumn(i);
+                    auto Mu_coeff = m_Mu_nnn_coeff.col(i);
                     switch (m_formPitzerTemp) {
                     case PITZER_TEMP_CONSTANT:
                         m_Mu_nnn[i] = Mu_coeff[0];
@@ -1709,7 +1709,7 @@ void HMWSoln::s_updatePitzer_CoeffWRTemp(int doDerivs) const
           for (size_t j = 1; j < m_kk; j++) {
               for (size_t k = 1; k < m_kk; k++) {
                   size_t n = i * m_kk *m_kk + j * m_kk + k;
-                  const double* Psi_coeff = m_Psi_ijk_coeff.ptrColumn(n);
+                  auto Psi_coeff = m_Psi_ijk_coeff.col(n);
                   m_Psi_ijk[n] = Psi_coeff[0];
               }
           }
@@ -1720,7 +1720,7 @@ void HMWSoln::s_updatePitzer_CoeffWRTemp(int doDerivs) const
           for (size_t j = 1; j < m_kk; j++) {
               for (size_t k = 1; k < m_kk; k++) {
                   size_t n = i * m_kk *m_kk + j * m_kk + k;
-                  const double* Psi_coeff = m_Psi_ijk_coeff.ptrColumn(n);
+                  auto Psi_coeff = m_Psi_ijk_coeff.col(n);
                   m_Psi_ijk[n] = Psi_coeff[0] + Psi_coeff[1]*tlin;
                   m_Psi_ijk_L[n] = Psi_coeff[1];
                   m_Psi_ijk_LL[n] = 0.0;
@@ -1733,7 +1733,7 @@ void HMWSoln::s_updatePitzer_CoeffWRTemp(int doDerivs) const
           for (size_t j = 1; j < m_kk; j++) {
               for (size_t k = 1; k < m_kk; k++) {
                   size_t n = i * m_kk *m_kk + j * m_kk + k;
-                  const double* Psi_coeff = m_Psi_ijk_coeff.ptrColumn(n);
+                  auto Psi_coeff = m_Psi_ijk_coeff.col(n);
                   m_Psi_ijk[n] = Psi_coeff[0]
                                  + Psi_coeff[1]*tlin
                                  + Psi_coeff[2]*tquad

--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -769,10 +769,11 @@ void MixtureFugacityTP::calcCriticalConditions(double& pc, double& tc, double& v
 }
 
 int MixtureFugacityTP::solveCubic(double T, double pres, double a, double b,
-                                  double aAlpha, double Vroot[3], double an,
+                                  double aAlpha, span<double> Vroot, double an,
                                   double bn, double cn, double dn, double tc, double vc) const
 {
-    fill_n(Vroot, 3, 0.0);
+    checkArraySize("MixtureFugacityTP::solveCubic: Vroot", Vroot.size(), 3);
+    fill(Vroot.begin(), Vroot.end(), 0.0);
     if (T <= 0.0) {
         throw CanteraError("MixtureFugacityTP::solveCubic",
             "negative temperature T = {}", T);

--- a/src/thermo/Nasa9PolyMultiTempRegion.cpp
+++ b/src/thermo/Nasa9PolyMultiTempRegion.cpp
@@ -22,7 +22,7 @@
 namespace Cantera
 {
 
-Nasa9PolyMultiTempRegion::Nasa9PolyMultiTempRegion(vector<Nasa9Poly1*>& regionPts)
+Nasa9PolyMultiTempRegion::Nasa9PolyMultiTempRegion(span<Nasa9Poly1*> regionPts)
 {
     // From now on, we own these pointers
     for (Nasa9Poly1* region : regionPts) {

--- a/src/thermo/PDSS_SSVol.cpp
+++ b/src/thermo/PDSS_SSVol.cpp
@@ -9,7 +9,6 @@
 
 #include "cantera/thermo/PDSS_SSVol.h"
 #include "cantera/thermo/VPStandardStateTP.h"
-#include <array>
 
 namespace Cantera
 {

--- a/src/thermo/PengRobinson.cpp
+++ b/src/thermo/PengRobinson.cpp
@@ -703,7 +703,7 @@ void PengRobinson::calcCriticalConditions(double& pc, double& tc, double& vc) co
 }
 
 int PengRobinson::solveCubic(double T, double pres, double a, double b, double aAlpha,
-                             double Vroot[3]) const
+                             span<double> Vroot) const
 {
     // Derive the coefficients of the cubic polynomial (in terms of molar volume v)
     double bsqr = b * b;

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -57,7 +57,7 @@ void RedlichKwongMFTP::setSpeciesCoeffs(const string& species,
             a_coeff_vec(1, k + m_kk * j) = a1kj;
         }
     }
-    a_coeff_vec.getRow(0, a_vec_Curr_.data());
+    a_coeff_vec.getRow(0, a_vec_Curr_);
     b_vec_Curr_[k] = b;
 }
 

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -796,7 +796,8 @@ void RedlichKwongMFTP::calcCriticalConditions(double& pc, double& tc, double& vc
     vc = omega_vc * GasConstant * tc / pc;
 }
 
-int RedlichKwongMFTP::solveCubic(double T, double pres, double a, double b, double Vroot[3]) const
+int RedlichKwongMFTP::solveCubic(double T, double pres, double a, double b,
+                                 span<double> Vroot) const
 {
 
     // Derive the coefficients of the cubic polynomial to solve.

--- a/src/transport/DustyGasTransport.cpp
+++ b/src/transport/DustyGasTransport.cpp
@@ -98,6 +98,9 @@ void DustyGasTransport::getMolarFluxes(span<const double> state1,
                                        span<const double> state2,
                                        const double delta, span<double> fluxes)
 {
+    checkArraySize("DustyGasTransport::getMolarFluxes: state1", state1.size(), m_nsp + 2);
+    checkArraySize("DustyGasTransport::getMolarFluxes: state2", state2.size(), m_nsp + 2);
+    checkArraySize("DustyGasTransport::getMolarFluxes: fluxes", fluxes.size(), m_nsp);
     // cbar will be the average concentration between the two points
     span<double> cbar(m_spwork);
     span<double> gradc(m_spwork2);
@@ -167,6 +170,10 @@ void DustyGasTransport::updateMultiDiffCoeffs()
 
 void DustyGasTransport::getMultiDiffCoeffs(const size_t ld, span<double> d)
 {
+    if (ld < m_nsp) {
+        throw CanteraError("DustyGasTransport::getMultiDiffCoeffs", "ld is too small");
+    }
+    checkArraySize("DustyGasTransport::getMultiDiffCoeffs", d.size(), ld * m_nsp);
     updateMultiDiffCoeffs();
     for (size_t i = 0; i < m_nsp; i++) {
         for (size_t j = 0; j < m_nsp; j++) {

--- a/src/transport/DustyGasTransport.cpp
+++ b/src/transport/DustyGasTransport.cpp
@@ -100,7 +100,7 @@ void DustyGasTransport::getMolarFluxes(span<const double> state1,
 {
     // cbar will be the average concentration between the two points
     span<double> cbar(m_spwork);
-    double* const gradc = m_spwork2.data();
+    span<double> gradc(m_spwork2);
     const double t1 = state1[0];
     const double t2 = state2[0];
     const double rho1 = state1[1];
@@ -128,7 +128,7 @@ void DustyGasTransport::getMolarFluxes(span<const double> state1,
     updateMultiDiffCoeffs();
 
     // Multiply m_multidiff and gradc together and store the result in fluxes[]
-    multiply(m_multidiff, gradc, fluxes.data());
+    multiply(m_multidiff, gradc, fluxes);
     for (size_t k = 0; k < m_nsp; k++) {
         cbar[k] /= m_dk[k];
     }
@@ -148,7 +148,7 @@ void DustyGasTransport::getMolarFluxes(span<const double> state1,
     scale(cbar.begin(), cbar.end(), cbar.begin(), b);
 
     // Multiply m_multidiff with cbar and add it to fluxes
-    increment(m_multidiff, cbar.data(), fluxes.data());
+    increment(m_multidiff, cbar, fluxes);
     scale(fluxes.begin(), fluxes.end(), fluxes.begin(), -1.0);
 }
 

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -581,8 +581,8 @@ void GasTransport::fitProperties(MMCollisionInt& integrals)
                 w2[n] = 1.0/(spcond[n]*spcond[n]);
             }
         }
-        polyfit(np, degree, tlog.data(), spvisc.data(), w.data(), c.data());
-        polyfit(np, degree, tlog.data(), spcond.data(), w2.data(), c2.data());
+        polyfit(degree, tlog, spvisc, w, c);
+        polyfit(degree, tlog, spcond, w2, c2);
 
         // evaluate max fit errors for viscosity
         for (size_t n = 0; n < np; n++) {
@@ -673,7 +673,7 @@ void GasTransport::fitDiffCoeffs(MMCollisionInt& integrals)
                     w[n] = 1.0/(diff[n]*diff[n]);
                 }
             }
-            polyfit(np, degree, tlog.data(), diff.data(), w.data(), c.data());
+            polyfit(degree, tlog, diff, w, c);
 
             for (size_t n = 0; n < np; n++) {
                 double val, fit;

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -589,11 +589,11 @@ void GasTransport::fitProperties(MMCollisionInt& integrals)
             double val, fit;
             if (m_mode == CK_Mode) {
                 val = exp(spvisc[n]);
-                fit = exp(poly3(tlog[n], c.data()));
+                fit = exp(poly3(tlog[n], c));
             } else {
                 double sqrt_T = exp(0.5*tlog[n]);
                 val = sqrt_T * pow(spvisc[n],2);
-                fit = sqrt_T * pow(poly4(tlog[n], c.data()),2);
+                fit = sqrt_T * pow(poly4(tlog[n], c),2);
             }
             err = fit - val;
             relerr = err/val;
@@ -608,11 +608,11 @@ void GasTransport::fitProperties(MMCollisionInt& integrals)
             double val, fit;
             if (m_mode == CK_Mode) {
                 val = exp(spcond[n]);
-                fit = exp(poly3(tlog[n], c2.data()));
+                fit = exp(poly3(tlog[n], c2));
             } else {
                 double sqrt_T = exp(0.5*tlog[n]);
                 val = sqrt_T * spcond[n];
-                fit = sqrt_T * poly4(tlog[n], c2.data());
+                fit = sqrt_T * poly4(tlog[n], c2);
             }
             err = fit - val;
             relerr = err/val;
@@ -679,12 +679,12 @@ void GasTransport::fitDiffCoeffs(MMCollisionInt& integrals)
                 double val, fit;
                 if (m_mode == CK_Mode) {
                     val = exp(diff[n]);
-                    fit = exp(poly3(tlog[n], c.data()));
+                    fit = exp(poly3(tlog[n], c));
                 } else {
                     double t = exp(tlog[n]);
                     double pre = pow(t, 1.5);
                     val = pre * diff[n];
-                    fit = pre * poly4(tlog[n], c.data());
+                    fit = pre * poly4(tlog[n], c);
                 }
                 err = fit - val;
                 relerr = err/val;

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -156,6 +156,7 @@ void GasTransport::getBinaryDiffCoeffs(const size_t ld, span<double> d)
     if (ld < m_nsp) {
         throw CanteraError("GasTransport::getBinaryDiffCoeffs", "ld is too small");
     }
+    checkArraySize("GasTransport::getBinaryDiffCoeffs", d.size(), ld * m_nsp);
     double rp = 1.0/m_thermo->pressure();
     for (size_t i = 0; i < m_nsp; i++) {
         for (size_t j = 0; j < m_nsp; j++) {
@@ -166,6 +167,7 @@ void GasTransport::getBinaryDiffCoeffs(const size_t ld, span<double> d)
 
 void GasTransport::getMixDiffCoeffs(span<double> d)
 {
+    checkArraySize("GasTransport::getMixDiffCoeffs", d.size(), m_nsp);
     update_T();
     update_C();
 
@@ -197,6 +199,7 @@ void GasTransport::getMixDiffCoeffs(span<double> d)
 
 void GasTransport::getMixDiffCoeffsMole(span<double> d)
 {
+    checkArraySize("GasTransport::getMixDiffCoeffsMole", d.size(), m_nsp);
     update_T();
     update_C();
 
@@ -227,6 +230,7 @@ void GasTransport::getMixDiffCoeffsMole(span<double> d)
 
 void GasTransport::getMixDiffCoeffsMass(span<double> d)
 {
+    checkArraySize("GasTransport::getMixDiffCoeffsMass", d.size(), m_nsp);
     update_T();
     update_C();
 

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -72,7 +72,7 @@ double GasTransport::viscosity()
         updateViscosity_T();
     }
 
-    multiply(m_phi, m_molefracs.data(), m_spwork.data());
+    multiply(m_phi, m_molefracs, m_spwork);
 
     for (size_t k = 0; k < m_nsp; k++) {
         vismix += m_molefracs[k] * m_visc[k]/m_spwork[k]; //denom;

--- a/src/transport/HighPressureGasTransport.cpp
+++ b/src/transport/HighPressureGasTransport.cpp
@@ -218,6 +218,7 @@ void HighPressureGasTransportBase::updateCorrectionFactors() {
 
 void HighPressureGasTransportBase::getBinaryDiffCoeffs(const size_t ld, span<double> d)
 {
+    checkArraySize("HighPressureGasTransport::getBinaryDiffCoeffs", d.size(), ld * m_nsp);
     update_C();
     update_T();
     updateCorrectionFactors();
@@ -243,6 +244,7 @@ void HighPressureGasTransportBase::getBinaryDiffCoeffs(const size_t ld, span<dou
 
 void HighPressureGasTransportBase::getMixDiffCoeffs(span<double> d)
 {
+    checkArraySize("HighPressureGasTransport::getMixDiffCoeffs", d.size(), m_nsp);
     update_T();
     update_C();
     updateCorrectionFactors();
@@ -275,6 +277,7 @@ void HighPressureGasTransportBase::getMixDiffCoeffs(span<double> d)
 
 void HighPressureGasTransportBase::getMixDiffCoeffsMole(span<double> d)
 {
+    checkArraySize("HighPressureGasTransport::getMixDiffCoeffsMole", d.size(), m_nsp);
     update_T();
     update_C();
     updateCorrectionFactors();
@@ -306,6 +309,7 @@ void HighPressureGasTransportBase::getMixDiffCoeffsMole(span<double> d)
 
 void HighPressureGasTransportBase::getMixDiffCoeffsMass(span<double> d)
 {
+    checkArraySize("HighPressureGasTransport::getMixDiffCoeffsMass", d.size(), m_nsp);
     update_T();
     update_C();
     updateCorrectionFactors();

--- a/src/transport/HighPressureGasTransport.cpp
+++ b/src/transport/HighPressureGasTransport.cpp
@@ -216,7 +216,7 @@ void HighPressureGasTransportBase::updateCorrectionFactors() {
     }
 }
 
-void HighPressureGasTransportBase::getBinaryDiffCoeffs(const size_t ld, double* const d)
+void HighPressureGasTransportBase::getBinaryDiffCoeffs(const size_t ld, span<double> d)
 {
     update_C();
     update_T();
@@ -241,7 +241,7 @@ void HighPressureGasTransportBase::getBinaryDiffCoeffs(const size_t ld, double* 
     }
 }
 
-void HighPressureGasTransportBase::getMixDiffCoeffs(double* const d)
+void HighPressureGasTransportBase::getMixDiffCoeffs(span<double> d)
 {
     update_T();
     update_C();
@@ -273,7 +273,7 @@ void HighPressureGasTransportBase::getMixDiffCoeffs(double* const d)
     }
 }
 
-void HighPressureGasTransportBase::getMixDiffCoeffsMole(double* const d)
+void HighPressureGasTransportBase::getMixDiffCoeffsMole(span<double> d)
 {
     update_T();
     update_C();
@@ -304,7 +304,7 @@ void HighPressureGasTransportBase::getMixDiffCoeffsMole(double* const d)
     }
 }
 
-void HighPressureGasTransportBase::getMixDiffCoeffsMass(double* const d)
+void HighPressureGasTransportBase::getMixDiffCoeffsMass(span<double> d)
 {
     update_T();
     update_C();

--- a/src/transport/IonGasTransport.cpp
+++ b/src/transport/IonGasTransport.cpp
@@ -339,6 +339,7 @@ double IonGasTransport::omega11_n64(const double tstar, const double gamma)
 
 void IonGasTransport::getMixDiffCoeffs(span<double> d)
 {
+    checkArraySize("IonGasTransport::getMixDiffCoeffs", d.size(), m_nsp);
     update_T();
     update_C();
 
@@ -374,6 +375,7 @@ void IonGasTransport::getMixDiffCoeffs(span<double> d)
 
 void IonGasTransport::getMobilities(span<double> mobi)
 {
+    checkArraySize("IonGasTransport::getMobilities", mobi.size(), m_nsp);
     update_T();
     update_C();
 

--- a/src/transport/IonGasTransport.cpp
+++ b/src/transport/IonGasTransport.cpp
@@ -59,11 +59,9 @@ void IonGasTransport::init(shared_ptr<ThermoPhase> thermo, int mode)
                          1200.0, 1500.0, 2000.0, 2500.0, 3000.0, 4000.0};
     const vector<double> om11_O2{120.0, 107.0, 98.1, 92.1, 83.0, 77.0,
                             72.6, 67.9, 62.7, 59.3, 56.7, 53.8};
-    vector<double> w(temp.size(),-1);
     int degree = 5;
     m_om11_O2.resize(degree + 1);
-    polyfit(temp.size(), degree, temp.data(), om11_O2.data(),
-            w.data(), m_om11_O2.data());
+    polyfit(degree, temp, om11_O2, {}, m_om11_O2);
     // set up Monchick and Mason parameters
     setupCollisionParameters();
     // set up n64 parameters
@@ -214,7 +212,7 @@ void IonGasTransport::fitDiffCoeffs(MMCollisionInt& integrals)
                 diff[n] = diffcoeff/pow(t, 1.5);
                 w[n] = 1.0/(diff[n]*diff[n]);
             }
-            polyfit(np, degree, tlog.data(), diff.data(), w.data(), c.data());
+            polyfit(degree, tlog, diff, w, c);
 
             for (size_t n = 0; n < np; n++) {
                 double val, fit;

--- a/src/transport/IonGasTransport.cpp
+++ b/src/transport/IonGasTransport.cpp
@@ -139,7 +139,7 @@ double IonGasTransport::thermalConductivity()
 double IonGasTransport::electricalConductivity()
 {
     vector<double> mobi(m_nsp);
-    getMobilities(&mobi[0]);
+    getMobilities(mobi);
     double p = m_thermo->pressure();
     double sum = 0.0;
     for (size_t k : m_kIon) {
@@ -339,7 +339,7 @@ double IonGasTransport::omega11_n64(const double tstar, const double gamma)
     return om11;
 }
 
-void IonGasTransport::getMixDiffCoeffs(double* const d)
+void IonGasTransport::getMixDiffCoeffs(span<double> d)
 {
     update_T();
     update_C();
@@ -374,7 +374,7 @@ void IonGasTransport::getMixDiffCoeffs(double* const d)
     }
 }
 
-void IonGasTransport::getMobilities(double* const mobi)
+void IonGasTransport::getMobilities(span<double> mobi)
 {
     update_T();
     update_C();

--- a/src/transport/IonGasTransport.cpp
+++ b/src/transport/IonGasTransport.cpp
@@ -108,7 +108,7 @@ double IonGasTransport::viscosity()
         updateViscosity_T();
     }
 
-    multiply(m_phi, m_molefracs.data(), m_spwork.data());
+    multiply(m_phi, m_molefracs, m_spwork);
 
     for (size_t k : m_kNeutral) {
         vismix += m_molefracs[k] * m_visc[k]/m_spwork[k]; //denom;

--- a/src/transport/IonGasTransport.cpp
+++ b/src/transport/IonGasTransport.cpp
@@ -204,7 +204,7 @@ void IonGasTransport::fitDiffCoeffs(MMCollisionInt& integrals)
                      j == m_thermo->speciesIndex("O2-", false)) &&
                     (k == m_thermo->speciesIndex("O2", false) ||
                      j == m_thermo->speciesIndex("O2", false))) {
-                       om11 = poly5(t, m_om11_O2.data()) / 1e20;
+                       om11 = poly5(t, m_om11_O2) / 1e20;
                 }
                 double diffcoeff = 3.0/16.0 * sqrt(2.0 * Pi/m_reducedMass(k,j))
                     * pow(Boltzmann * t, 1.5) / om11;
@@ -219,7 +219,7 @@ void IonGasTransport::fitDiffCoeffs(MMCollisionInt& integrals)
                 double t = exp(tlog[n]);
                 double pre = pow(t, 1.5);
                 val = pre * diff[n];
-                fit = pre * poly4(tlog[n], c.data());
+                fit = pre * poly4(tlog[n], c);
                 err = fit - val;
                 relerr = err/val;
                 mxerr = std::max(mxerr, fabs(err));

--- a/src/transport/MMCollisionInt.cpp
+++ b/src/transport/MMCollisionInt.cpp
@@ -20,6 +20,8 @@ std::array<double, 8> MMCollisionInt::delta = {
 
 double MMCollisionInt::quadInterp(double x0, span<const double> x, span<const double> y)
 {
+    checkArraySize("MMCollisionInt::quadInterp: x", x.size(), 3);
+    checkArraySize("MMCollisionInt::quadInterp: y", y.size(), 3);
     double dx21 = x[1] - x[0];
     double dx32 = x[2] - x[1];
     double dx31 = dx21 + dx32;

--- a/src/transport/MMCollisionInt.cpp
+++ b/src/transport/MMCollisionInt.cpp
@@ -290,7 +290,7 @@ double MMCollisionInt::omega22(double ts, double deltastar)
         if (deltastar == 0.0) {
             values[i-i1] = omega22_table[8*i];
         } else {
-            values[i-i1] = poly6(deltastar, m_o22poly[i].data());
+            values[i-i1] = poly6(deltastar, m_o22poly[i]);
         }
     }
     return quadInterp(log(ts), span<const double>(&m_logTemp[i1], 3), values);
@@ -313,7 +313,7 @@ double MMCollisionInt::astar(double ts, double deltastar)
         if (deltastar == 0.0) {
             values[i-i1] = astar_table[8*(i + 1)];
         } else {
-            values[i-i1] = poly6(deltastar, m_apoly[i].data());
+            values[i-i1] = poly6(deltastar, m_apoly[i]);
         }
     }
     return quadInterp(log(ts), span<const double>(&m_logTemp[i1], 3), values);
@@ -336,7 +336,7 @@ double MMCollisionInt::bstar(double ts, double deltastar)
         if (deltastar == 0.0) {
             values[i-i1] = bstar_table[8*(i + 1)];
         } else {
-            values[i-i1] = poly6(deltastar, m_bpoly[i].data());
+            values[i-i1] = poly6(deltastar, m_bpoly[i]);
         }
     }
     return quadInterp(log(ts), span<const double>(&m_logTemp[i1], 3), values);
@@ -359,7 +359,7 @@ double MMCollisionInt::cstar(double ts, double deltastar)
         if (deltastar == 0.0) {
             values[i-i1] = cstar_table[8*(i + 1)];
         } else {
-            values[i-i1] = poly6(deltastar, m_cpoly[i].data());
+            values[i-i1] = poly6(deltastar, m_cpoly[i]);
         }
     }
     return quadInterp(log(ts), span<const double>(&m_logTemp[i1], 3), values);
@@ -374,7 +374,7 @@ void MMCollisionInt::fit_omega22(int degree, double deltastar, span<double> o22)
         if (deltastar == 0.0) {
             values[i] = omega22_table[8*(i + m_nmin)];
         } else {
-            values[i] = poly6(deltastar, m_o22poly[i+m_nmin].data());
+            values[i] = poly6(deltastar, m_o22poly[i+m_nmin]);
         }
     }
     polyfit(degree, logT, values, {}, o22);
@@ -390,7 +390,7 @@ void MMCollisionInt::fit(int degree, double deltastar, span<double> a,
         if (deltastar == 0.0) {
             values[i] = astar_table[8*(i + m_nmin + 1)];
         } else {
-            values[i] = poly6(deltastar, m_apoly[i+m_nmin].data());
+            values[i] = poly6(deltastar, m_apoly[i+m_nmin]);
         }
     }
     polyfit(degree, logT, values, {}, a);
@@ -399,7 +399,7 @@ void MMCollisionInt::fit(int degree, double deltastar, span<double> a,
         if (deltastar == 0.0) {
             values[i] = bstar_table[8*(i + m_nmin + 1)];
         } else {
-            values[i] = poly6(deltastar, m_bpoly[i+m_nmin].data());
+            values[i] = poly6(deltastar, m_bpoly[i+m_nmin]);
         }
     }
     polyfit(degree, logT, values, {}, b);
@@ -408,7 +408,7 @@ void MMCollisionInt::fit(int degree, double deltastar, span<double> a,
         if (deltastar == 0.0) {
             values[i] = cstar_table[8*(i + m_nmin + 1)];
         } else {
-            values[i] = poly6(deltastar, m_cpoly[i+m_nmin].data());
+            values[i] = poly6(deltastar, m_cpoly[i+m_nmin]);
         }
     }
     polyfit(degree, logT, values, {}, c);

--- a/src/transport/MMCollisionInt.h
+++ b/src/transport/MMCollisionInt.h
@@ -89,23 +89,23 @@ private:
     vector<vector<double>> m_bpoly;
     vector<vector<double>> m_cpoly;
 
-    static double delta[8];
-    static double tstar22[37];
+    static std::array<double, 8> delta;
+    static std::array<double, 37> tstar22;
 
     //! Table of omega22 values
-    static double omega22_table[37*8];
+    static std::array<double, 37*8> omega22_table;
 
     //! T* values (reduced temperature)
-    static double tstar[39];
+    static std::array<double, 39> tstar;
 
     //! astar table
-    static double astar_table[39*8];
+    static std::array<double, 39*8> astar_table;
 
     //! bstar table
-    static double bstar_table[39*8];
+    static std::array<double, 39*8> bstar_table;
 
     //! cstar table
-    static double cstar_table[39*8];
+    static std::array<double, 39*8> cstar_table;
 
     //! Log temp
     vector<double> m_logTemp;

--- a/src/transport/MMCollisionInt.h
+++ b/src/transport/MMCollisionInt.h
@@ -73,15 +73,16 @@ public:
     double astar(double ts, double deltastar);
     double bstar(double ts, double deltastar);
     double cstar(double ts, double deltastar);
-    void fit(int degree, double deltastar, double* astar, double* bstar, double* cstar);
-    void fit_omega22(int degree, double deltastar, double* om22);
+    void fit(int degree, double deltastar, span<double> astar, span<double> bstar,
+             span<double> cstar);
+    void fit_omega22(int degree, double deltastar, span<double> om22);
     double omega11(double ts, double deltastar) {
         return omega22(ts, deltastar)/astar(ts, deltastar);
     }
 
 private:
-    double fitDelta(int table, int ntstar, int degree, double* c);
-    double quadInterp(double x0, double* x, double* y);
+    double fitDelta(int table, int ntstar, int degree, span<double> c);
+    double quadInterp(double x0, span<const double> x, span<const double> y);
 
     vector<vector<double>> m_o22poly;
     vector<vector<double>> m_apoly;

--- a/src/transport/MixTransport.cpp
+++ b/src/transport/MixTransport.cpp
@@ -22,6 +22,7 @@ void MixTransport::init(shared_ptr<ThermoPhase> thermo, int mode)
 
 void MixTransport::getMobilities(span<double> mobil)
 {
+    checkArraySize("MixTransport::getMobilities", mobil.size(), m_nsp);
     getMixDiffCoeffs(m_spwork);
     double c1 = ElectronCharge / (Boltzmann * m_temp);
     for (size_t k = 0; k < m_nsp; k++) {
@@ -50,6 +51,7 @@ double MixTransport::thermalConductivity()
 
 void MixTransport::getThermalDiffCoeffs(span<double> dt)
 {
+    checkArraySize("MixTransport::getThermalDiffCoeffs", dt.size(), m_nsp);
     update_T();
     update_C();
     if (!m_bindiff_ok) {
@@ -127,6 +129,15 @@ void MixTransport::getSpeciesFluxes(size_t ndim, span<const double> grad_T,
                                     size_t ldx, span<const double> grad_X,
                                     size_t ldf, span<double> fluxes)
 {
+    checkArraySize("MixTransport::getSpeciesFluxes: grad_T", grad_T.size(), ndim);
+    if (ldx < m_nsp) {
+        throw CanteraError("MixTransport::getSpeciesFluxes", "ldx is too small");
+    }
+    checkArraySize("MixTransport::getSpeciesFluxes: grad_X", grad_X.size(), ldx * ndim);
+    if (ldf < m_nsp) {
+        throw CanteraError("MixTransport::getSpeciesFluxes", "ldf is too small");
+    }
+    checkArraySize("MixTransport::getSpeciesFluxes: fluxes", fluxes.size(), ldf * ndim);
     update_T();
     update_C();
     getMixDiffCoeffs(m_spwork);

--- a/src/transport/MixTransport.cpp
+++ b/src/transport/MixTransport.cpp
@@ -20,9 +20,9 @@ void MixTransport::init(shared_ptr<ThermoPhase> thermo, int mode)
     m_cond.resize(m_nsp);
 }
 
-void MixTransport::getMobilities(double* const mobil)
+void MixTransport::getMobilities(span<double> mobil)
 {
-    getMixDiffCoeffs(m_spwork.data());
+    getMixDiffCoeffs(m_spwork);
     double c1 = ElectronCharge / (Boltzmann * m_temp);
     for (size_t k = 0; k < m_nsp; k++) {
         mobil[k] = c1 * m_spwork[k];
@@ -48,7 +48,7 @@ double MixTransport::thermalConductivity()
     return m_lambda;
 }
 
-void MixTransport::getThermalDiffCoeffs(double* const dt)
+void MixTransport::getThermalDiffCoeffs(span<double> dt)
 {
     update_T();
     update_C();
@@ -108,7 +108,7 @@ void MixTransport::getThermalDiffCoeffs(double* const dt)
     }
 
     vector<double>& Dm = m_spwork;
-    getMixDiffCoeffs(Dm.data());
+    getMixDiffCoeffs(Dm);
 
     double mmw = m_thermo->meanMolecularWeight();
     double norm = 0.;
@@ -123,13 +123,13 @@ void MixTransport::getThermalDiffCoeffs(double* const dt)
     }
 }
 
-void MixTransport::getSpeciesFluxes(size_t ndim, const double* const grad_T,
-                                    size_t ldx, const double* const grad_X,
-                                    size_t ldf, double* const fluxes)
+void MixTransport::getSpeciesFluxes(size_t ndim, span<const double> grad_T,
+                                    size_t ldx, span<const double> grad_X,
+                                    size_t ldf, span<double> fluxes)
 {
     update_T();
     update_C();
-    getMixDiffCoeffs(m_spwork.data());
+    getMixDiffCoeffs(m_spwork);
     auto mw = m_thermo->molecularWeights();
     auto y = m_thermo->massFractions();
     double rhon = m_thermo->molarDensity();

--- a/src/transport/MixTransport.cpp
+++ b/src/transport/MixTransport.cpp
@@ -94,9 +94,9 @@ void MixTransport::getThermalDiffCoeffs(span<double> dt)
 
             double Cstar = 0.;
             if (m_mode == CK_Mode) {
-                Cstar = poly6(log_tstar, m_cstar_poly[ipoly].data());
+                Cstar = poly6(log_tstar, m_cstar_poly[ipoly]);
             } else {
-                Cstar = poly8(log_tstar, m_cstar_poly[ipoly].data());
+                Cstar = poly8(log_tstar, m_cstar_poly[ipoly]);
             }
 
             double dt_T = ((1.2*Cstar - 1.0)/(m_bdiff(k,j)*rp))

--- a/src/transport/MultiTransport.cpp
+++ b/src/transport/MultiTransport.cpp
@@ -102,6 +102,7 @@ double MultiTransport::thermalConductivity()
 
 void MultiTransport::getThermalDiffCoeffs(span<double> dt)
 {
+    checkArraySize("MultiTransport::getThermalDiffCoeffs", dt.size(), m_nsp);
     solveLMatrixEquation();
     const double c = 1.6/GasConstant;
     for (size_t k = 0; k < m_nsp; k++) {
@@ -175,6 +176,15 @@ void MultiTransport::getSpeciesFluxes(size_t ndim, span<const double> grad_T,
                                       size_t ldx, span<const double> grad_X,
                                       size_t ldf, span<double> fluxes)
 {
+    if (ldx < m_nsp) {
+        throw CanteraError("MultiTransport::getSpeciesFluxes", "ldx is too small");
+    }
+    if (ldf < m_nsp) {
+        throw CanteraError("MultiTransport::getSpeciesFluxes", "ldf is too small");
+    }
+    checkArraySize("MultiTransport::getSpeciesFluxes: grad_T", grad_T.size(), ndim);
+    checkArraySize("MultiTransport::getSpeciesFluxes: grad_X", grad_X.size(), ldx * ndim);
+    checkArraySize("MultiTransport::getSpeciesFluxes: fluxes", fluxes.size(), ldf * ndim);
     // update the binary diffusion coefficients if necessary
     update_T();
     updateDiff_T();
@@ -262,6 +272,9 @@ void MultiTransport::getMassFluxes(span<const double> state1,
                                    span<const double> state2,
                                    double delta, span<double> fluxes)
 {
+    checkArraySize("MultiTransport::getMassFluxes: state1", state1.size(), m_nsp + 2);
+    checkArraySize("MultiTransport::getMassFluxes: state2", state2.size(), m_nsp + 2);
+    checkArraySize("MultiTransport::getMassFluxes: fluxes", fluxes.size(), m_nsp);
     span<double> x1(m_spwork1);
     span<double> x2(m_spwork2);
     span<double> x3(m_spwork3);
@@ -358,6 +371,10 @@ void MultiTransport::getMolarFluxes(span<const double> state1,
 
 void MultiTransport::getMultiDiffCoeffs(const size_t ld, span<double> d)
 {
+    if (ld < m_nsp) {
+        throw CanteraError("MultiTransport::getMultiDiffCoeffs", "ld is too small");
+    }
+    checkArraySize("MultiTransport::getMultiDiffCoeffs", d.size(), ld * m_nsp);
     double p = pressure_ig();
 
     // update the mole fractions

--- a/src/transport/MultiTransport.cpp
+++ b/src/transport/MultiTransport.cpp
@@ -164,7 +164,7 @@ void MultiTransport::solveLMatrixEquation()
     // Solve it using GMRES or LU decomposition. The last solution in m_a should
     // provide a good starting guess, so convergence should be fast.
     m_a = m_b;
-    solve(m_Lmatrix, m_a.data());
+    solve(m_Lmatrix, m_a);
     m_lmatrix_soln_ok = true;
     m_molefracs_last = m_molefracs;
     // L matrix is overwritten with LU decomposition
@@ -234,7 +234,7 @@ void MultiTransport::getSpeciesFluxes(size_t ndim, span<const double> grad_T,
     }
 
     // solve the equations
-    solve(m_aa, fluxes.data(), ndim, ldf);
+    solve(m_aa, fluxes, ndim, ldf);
     double pp = pressure_ig();
 
     // multiply diffusion velocities by rho * V to create mass fluxes, and
@@ -329,7 +329,7 @@ void MultiTransport::getMassFluxes(span<const double> state1,
     fluxes[jmax] = 0.0;
 
     // Solve the equations
-    solve(m_aa, fluxes.data());
+    solve(m_aa, fluxes);
 
     double pp = pressure_ig();
     // multiply diffusion velocities by rho * Y_k to create

--- a/src/transport/MultiTransport.cpp
+++ b/src/transport/MultiTransport.cpp
@@ -434,13 +434,13 @@ void MultiTransport::updateThermal_T()
             double z = m_star_poly_uses_actualT[i][j] == 1 ? m_logt : m_logt - m_log_eps_k(i,j);
             int ipoly = m_poly[i][j];
             if (m_mode == CK_Mode) {
-                m_astar(i,j) = poly6(z, m_astar_poly[ipoly].data());
-                m_bstar(i,j) = poly6(z, m_bstar_poly[ipoly].data());
-                m_cstar(i,j) = poly6(z, m_cstar_poly[ipoly].data());
+                m_astar(i,j) = poly6(z, m_astar_poly[ipoly]);
+                m_bstar(i,j) = poly6(z, m_bstar_poly[ipoly]);
+                m_cstar(i,j) = poly6(z, m_cstar_poly[ipoly]);
             } else {
-                m_astar(i,j) = poly8(z, m_astar_poly[ipoly].data());
-                m_bstar(i,j) = poly8(z, m_bstar_poly[ipoly].data());
-                m_cstar(i,j) = poly8(z, m_cstar_poly[ipoly].data());
+                m_astar(i,j) = poly8(z, m_astar_poly[ipoly]);
+                m_bstar(i,j) = poly8(z, m_bstar_poly[ipoly]);
+                m_cstar(i,j) = poly8(z, m_cstar_poly[ipoly]);
             }
             m_astar(j,i) = m_astar(i,j);
             m_bstar(j,i) = m_bstar(i,j);

--- a/src/zeroD/FlowReactor.cpp
+++ b/src/zeroD/FlowReactor.cpp
@@ -144,7 +144,7 @@ void FlowReactor::getStateDae(span<double> y, span<double> ydot)
     }
 
     // and solve
-    solve(a, ydot.data(), 1, 0);
+    solve(a, ydot, 1, 0);
 }
 
 void FlowReactor::updateState(span<const double> y)

--- a/test/clib/test_clib.cpp
+++ b/test/clib/test_clib.cpp
@@ -218,7 +218,7 @@ TEST(ct, transport)
     vector<double> cpp_dkm(nsp);
     auto sol = newSolution("gri30.yaml", "gri30");
     auto transport = sol->transport();
-    transport->getMixDiffCoeffs(cpp_dkm.data());
+    transport->getMixDiffCoeffs(cpp_dkm);
 
     for (size_t n = 0; n < nsp; n++) {
         ASSERT_NEAR(cpp_dkm[n], c_dkm[n], 1e-10);

--- a/test/equil/equil_gas.cpp
+++ b/test/equil/equil_gas.cpp
@@ -94,7 +94,7 @@ TEST_F(OverconstrainedEquil, BasisOptimize)
     MultiPhase mphase;
     mphase.addPhase(gas.get(), 10.0);
     mphase.init();
-    int usedZeroedSpecies = 0;
+    bool usedZeroedSpecies = false;
     vector<size_t> orderVectorSpecies(mphase.nSpecies());
     vector<size_t> orderVectorElements(mphase.nElements());
     std::iota(orderVectorSpecies.begin(), orderVectorSpecies.end(), 0);
@@ -103,7 +103,7 @@ TEST_F(OverconstrainedEquil, BasisOptimize)
     bool doFormMatrix = true;
     vector<double> formRxnMatrix(mphase.nSpecies() * mphase.nElements());
 
-    size_t nc = BasisOptimize(&usedZeroedSpecies, doFormMatrix, &mphase,
+    size_t nc = BasisOptimize(usedZeroedSpecies, doFormMatrix, &mphase,
                               orderVectorSpecies, orderVectorElements,
                               formRxnMatrix);
     ASSERT_EQ(1, (int) nc);
@@ -115,7 +115,7 @@ TEST_F(OverconstrainedEquil, DISABLED_BasisOptimize2)
     MultiPhase mphase;
     mphase.addPhase(gas.get(), 10.0);
     mphase.init();
-    int usedZeroedSpecies = 0;
+    bool usedZeroedSpecies = false;
     vector<size_t> orderVectorSpecies(mphase.nSpecies());
     vector<size_t> orderVectorElements(mphase.nElements());
     std::iota(orderVectorSpecies.begin(), orderVectorSpecies.end(), 0);
@@ -124,7 +124,7 @@ TEST_F(OverconstrainedEquil, DISABLED_BasisOptimize2)
     bool doFormMatrix = true;
     vector<double> formRxnMatrix(mphase.nSpecies() * mphase.nElements());
 
-    size_t nc = BasisOptimize(&usedZeroedSpecies, doFormMatrix, &mphase,
+    size_t nc = BasisOptimize(usedZeroedSpecies, doFormMatrix, &mphase,
                               orderVectorSpecies, orderVectorElements,
                               formRxnMatrix);
     ASSERT_EQ(1, (int) nc);

--- a/test/general/test_matrices.cpp
+++ b/test/general/test_matrices.cpp
@@ -46,11 +46,11 @@ public:
 TEST_F(BandMatrixTest, matrix_times_vector)
 {
     vector<double> c(6, 0.0);
-    A1.mult(x.data(), c.data());
+    A1.mult(x, c);
     for (size_t i = 0; i < 6; i++) {
         EXPECT_DOUBLE_EQ(b1[i], c[i]);
     }
-    A2.mult(x.data(), c.data());
+    A2.mult(x, c);
     for (size_t i = 0; i < 6; i++) {
         EXPECT_DOUBLE_EQ(b2[i], c[i]);
     }
@@ -59,11 +59,11 @@ TEST_F(BandMatrixTest, matrix_times_vector)
 TEST_F(BandMatrixTest, vector_times_matrix)
 {
     vector<double> c(6, 0.0);
-    A1.leftMult(x.data(), c.data());
+    A1.leftMult(x, c);
     for (size_t i = 0; i < 6; i++) {
         EXPECT_DOUBLE_EQ(v1[i], c[i]);
     }
-    A2.leftMult(x.data(), c.data());
+    A2.leftMult(x, c);
     for (size_t i = 0; i < 6; i++) {
         EXPECT_DOUBLE_EQ(v2[i], c[i]);
     }
@@ -72,11 +72,11 @@ TEST_F(BandMatrixTest, vector_times_matrix)
 TEST_F(BandMatrixTest, solve_linear_system)
 {
     vector<double> c(6, 0.0);
-    A1.solve(b1.data(), c.data());
+    A1.solve(b1, c);
     for (size_t i = 0; i < 6; i++) {
         EXPECT_NEAR(x[i], c[i], 1e-10);
     }
-    A2.solve(b2.data(), c.data());
+    A2.solve(b2, c);
     for (size_t i = 0; i < 6; i++) {
         EXPECT_NEAR(x[i], c[i], 1e-10);
     }
@@ -147,15 +147,15 @@ public:
 TEST_F(DenseMatrixTest, matrix_times_vector)
 {
     vector<double> c(4, 0.0);
-    A1.mult(x4.data(), c.data());
+    A1.mult(x4, c);
     for (size_t i = 0; i < 4; i++) {
         EXPECT_DOUBLE_EQ(b1[i], c[i]);
     }
-    A2.mult(x3.data(), c.data());
+    A2.mult(x3, c);
     for (size_t i = 0; i < 4; i++) {
         EXPECT_DOUBLE_EQ(b2[i], c[i]);
     }
-    A3.mult(x4.data(), c.data());
+    A3.mult(x4, c);
     for (size_t i = 0; i < 3; i++) {
         EXPECT_DOUBLE_EQ(b3[i], c[i]);
     }
@@ -183,7 +183,7 @@ TEST_F(DenseMatrixTest, matrix_times_matrix)
 TEST_F(DenseMatrixTest, solve_single_rhs)
 {
     vector<double> c(b1);
-    solve(A1, c.data());
+    solve(A1, c);
     for (size_t i = 0; i < 4; i++) {
         EXPECT_NEAR(x4[i], c[i], 1e-12);
     }
@@ -208,19 +208,19 @@ TEST_F(DenseMatrixTest, solve_multi_rhs)
 TEST_F(DenseMatrixTest, increment)
 {
     vector<double> c(b1.size(), 3.0);
-    increment(A1, x4.data(), c.data());
+    increment(A1, x4, c);
     for (size_t i = 0; i < 4; i++) {
         EXPECT_DOUBLE_EQ(3.0 + b1[i], c[i]);
     }
 
     c.assign(b2.size(), 3.0);
-    increment(A2, x3.data(), c.data());
+    increment(A2, x3, c);
     for (size_t i = 0; i < 4; i++) {
         EXPECT_DOUBLE_EQ(3.0 + b2[i], c[i]);
     }
 
     c.assign(b3.size(), 3.0);
-    increment(A3, x4.data(), c.data());
+    increment(A3, x4, c);
     for (size_t i = 0; i < 3; i++) {
         EXPECT_DOUBLE_EQ(3.0 + b3[i], c[i]);
     }

--- a/test/general/test_numerics.cpp
+++ b/test/general/test_numerics.cpp
@@ -20,10 +20,9 @@ TEST(Polyfit, exact_fit)
 {
     vector<double> x{0, 0.3, 1.0, 1.5, 2.0, 2.5};
     vector<double> p(6);
-    vector<double> w(6, -1.0);
     for (int i = 0; i < 20; i++) {
         vector<double> y{-1.1*i, cos(i), pow(-1,i), 3.2/(i+1), 0.1*i*i, sin(i)};
-        polyfit(6, 5, x.data(), y.data(), w.data(), p.data());
+        polyfit(5, x, y, {}, p);
         for (size_t j = 0; j < 6; j++) {
             EXPECT_NEAR(polyval(p, x[j]), y[j], 1e-10);
         }
@@ -53,7 +52,7 @@ TEST(Polyfit, sequential)
     for (size_t i = 0; i < PP.size(); i++) {
         size_t N = i + 1;
         vector<double> p(N);
-        double rms = polyfit(7, i, x.data(), y.data(), nullptr, p.data());
+        double rms = polyfit(i, x, y, {}, p);
         EXPECT_LT(rms, rms_prev);
         rms_prev = rms;
         for (size_t j = 0; j < N; j++) {
@@ -86,7 +85,7 @@ TEST(Polyfit, weighted)
     for (size_t i = 0; i < PP.size(); i++) {
         size_t N = i + 1;
         vector<double> p(N);
-        double rms = polyfit(7, i, x.data(), y.data(), w.data(), p.data());
+        double rms = polyfit(i, x, y, w, p);
         EXPECT_LT(rms, rms_prev);
         rms_prev = rms;
         for (size_t j = 0; j < N; j++) {

--- a/test/thermo/CoverageDependentSurfPhase_Test.cpp
+++ b/test/thermo/CoverageDependentSurfPhase_Test.cpp
@@ -162,7 +162,7 @@ TEST_F(CoverageDependentSurfPhase_Test, standard_enthalpies_RT)
     expected_result[1] += (h_high * (test_covs[0][2] - 0.4)) / RT;
     expected_result[1] += ((int_cp_tnow - int_cp_298)
                             * test_covs[0][2] * test_covs[0][2]) / RT;
-    expected_result[1] += poly4(test_covs[0][3], h_coeffs.data()) / RT;
+    expected_result[1] += poly4(test_covs[0][3], h_coeffs) / RT;
     expected_result[1] += h_int / RT;
     EXPECT_NEAR(enthalpies_RT[1], expected_result[1], 1.e-6);
 }
@@ -207,7 +207,7 @@ TEST_F(CoverageDependentSurfPhase_Test, standard_entropies_R)
     expected_result[1] += (s_slope * test_covs[0][1]) / GasConstant;
     expected_result[1] += (s_low * 0.4) / GasConstant;
     expected_result[1] += (s_high * (test_covs[0][2] - 0.4)) / GasConstant;
-    expected_result[1] += poly4(test_covs[0][3], s_coeffs.data()) / GasConstant;
+    expected_result[1] += poly4(test_covs[0][3], s_coeffs) / GasConstant;
     expected_result[1] += s_int / GasConstant;
     expected_result[1] += 0.5 * (int_cp_T_tnow - int_cp_T_298)
                           * test_covs[0][2] * test_covs[0][2] / GasConstant;

--- a/test/thermo/RedlichKisterTest.cpp
+++ b/test/thermo/RedlichKisterTest.cpp
@@ -6,8 +6,6 @@
 #include "cantera/base/stringUtils.h"
 #include "cantera/thermo/PDSS_ConstVol.h"
 
-#include <array>
-
 namespace Cantera
 {
 

--- a/test/thermo/phaseConstructors.cpp
+++ b/test/thermo/phaseConstructors.cpp
@@ -25,7 +25,6 @@
 #include "cantera/base/stringUtils.h"
 
 #include <fstream>
-#include <array>
 
 #include "thermo_data.h"
 

--- a/test/transport/transportFromScratch.cpp
+++ b/test/transport/transportFromScratch.cpp
@@ -74,8 +74,8 @@ TEST_F(TransportFromScratch, binaryDiffCoeffs)
     Array2D bdiffTest(3,3);
     ref->setState_TPX(400, 5e5, "H2:0.5, O2:0.3, H2O:0.2");
     test->setState_TPX(400, 5e5, "H2:0.5, O2:0.3, H2O:0.2");
-    trRef->getBinaryDiffCoeffs(K, &bdiffRef(0,0));
-    trTest.getBinaryDiffCoeffs(K, &bdiffTest(0,0));
+    trRef->getBinaryDiffCoeffs(K, bdiffRef.data());
+    trTest.getBinaryDiffCoeffs(K, bdiffTest.data());
 
     for (size_t i=0; i < K; i++) {
         for (size_t j=0; j < K; j++) {
@@ -95,8 +95,8 @@ TEST_F(TransportFromScratch, mixDiffCoeffs)
     vector<double> Dtest(3);
     ref->setState_TPX(400, 5e5, "H2:0.5, O2:0.3, H2O:0.2");
     test->setState_TPX(400, 5e5, "H2:0.5, O2:0.3, H2O:0.2");
-    trRef->getMixDiffCoeffs(&Dref[0]);
-    trTest.getMixDiffCoeffs(&Dtest[0]);
+    trRef->getMixDiffCoeffs(Dref);
+    trTest.getMixDiffCoeffs(Dtest);
 
     for (size_t k=0; k < K; k++) {
         EXPECT_DOUBLE_EQ(Dref[k], Dtest[k]) << "k = " << k;
@@ -143,8 +143,8 @@ TEST_F(TransportFromScratch, multiDiffCoeffs)
     Array2D Dtest(3,3);
     ref->setState_TPX(400, 5e5, "H2:0.5, O2:0.3, H2O:0.2");
     test->setState_TPX(400, 5e5, "H2:0.5, O2:0.3, H2O:0.2");
-    trRef->getMultiDiffCoeffs(K, &Dref(0,0));
-    trTest.getMultiDiffCoeffs(K, &Dtest(0,0));
+    trRef->getMultiDiffCoeffs(K, Dref.data());
+    trTest.getMultiDiffCoeffs(K, Dtest.data());
 
     for (size_t i=0; i < K; i++) {
         for (size_t j=0; j < K; j++) {

--- a/test/transport/transportModels.cpp
+++ b/test/transport/transportModels.cpp
@@ -93,12 +93,12 @@ TEST_F(NoTransportTest, check_exceptions_vector)
     // vector quantities
     auto tr = soln_->transport();
     vector<double> out(soln_->thermo()->nSpecies());
-    ASSERT_THROW(tr->getSpeciesViscosities(out.data()), CanteraError);
-    ASSERT_THROW(tr->getMobilities(out.data()), CanteraError);
-    ASSERT_THROW(tr->getThermalDiffCoeffs(out.data()), CanteraError);
-    ASSERT_THROW(tr->getMixDiffCoeffs(out.data()), CanteraError);
-    ASSERT_THROW(tr->getMixDiffCoeffsMole(out.data()), CanteraError);
-    ASSERT_THROW(tr->getMixDiffCoeffsMass(out.data()), CanteraError);
+    ASSERT_THROW(tr->getSpeciesViscosities(out), CanteraError);
+    ASSERT_THROW(tr->getMobilities(out), CanteraError);
+    ASSERT_THROW(tr->getThermalDiffCoeffs(out), CanteraError);
+    ASSERT_THROW(tr->getMixDiffCoeffs(out), CanteraError);
+    ASSERT_THROW(tr->getMixDiffCoeffsMole(out), CanteraError);
+    ASSERT_THROW(tr->getMixDiffCoeffsMass(out), CanteraError);
 }
 
 class DefaultTransportTest : public testing::Test

--- a/test/transport/transportPolynomials.cpp
+++ b/test/transport/transportPolynomials.cpp
@@ -20,9 +20,9 @@ public:
         size_t k = phase->speciesIndex(speciek);
         vector<double> coeffs (cmode == CK_Mode ? 4 : 5);
         if (cmode == CK_Mode) {
-            ck_tran.getViscosityPolynomial(k, &coeffs[0]);
+            ck_tran.getViscosityPolynomial(k, coeffs);
         } else {
-            tran.getViscosityPolynomial(k, &coeffs[0]);
+            tran.getViscosityPolynomial(k, coeffs);
         }
         for (size_t i = 0; i < visc_coeff_expected.size(); i++) {
             EXPECT_NEAR(coeffs[i], visc_coeff_expected[i], 1e-5);
@@ -36,9 +36,9 @@ public:
         size_t k = phase->speciesIndex(speciek);
         vector<double> coeffs (cmode == CK_Mode ? 4 : 5);
         if (cmode == CK_Mode) {
-            ck_tran.getConductivityPolynomial(k, &coeffs[0]);
+            ck_tran.getConductivityPolynomial(k, coeffs);
         } else {
-            tran.getConductivityPolynomial(k, &coeffs[0]);
+            tran.getConductivityPolynomial(k, coeffs);
         }
         for (size_t i = 0; i < cond_coeff_expected.size(); i++) {
             EXPECT_NEAR(coeffs[i], cond_coeff_expected[i], 1e-5);
@@ -51,9 +51,9 @@ public:
         size_t j = phase->speciesIndex(speciej);
         vector<double> coeffs (cmode == CK_Mode ? 4 : 5);
         if (cmode == CK_Mode) {
-            ck_tran.getBinDiffusivityPolynomial(k, j, &coeffs[0]);
+            ck_tran.getBinDiffusivityPolynomial(k, j, coeffs);
         } else {
-            tran.getBinDiffusivityPolynomial(k, j, &coeffs[0]);
+            tran.getBinDiffusivityPolynomial(k, j, coeffs);
         }
         for (size_t i = 0; i < bindiff_coeff_expected.size(); i++) {
             EXPECT_NEAR(coeffs[i], bindiff_coeff_expected[i], 1e-5);

--- a/test_problems/dustyGasTransport/dustyGasTransportTest.cpp
+++ b/test_problems/dustyGasTransport/dustyGasTransportTest.cpp
@@ -25,7 +25,7 @@ int main(int argc, char** argv)
         tranDusty->setMeanPoreRadius(1.5E-7);
         tranDusty->setMeanParticleDiameter(1.5E-6);
 
-        tranDusty->getMultiDiffCoeffs(nsp, multiD.data());
+        tranDusty->getMultiDiffCoeffs(nsp, multiD);
         printf("MultiDiffusion coefficients: \n");
         for (size_t i = 0; i < nsp; i++) {
             for (size_t j = 0; j < nsp; j++) {
@@ -43,11 +43,11 @@ int main(int argc, char** argv)
         vector<double> fluxes;
         fluxes.resize(nsp);
 
-        tranDusty->getMolarFluxes(&state1[0], &state1[0], delta, &fluxes[0]);
+        tranDusty->getMolarFluxes(state1, state1, delta, fluxes);
         for (size_t i = 0; i < nsp; i++) {
             printf(" flux[%d] = %13.8E\n", int(i), fluxes[i]);
         }
-        tranDusty->getMolarFluxes(&state1[0], &state2[0], delta, &fluxes[0]);
+        tranDusty->getMolarFluxes(state1, state2, delta, fluxes);
         for (size_t i = 0; i < nsp; i++) {
             printf(" flux[%d] = %13.8E\n", int(i), fluxes[i]);
         }


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

This should be the last PR in the sequence for updating to use `std::span`. It covers the `Transport` class and friends, the various matrix classes, and other utility code. It also adds some documentation explaining the necessary migrations.

**If applicable, fill in the issue number this pull request is fixing**

- Closes Cantera/enhancements#237

**AI Statement (required)**

- **Extensive use of generative AI.** Significant portions of code or documentation were generated with AI, including
  logic and implementation decisions. All generated code and documentation were reviewed and understood by the contributor. *Written with the assistance of ChatGPT Codex 5.3*.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
