### PR TITLE
Fix handling of multi-occupancy surface species on MoleReactorSurface

### DIFF
--- a/src/zeroD/ReactorSurface.cpp
+++ b/src/zeroD/ReactorSurface.cpp
@@ -254,7 +254,7 @@ void MoleReactorSurface::updateState(double* y)
 void MoleReactorSurface::eval(double t, double* LHS, double* RHS)
 {
     for (size_t k = 0; k < m_nsp; k++) {
-        RHS[k] = m_sdot[k] * m_area / m_surf->size(k);
+        RHS[k] = m_sdot[k] * m_area;
     }
 }
 

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -1319,6 +1319,35 @@ class TestIdealGasReactor(TestReactor):
     reactorClass = ct.IdealGasReactor
 
 
+def test_MoleReactorSurface_site_occupancy():
+    # Test that MoleReactorSurface gives correct results for surfaces where the
+    # site occupancy varies for different species.
+    surf = ct.Interface('SiF4_NH3_mec.yaml')
+    gas = surf.adjacent['gas']
+    gas.TPX = 300, ct.one_atm, 'SiF4:0.5, NH3:0.5'
+    surf.TP = gas.TP
+    surf.coverages = 'HN_NH2(S):0.2, F2SINH(S):0.8'
+
+    res1 = ct.Reservoir(gas)
+    res2 = ct.Reservoir(gas)
+
+    rsurf1 = ct.ReactorSurface(surf, res1, kind="ReactorSurface")
+    rsurf2 = ct.ReactorSurface(surf, res2, kind="MoleReactorSurface")
+
+    net1 = ct.ReactorNet([rsurf1])
+    net2 = ct.ReactorNet([rsurf2])
+
+    net1.advance(0.1)
+    net2.advance(0.1)
+
+    assert sum(rsurf1.coverages) == approx(1.0)
+    assert sum(rsurf1.phase.X) == approx(1.0)
+    assert sum(rsurf2.coverages) == approx(1.0)
+    assert sum(rsurf2.phase.X) == approx(1.0)
+    assert rsurf1.coverages == approx(rsurf2.coverages)
+    assert rsurf2.phase.X == approx(rsurf1.phase.X)
+
+
 class TestWellStirredReactorIgnition:
     """ Ignition (or not) of a well-stirred reactor """
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Use the correct equation for the evolution of surface species moles on `MoleReactorSurface` (as given [in the "science" documentation](https://cantera.org/3.2/reference/reactors/interactions.html#mole-based-reactors))
- Add a test showing equivalence with the coverage-based `ReactorSurface` and that this actually preserves the sum of coverages and sum of mole fractions constraints

**AI Statement (required)**

- **No generative AI was used.** This contribution was written entirely without AI assistance.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
