### PR TITLE
Fix garbage collection issue with Mixture

### DIFF
--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -117,13 +117,6 @@ public:
         return m_nsp;
     }
 
-    //! Check that the specified species index is in range.
-    /*!
-     * @since Starting in %Cantera 3.2, returns the input species index, if valid.
-     * @exception Throws an IndexError if k is greater than nSpecies()-1
-     */
-    size_t checkSpeciesIndex(size_t k) const;
-
     //! Name of species with global index @e kGlob
     /*!
      * @param kGlob   global species index
@@ -197,13 +190,6 @@ public:
      * @return   Reference to the ThermoPhase object for the phase
      */
     ThermoPhase& phase(size_t n);
-
-    //! Check that the specified phase index is in range
-    /*!
-     * @since Starting in %Cantera 3.2, returns the input species index, if valid.
-     * @exception Throws an IndexError if m is greater than nPhases()-1
-     */
-    size_t checkPhaseIndex(size_t m) const;
 
     //! Returns the moles of global species @c k. units = kmol
     /*!
@@ -362,22 +348,6 @@ public:
      */
     void setTemperature(const double T);
 
-    //! Set the state of the underlying ThermoPhase objects in one call
-    /*!
-     * @param T      Temperature of the system (kelvin)
-     * @param Pres   pressure of the system (pascal)
-     */
-    void setState_TP(const double T, const double Pres);
-
-    //! Set the state of the underlying ThermoPhase objects in one call
-    /*!
-     * @param T      Temperature of the system (kelvin)
-     * @param Pres   pressure of the system (pascal)
-     * @param Moles  Vector of mole numbers of all the species in all the phases
-     *               (kmol)
-     */
-    void setState_TPMoles(const double T, const double Pres, span<const double> Moles);
-
     //! Pressure [Pa].
     double pressure() const {
         return m_press;
@@ -484,13 +454,6 @@ public:
      *             mole numbers (kmol).
      */
     void setMoles(span<const double> n);
-
-    //! Adds moles of a certain species to the mixture
-    /*!
-     * @param indexS      Index of the species in the MultiPhase object
-     * @param addedMoles  Value of the moles that are added to the species.
-     */
-    void addSpeciesMoles(const int indexS, const double addedMoles);
 
     //! Retrieves a vector of element abundances
     /*!

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -67,9 +67,8 @@ public:
      *  method addPhase().
      */
     MultiPhase() = default;
-
-    //! Destructor. Does nothing. Class MultiPhase does not take "ownership"
-    //! (that is, responsibility for destroying) the phase objects.
+    MultiPhase(const MultiPhase&) = delete;
+    MultiPhase& operator=(const MultiPhase&) = delete;
     virtual ~MultiPhase();
 
     //! Add a phase to the mixture.

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -72,22 +72,6 @@ public:
     //! (that is, responsibility for destroying) the phase objects.
     virtual ~MultiPhase();
 
-    //! Add a vector of phases to the mixture
-    /*!
-     * See the single addPhases command. This just does a bunch of phases
-     * at one time
-     *   @param phases Vector of pointers to phases
-     *   @param phaseMoles Vector of mole numbers in each phase (kmol)
-     */
-    void addPhases(span<ThermoPhase*> phases, span<const double> phaseMoles);
-
-    //! Add all phases present in 'mix' to this mixture.
-    /*!
-     *  @param mix  Add all of the phases in another MultiPhase
-     *              object to the current object.
-     */
-    void addPhases(MultiPhase& mix);
-
     //! Add a phase to the mixture.
     /*!
      *  This function must be called before the init() function is called,
@@ -98,16 +82,6 @@ public:
      *  @since New in %Cantera 3.2.
      */
     void addPhase(shared_ptr<ThermoPhase> p, double moles);
-
-    //! Add a phase to the mixture.
-    /*!
-     *  This function must be called before the init() function is called,
-     *  which serves to freeze the MultiPhase.
-     *
-     *  @param p pointer to the phase object
-     *  @param moles total number of moles of all species in this phase
-     */
-    void addPhase(ThermoPhase* p, double moles);
 
     //! Number of elements.
     size_t nElements() const {
@@ -588,13 +562,8 @@ private:
      */
     vector<double> m_moles;
 
-    //! Vector of the ThermoPhase pointers.
-    vector<ThermoPhase*> m_phase;
-
-    //! Vector of shared ThermoPhase pointers.
-    //! Contains valid phase entries if added by addPhase(shared_ptr<ThermoPhase>) and
-    //! null pointers if a phase is added via addPhase(ThermoPhase*).
-    vector<shared_ptr<ThermoPhase>> m_sharedPhase;
+    //! Vector of phase objects.
+    vector<shared_ptr<ThermoPhase>> m_phase;
 
     //! Global Stoichiometric Coefficient array
     /*!

--- a/interfaces/cython/cantera/mixture.pxd
+++ b/interfaces/cython/cantera/mixture.pxd
@@ -10,7 +10,7 @@ cdef extern from "cantera/equil/MultiPhase.h" namespace "Cantera":
     cdef cppclass CxxThermoPhase "Cantera::ThermoPhase"
     cdef cppclass CxxMultiPhase "Cantera::MultiPhase":
         CxxMultiPhase()
-        void addPhase(CxxThermoPhase*, double) except +translate_exception
+        void addPhase(shared_ptr[CxxThermoPhase], double) except +translate_exception
         void init() except +translate_exception
         void updatePhases() except +translate_exception
 

--- a/interfaces/cython/cantera/mixture.pyx
+++ b/interfaces/cython/cantera/mixture.pyx
@@ -58,8 +58,7 @@ cdef class Mixture:
             phases = [(p, 1 if i == 0 else 0) for i,p in enumerate(phases)]
 
         for phase,moles in phases:
-            # Block species from being added to the phase as long as this object exists
-            self.mix.addPhase(phase.thermo, moles)
+            self.mix.addPhase(phase.base.thermo(), moles)
             self._phases.append(phase)
 
         self.mix.init()

--- a/src/equil/ChemEquil.cpp
+++ b/src/equil/ChemEquil.cpp
@@ -165,7 +165,9 @@ void ChemEquil::update(const ThermoPhase& s)
 int ChemEquil::setInitialMoles(ThermoPhase& s, span<double> elMoleGoal, int loglevel)
 {
     MultiPhase mp;
-    mp.addPhase(&s, 1.0);
+    // Create a non-owning shared_ptr, since ThermoPhase `s` is guaranteed to outlive
+    // the MultiPhase object.
+    mp.addPhase(shared_ptr<ThermoPhase>(&s, [](ThermoPhase*) {}), 1.0);
     mp.init();
     MultiPhaseEquil e(&mp, true, loglevel-1);
     e.setInitialMixMoles(loglevel-1);
@@ -212,7 +214,7 @@ int ChemEquil::estimateElementPotentials(ThermoPhase& s, span<double> lambda_RT,
     s.getMoleFractions(xMF_est);
 
     MultiPhase mp;
-    mp.addPhase(&s, 1.0);
+    mp.addPhase(shared_ptr<ThermoPhase>(&s, [](ThermoPhase*) {}), 1.0);
     mp.init();
     int usedZeroedSpecies = 0;
     vector<double> formRxnMatrix(mp.nSpecies() * mp.nElements());

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -149,14 +149,6 @@ ThermoPhase& MultiPhase::phase(size_t n)
     return *m_phase[n];
 }
 
-size_t MultiPhase::checkPhaseIndex(size_t m) const
-{
-    if (m < nPhases()) {
-        return m;
-    }
-    throw IndexError("MultiPhase::checkPhaseIndex", "phase", m, nPhases());
-}
-
 double MultiPhase::speciesMoles(size_t k) const
 {
     size_t ip = m_spphase[k];
@@ -382,33 +374,6 @@ void MultiPhase::setMoles(span<const double> n)
         }
         loc += nsp;
     }
-}
-
-void MultiPhase::addSpeciesMoles(const int indexS, const double addedMoles)
-{
-    vector<double> tmpMoles(m_nsp, 0.0);
-    getMoles(tmpMoles);
-    tmpMoles[indexS] += addedMoles;
-    tmpMoles[indexS] = std::max(tmpMoles[indexS], 0.0);
-    setMoles(tmpMoles);
-}
-
-void MultiPhase::setState_TP(const double T, const double Pres)
-{
-    if (!m_init) {
-        init();
-    }
-    m_temp = T;
-    m_press = Pres;
-    updatePhases();
-}
-
-void MultiPhase::setState_TPMoles(const double T, const double Pres,
-                                  span<const double> n)
-{
-    m_temp = T;
-    m_press = Pres;
-    setMoles(n);
 }
 
 void MultiPhase::getElemAbundances(span<double> elemAbundances) const
@@ -735,14 +700,6 @@ size_t MultiPhase::elementIndex(const string& name, bool raise) const
         return npos;
     }
     throw CanteraError("MultiPhase::elementIndex", "Element '{}' not found", name);
-}
-
-size_t MultiPhase::checkSpeciesIndex(size_t k) const
-{
-    if (k < m_nsp) {
-        return k;
-    }
-    throw IndexError("MultiPhase::checkSpeciesIndex", "species", k, m_nsp);
 }
 
 string MultiPhase::speciesName(size_t k) const

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -1267,7 +1267,9 @@ void ThermoPhase::equilibrate(const string& XY, const string& solver,
 
     if (solver == "auto" || solver == "vcs" || solver == "gibbs") {
         MultiPhase M;
-        M.addPhase(this, 1.0);
+        // Create a non-owning shared_ptr, since this ThermoPhase object is guaranteed
+        // to outlive the MultiPhase object.
+        M.addPhase(shared_ptr<ThermoPhase>(this, [](ThermoPhase*) {}), 1.0);
         M.init();
         M.equilibrate(XY, solver, rtol, max_steps, max_iter,
                       estimate_equil, log_level);

--- a/test/equil/equil_gas.cpp
+++ b/test/equil/equil_gas.cpp
@@ -72,7 +72,7 @@ TEST_F(OverconstrainedEquil, exceptions)
 {
     setup();
     MultiPhase mphase;
-    mphase.addPhase(gas.get(), 10.0);
+    mphase.addPhase(gas, 10.0);
     mphase.init();
 
     ASSERT_THROW(mphase.elementName(200), IndexError);
@@ -92,7 +92,7 @@ TEST_F(OverconstrainedEquil, BasisOptimize)
 {
     setup();
     MultiPhase mphase;
-    mphase.addPhase(gas.get(), 10.0);
+    mphase.addPhase(gas, 10.0);
     mphase.init();
     int usedZeroedSpecies = 0;
     vector<size_t> orderVectorSpecies(mphase.nSpecies());
@@ -113,7 +113,7 @@ TEST_F(OverconstrainedEquil, DISABLED_BasisOptimize2)
 {
     setup("O, H, C, N, Ar");
     MultiPhase mphase;
-    mphase.addPhase(gas.get(), 10.0);
+    mphase.addPhase(gas, 10.0);
     mphase.init();
     int usedZeroedSpecies = 0;
     vector<size_t> orderVectorSpecies(mphase.nSpecies());

--- a/test_problems/VCSnonideal/NaCl_equil/nacl_equil.cpp
+++ b/test_problems/VCSnonideal/NaCl_equil/nacl_equil.cpp
@@ -101,16 +101,16 @@ int main(int argc, char** argv)
         gas->setState_TPX(T, pres, Xmol);
 
 
-        auto ss = make_unique<StoichSubstance>("NaCl_Solid.yaml");
+        auto ss = make_shared<StoichSubstance>("NaCl_Solid.yaml");
         ss->setState_TP(T, pres);
 
 
         // Construct the multiphase object
         MultiPhase* mp = new MultiPhase();
 
-        mp->addPhase(hmw.get(), 2.0);
-        mp->addPhase(gas.get(), 4.0);
-        mp->addPhase(ss.get(), 5.0);
+        mp->addPhase(hmw, 2.0);
+        mp->addPhase(gas, 4.0);
+        mp->addPhase(ss, 5.0);
 
 
         try {


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix issue with destructor ordering when `Mixture` objects are deleted by the Python garbage collector
- Simplify `MultiPhase` to always hold `shared_ptr<ThermoPhase` instead of allowing mixed owned and unowned objects
- Remove some unnecessary, unused methods of `MultiPhase`.

**If applicable, fill in the issue number this pull request is fixing**

This resolves a latent issue that was revealed in some of the CI runs on #2082. I'll be creating a separate PR to fix this on the `3.2` branch.

**AI Statement (required)**

- **Limited use of generative AI.** Standard or boilerplate code snippets were generated with AI and manually reviewed;
  all design, logic, and implementation decisions were made by the contributor. Examples: IDE code-completions or brief LLM queries for common patterns.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
