### PR TITLE
Support compilation for Pyodide

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -602,6 +602,40 @@ jobs:
             --delete --delete-excluded --filter='P .htaccess' \
             "${DOCS_OUTPUT_DIR}" ${RSYNC_USER}@${RSYNC_SERVER}:${RSYNC_DEST}
 
+  pyodide-wheel:
+    name: Build Pyodide wheel
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v6
+        name: Checkout the repository
+        with:
+          submodules: recursive
+          persist-credentials: false
+      - name: Set up Pixi
+        uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
+      - name: Build Pyodide wheel
+        run: |
+          pixi run -e pyodide scons pyodide-wheel
+      - name: Create Pyodide venv
+        run: |
+          pixi run -e pyodide pyodide venv .pyodide-venv
+      - name: Install wheel and dependencies into Pyodide venv
+        run: |
+          WHEEL=$(ls build/pyodide_dist/cantera-*.whl)
+          pixi run -e pyodide .pyodide-venv/bin/pip install pytest graphviz pandas \
+            pint "$WHEEL"
+      - name: Upload Pyodide wheel artifact
+        uses: actions/upload-artifact@v6
+        with:
+          path: build/pyodide_dist/cantera-*.whl
+          name: cantera-wheel-pyodide
+          if-no-files-found: error
+          retention-days: 14
+      - name: Run Python tests
+        run: |
+          pixi run -e pyodide .pyodide-venv/bin/python -m pytest -raP -v --durations=50 test/python
+
   run-examples:
     name: Run Python ${{ matrix.python-version }} examples on ${{ matrix.os }}, NumPy ${{ matrix.numpy || 'latest' }}
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -56,4 +56,5 @@ coverage.info
 .coverage
 # pixi environments
 .pixi/*
+pixi.lock
 !.pixi/config.toml

--- a/SConstruct
+++ b/SConstruct
@@ -40,6 +40,8 @@ Basic usage:
 
     'scons doxygen' - Build the Doxygen documentation
 
+    'scons pyodide-wheel' - Build Pyodide wheels from Python sdist packages.
+
 Additional command options:
 
     'scons help --options' - Print a description of user-specifiable options.
@@ -104,7 +106,7 @@ if os.name not in ["nt", "posix"]:
 
 valid_commands = ("build", "clean", "install", "uninstall",
                   "help", "msi", "samples", "sphinx", "doxygen", "dump",
-                  "sdist")
+                  "sdist", "pyodide-wheel")
 
 # set default logging level
 if GetOption("silent"):
@@ -185,19 +187,17 @@ cython_version_spec = SpecifierSet(">=3.0.8,!=3.1.2", prereleases=True)
 numpy_version_spec = SpecifierSet(">=1.26.4,<3", prereleases=True)
 ruamel_version_spec = SpecifierSet(">=0.17.21,<1", prereleases=True)
 
-if "sdist" in COMMAND_LINE_TARGETS:
-    if "clean" in COMMAND_LINE_TARGETS:
-        COMMAND_LINE_TARGETS.remove("clean")
-    if len(COMMAND_LINE_TARGETS) > 1:
-        logger.error("'sdist' target cannot be built simultaneously with other targets.")
-        sys.exit(1)
+python_sdist_dir = "/".join((os.getcwd(), "build", "python_sdist"))
+
+
+def _build_python_sdist() -> None:
     logger.info("Copying files for sdist...")
     subprocess.run(
         [
             sys.executable,
             "interfaces/python_sdist/build_sdist.py",
             os.getcwd(),
-            "/".join((os.getcwd(), "build", "python_sdist")),
+            python_sdist_dir,
             cantera_git_commit,
             py_requires_ver_str,
             cantera_version,
@@ -214,13 +214,45 @@ if "sdist" in COMMAND_LINE_TARGETS:
             "-m",
             "build",
             "--sdist",
-            "/".join((os.getcwd(), "build", "python_sdist")),
+            python_sdist_dir,
         ],
     )
     message = textwrap.dedent(f"""
         ****************************************************************
         Python sdist 'Cantera-{cantera_version}.tar.gz' created successfully.
         The sdist file is in the 'build/python_sdist/dist' directory.
+        ****************************************************************
+    """)
+    logger.info(message, print_level=False)
+
+
+if "sdist" in COMMAND_LINE_TARGETS:
+    if "clean" in COMMAND_LINE_TARGETS:
+        COMMAND_LINE_TARGETS.remove("clean")
+    if len(COMMAND_LINE_TARGETS) > 1:
+        logger.error("'sdist' target cannot be built simultaneously with other targets.")
+        sys.exit(1)
+    _build_python_sdist()
+    sys.exit(0)
+
+if "pyodide-wheel" in COMMAND_LINE_TARGETS:
+    if "clean" in COMMAND_LINE_TARGETS:
+        COMMAND_LINE_TARGETS.remove("clean")
+    if len(COMMAND_LINE_TARGETS) > 1:
+        logger.error("'pyodide-wheel' target cannot be built simultaneously with other targets.")
+        sys.exit(1)
+    _build_python_sdist()
+    subprocess.run(
+        [
+            sys.executable,
+            "interfaces/python_sdist/build_pyodide_wheel.py",
+        ],
+        check=True,
+    )
+    message = textwrap.dedent("""
+        ****************************************************************
+        Pyodide wheel(s) created successfully.
+        The wheel file(s) are in the 'build/pyodide_dist' directory.
         ****************************************************************
     """)
     logger.info(message, print_level=False)

--- a/doc/sphinx/develop/distribution-packages/pyodide-wheel.md
+++ b/doc/sphinx/develop/distribution-packages/pyodide-wheel.md
@@ -1,0 +1,98 @@
+# Building a Pyodide Wheel for Cantera
+
+Cantera can be built as a Pyodide-compatible wheel so the Python module can run in
+browser-based environments (for example, JupyterLite).
+
+This page documents the local and CI workflow used in this repository for generating and
+smoke-testing that wheel.
+
+## Overview
+
+The Pyodide build follows the same two-stage packaging model as the standard Python
+wheel flow:
+
+1. Build an sdist from the Cantera source tree using SCons.
+2. Build the wheel from that sdist using the Pyodide toolchain.
+
+The SCons entry point for this is:
+
+```sh
+scons pyodide-wheel
+```
+
+Output wheels are written to:
+
+```text
+build/pyodide_dist/
+```
+
+## Requirements
+
+The Pyodide build uses the dedicated `pyodide` Pixi environment in `pixi.toml`.
+At minimum, this environment needs:
+
+- Python 3.13
+- SCons
+- `pyodide-build`
+- `build`
+- `scikit-build-core`
+- CMake and Ninja
+- Boost headers (`boost-cpp`)
+- Cantera's Python build dependencies (`cython`, `numpy`, `ruamel.yaml`, `pip`)
+
+```{note}
+When using `pyodide venv`, the generated interpreter requires `node` to be available on
+`PATH`. This can be achieved by running Pyodide venv commands through Pixi as
+`pixi run -e pyodide ...` so the right runtime is present.
+```
+
+## Local Build
+
+From the repository root:
+
+```sh
+pixi run -e pyodide scons pyodide-wheel
+```
+
+This creates a wheel named something like:
+
+```text
+build/pyodide_dist/cantera-<version>-cp313-cp313-pyodide_<abi>_wasm32.whl
+```
+
+## Local Testing
+
+To test the Pyodide wheel locally, you can set up a Pyodide venv and install the wheel
+and run one of the Cantera examples:
+
+```sh
+pixi run -e pyodide pyodide venv .pyodide-venv
+WHEEL=$(ls build/pyodide_dist/cantera-*.whl)
+pixi run -e pyodide .pyodide-venv/bin/pip install "$WHEEL"
+pixi run -e pyodide .pyodide-venv/bin/python samples/python/thermo/rankine.py
+```
+
+To run other examples, you may need to install additional packages like Matplotlib
+and Pandas in this venv.
+
+## CI Job and Artifacts
+
+The `pyodide-wheel` CI job in `.github/workflows/main.yml` does the following:
+
+1. Builds the Pyodide wheel via `scons pyodide-wheel`.
+2. Creates a Pyodide virtual environment.
+3. Installs the built wheel.
+4. Uploads the wheel as a GitHub artifact (`cantera-wheel-pyodide`).
+5. Runs the Python unit test suite using Pyodide.
+
+## Common Pitfalls
+
+- **Wrong import target during testing**:
+  If `pytest` imports `build/python/cantera` instead of the wheel, clear path overrides
+  such as `PYTHONPATH` and verify `import cantera; print(cantera.__file__)`.
+- **`No node executable found on the path`**:
+  Run `.pyodide-venv/bin/python` through `pixi run -e pyodide ...` so the Node runtime
+  from that environment is available.
+- **JupyterLite `--piplite-wheels` path confusion**:
+  `--piplite-wheels` paths are resolved relative to `--lite-dir`, not the current
+  working directory.

--- a/doc/sphinx/develop/index.md
+++ b/doc/sphinx/develop/index.md
@@ -94,6 +94,7 @@ yaml-extensions
 
 - [](distribution-packages/release-checklist)
 - [](distribution-packages/pypi-sdist-wheel)
+- [](distribution-packages/pyodide-wheel)
 - [](distribution-packages/conda)
 - [](distribution-packages/ubuntu-ppa)
 - [](distribution-packages/windows-and-macos.md)
@@ -105,6 +106,7 @@ yaml-extensions
 
 distribution-packages/release-checklist
 distribution-packages/pypi-sdist-wheel
+distribution-packages/pyodide-wheel
 distribution-packages/conda
 distribution-packages/ubuntu-ppa
 distribution-packages/windows-and-macos

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -3,7 +3,7 @@
 
 from .interrupts import no_op
 import warnings
-from os import get_terminal_size as _get_terminal_size
+from shutil import get_terminal_size as _get_terminal_size
 import numpy as np
 cimport numpy as np
 

--- a/interfaces/cython/cantera/solutionbase.pyx
+++ b/interfaces/cython/cantera/solutionbase.pyx
@@ -4,7 +4,7 @@
 cimport numpy as np
 import numpy as np
 from pathlib import PurePath as _PurePath
-from os import get_terminal_size as _get_terminal_size
+from shutil import get_terminal_size as _get_terminal_size
 import warnings
 
 from .thermo cimport *

--- a/interfaces/python_sdist/CMakeLists.txt
+++ b/interfaces/python_sdist/CMakeLists.txt
@@ -6,6 +6,10 @@ project(${SKBUILD_PROJECT_NAME} LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
+option(
+  CANTERA_PYODIDE
+  "Build Cantera Python module with a feature set suitable for Pyodide/emscripten."
+  OFF)
 
 find_package(
   Python

--- a/interfaces/python_sdist/build_pyodide_wheel.py
+++ b/interfaces/python_sdist/build_pyodide_wheel.py
@@ -1,0 +1,70 @@
+"""Build a Pyodide-targeted wheel from an existing Cantera Python sdist."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import tarfile
+import tempfile
+
+
+def _find_latest_sdist(dist_dir: Path) -> Path:
+    candidates = sorted(
+        dist_dir.glob("cantera-*.tar.gz", case_sensitive=False),
+        key=lambda candidate: candidate.stat().st_mtime,
+        reverse=True,
+    )
+    if not candidates:
+        raise FileNotFoundError(f"No Cantera sdist found in '{dist_dir}'.")
+    return candidates[0]
+
+
+def _run(command: list[str], cwd: Path, env: dict[str, str] | None = None) -> None:
+    print(f"+ {' '.join(command)}")
+    subprocess.run(command, cwd=cwd, env=env, check=True)
+
+
+def _extract_sdist(sdist: Path) -> Path:
+    temp_root = Path(tempfile.mkdtemp(prefix="cantera-pyodide-src-"))
+    with tarfile.open(sdist, mode="r:gz") as archive:
+        archive.extractall(path=temp_root)
+    candidates = [path for path in temp_root.iterdir() if path.is_dir()]
+    if len(candidates) != 1:
+        raise RuntimeError(
+            f"Expected exactly one source directory in extracted sdist at '{temp_root}'."
+        )
+    return candidates[0]
+
+
+def main() -> int:
+    repo_root = Path(subprocess.getoutput("git rev-parse --show-toplevel").strip())
+    dist_dir = repo_root / "build" / "python_sdist" / "dist"
+    sdist = _find_latest_sdist(dist_dir)
+    if not sdist.is_file():
+        raise FileNotFoundError(f"Cantera sdist not found: '{sdist}'.")
+
+    outdir = repo_root / "build" / "pyodide_dist"
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    env = dict(os.environ)
+    env["CANTERA_PYODIDE"] = "ON"
+    cmake_args = env.get("CMAKE_ARGS", "").strip()
+    pyodide_cmake_args = "-DCMAKE_CXX_SCAN_FOR_MODULES=OFF"
+    env["CMAKE_ARGS"] = f"{cmake_args} {pyodide_cmake_args}".strip()
+    if "Boost_INCLUDE_DIRS" not in env and (conda_prefix := env.get("CONDA_PREFIX")):
+        boost_include = Path(conda_prefix) / "include"
+        if boost_include.is_dir():
+            env["Boost_INCLUDE_DIRS"] = str(boost_include)
+
+    print(f"Using sdist: {sdist}")
+    print(f"Output dir: {outdir}")
+    source_dir = _extract_sdist(sdist)
+    print(f"Extracted source: {source_dir}")
+    _run(["pyodide", "build", str(source_dir), "--outdir", str(outdir)],
+         cwd=repo_root, env=env)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/interfaces/python_sdist/build_sdist.py
+++ b/interfaces/python_sdist/build_sdist.py
@@ -52,8 +52,8 @@ def do_configure_substitution(
         "CT_USE_SYSTEM_FMT": "#define CT_USE_SYSTEM_FMT 1",
         "CT_USE_SYSTEM_YAMLCPP": "#define CT_USE_SYSTEM_YAMLCPP 1",
         "CT_SUNDIALS_USE_LAPACK": "#cmakedefine01 CT_SUNDIALS_USE_LAPACK",
-        "CT_USE_HDF5": "#define CT_USE_HDF5 1",
-        "CT_USE_SYSTEM_HIGHFIVE": "#define CT_USE_SYSTEM_HIGHFIVE 1",
+        "CT_USE_HDF5": "#cmakedefine01 CT_USE_HDF5",
+        "CT_USE_SYSTEM_HIGHFIVE": "#cmakedefine01 CT_USE_SYSTEM_HIGHFIVE",
     }
     configure_output = configure_template.format_map(configure_subst)
     return configure_output

--- a/interfaces/python_sdist/pyproject.toml.in
+++ b/interfaces/python_sdist/pyproject.toml.in
@@ -66,7 +66,7 @@ logging.level = "DEBUG"
 build.verbose = true
 
 [tool.scikit-build.cmake]
-version = ">=3.27"
+version = ">=3.27,<4"
 
 [tool.scikit-build.ninja]
 version = ">=1.13"
@@ -74,6 +74,7 @@ make-fallback = false
 
 [tool.scikit-build.cmake.define]
 CMAKE_POSITION_INDEPENDENT_CODE = "ON"
+CANTERA_PYODIDE = { env = "CANTERA_PYODIDE", default = "OFF" }
 Boost_INCLUDE_DIRS = { env = "Boost_INCLUDE_DIRS" }
 HDF5_ROOT = { env = "HDF5_ROOT" }
 

--- a/interfaces/python_sdist/src/CMakeLists.txt
+++ b/interfaces/python_sdist/src/CMakeLists.txt
@@ -1,5 +1,15 @@
 include(FetchContent)
 
+if(CANTERA_PYODIDE)
+  set(CANTERA_ENABLE_LAPACK OFF)
+  set(CT_USE_HDF5 0)
+  set(CT_USE_SYSTEM_HIGHFIVE 0)
+else()
+  set(CANTERA_ENABLE_LAPACK ON)
+  set(CT_USE_HDF5 1)
+  set(CT_USE_SYSTEM_HIGHFIVE 1)
+endif()
+
 set(EIGEN_VERSION 3.4.0)
 FetchContent_Declare(
   eigen
@@ -40,15 +50,17 @@ FetchContent_Declare(
   FIND_PACKAGE_ARGS NAMES fmt GLOBAL
 )
 
-set(HIGHFIVE_VERSION .3.1.1)
-FetchContent_Declare(
-  HighFive
-  URL https://github.com/highfive-devs/HighFive/archive/refs/tags/v${HIGHFIVE_VERSION}.tar.gz
-  URL_HASH SHA256=c0bc76b01868a133bf4550a07321923c5582fe3967edc102864b082e40799914
-  # FIND_PACKAGE_ARGS has to be the last thing in this call because it greedily takes
-  # everything after it to pass to `find_package()`
-  FIND_PACKAGE_ARGS NAMES HighFive
-)
+if(CT_USE_HDF5)
+  set(HIGHFIVE_VERSION .3.1.1)
+  FetchContent_Declare(
+    HighFive
+    URL https://github.com/highfive-devs/HighFive/archive/refs/tags/v${HIGHFIVE_VERSION}.tar.gz
+    URL_HASH SHA256=c0bc76b01868a133bf4550a07321923c5582fe3967edc102864b082e40799914
+    # FIND_PACKAGE_ARGS has to be the last thing in this call because it greedily takes
+    # everything after it to pass to `find_package()`
+    FIND_PACKAGE_ARGS NAMES HighFive
+  )
+endif()
 
 if(NOT DEFINED Boost_INCLUDE_DIRS)
   find_package(Boost 1.70 CONFIG REQUIRED)
@@ -80,14 +92,16 @@ set(BUILD_IDA OFF)
 set(BUILD_KINSOL OFF)
 set(BUILD_CPODES OFF)
 set(BUILD_FORTRAN_MODULE_INTERFACE OFF)
-if ("${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
+if(CANTERA_ENABLE_LAPACK AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Darwin")
     set(ENABLE_LAPACK ON)
     set(BLA_VENDOR Apple)
     set(SUNDIALS_LAPACK_CASE "LOWER")
     set(SUNDIALS_LAPACK_UNDERSCORES "NONE")
-elseif ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
+elseif(CANTERA_ENABLE_LAPACK AND "${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     set(ENABLE_LAPACK ON)
     set(BLA_VENDOR OpenBLAS)
+else()
+    set(ENABLE_LAPACK OFF)
 endif()
 
 # fmt build options
@@ -103,7 +117,11 @@ set(EIGEN_BUILD_DOC OFF)
 set(YAML_CPP_FORMAT_SOURCE OFF)
 set(YAML_CPP_INSTALL OFF)
 
-FetchContent_MakeAvailable(eigen yaml-cpp sundials fmt HighFive)
+set(CT_FETCHCONTENT_TARGETS eigen yaml-cpp sundials fmt)
+if(CT_USE_HDF5)
+  list(APPEND CT_FETCHCONTENT_TARGETS HighFive)
+endif()
+FetchContent_MakeAvailable(${CT_FETCHCONTENT_TARGETS})
 
 file(GLOB_RECURSE CT_LIB_SOURCES "*.cpp")
 # The Python extension handler is built with the rest of the Python library because it
@@ -111,7 +129,7 @@ file(GLOB_RECURSE CT_LIB_SOURCES "*.cpp")
 list(FILTER CT_LIB_SOURCES EXCLUDE REGEX "extensions/.*")
 list(APPEND CT_LIB_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/extensions/canteraShared.cpp" "${CMAKE_CURRENT_SOURCE_DIR}/extensions/pythonShim.cpp")
 
-if (NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
+if(CANTERA_ENABLE_LAPACK AND NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Windows")
     find_package(LAPACK REQUIRED)
     find_package(BLAS REQUIRED)
     set(CT_USE_LAPACK 1)
@@ -133,7 +151,6 @@ target_link_libraries(cantera_lib PUBLIC
     yaml-cpp::yaml-cpp
     fmt::fmt
     Eigen3::Eigen
-    HighFive
     SUNDIALS::core
     SUNDIALS::nvecserial
     SUNDIALS::cvodes
@@ -145,3 +162,7 @@ target_link_libraries(cantera_lib PUBLIC
     SUNDIALS::sunnonlinsolnewton
     ${SUNDIALS_LIBRARIES}
 )
+
+if(CT_USE_HDF5)
+  target_link_libraries(cantera_lib PUBLIC HighFive)
+endif()

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,0 +1,94 @@
+[workspace]
+channels = ["conda-forge"]
+name = "cantera"
+platforms = ["linux-64", "linux-aarch64", "osx-64", "osx-arm64", "win-64"]
+version = "0.1.0"
+
+[tasks]
+build = "scons build"
+test = "scons test"
+
+[dependencies]
+python = "3.14.*"
+scons = ">=4.10.1,<5"
+boost-cpp = ">=1.85.0,<2"
+hdf5 = ">=1.14.6,<2"
+highfive = ">=3.2.0,<4"
+sundials = ">=7.6.0,<8"
+fmt = ">=12.1.0,<13"
+yaml-cpp = ">=0.8.0,<0.9"
+cython = ">=3.2.4,<4"
+numpy = ">=2.4.2,<3"
+pip = ">=26.0.1,<27"
+wheel = ">=0.46.3,<0.47"
+setuptools = ">=82.0.0,<83"
+typing-extensions = ">=4.15.0,<5"
+pytest = ">=9.0.2,<10"
+"ruamel.yaml" = ">=0.19.1,<0.20"
+jinja2 = ">=3.1.6,<4"
+pandas = ">=3.0.0,<4"
+scipy = ">=1.17.0,<2"
+matplotlib = ">=3.10.8,<4"
+python-graphviz = ">=0.21,<0.22"
+pint = ">=0.25.2,<0.26"
+
+[feature.devtools.dependencies]
+ipython = ">=9.10.0,<10"
+pyarrow = ">=23.0.1,<24"
+tqdm = ">=4.67.3,<5"
+go = ">=1.26.0,<2"
+mypy = ">=1.19.1,<2"
+pandas-stubs = ">=3.0.0.260204,<4"
+
+[feature.devtools.target.linux-64.dependencies]
+gperftools = ">=2.17.2,<3"
+
+[feature.devtools.target.osx-64.dependencies]
+gperftools = ">=2.17.2,<3"
+
+[feature.devtools.target.osx-arm64.dependencies]
+gperftools = ">=2.17.2,<3"
+
+[feature.docs.dependencies]
+doxygen = ">=1.13.2,<2"
+perl = ">=5.32.1,<5.33"
+sphinx = ">=9.1.0,<10"
+pydata-sphinx-theme = ">=0.16.1,<0.17"
+myst-nb = ">=1.3.0,<2"
+myst-parser = ">=5.0.0,<6"
+sphinx-gallery = ">=0.20.0,<0.21"
+sphinx-argparse = ">=0.5.2,<0.6"
+sphinx-copybutton = ">=0.5.2,<0.6"
+sphinx-design = ">=0.7.0,<0.8"
+sphinxcontrib-bibtex = ">=2.6.5,<3"
+sphinxcontrib-matlabdomain = ">=0.22.1,<0.23"
+sphinxcontrib-doxylink = ">=1.13.0,<2"
+graphviz = ">=14.1.2,<15"
+
+[feature.docs.pypi-dependencies]
+sphinx-tags = { git = "https://github.com/Cantera/sphinx-tags.git", rev = "main" }
+
+[feature.pyodide.dependencies]
+python = "3.13.*"
+scons = ">=4.10.1,<5"
+boost-cpp = ">=1.85.0,<2"
+cython = ">=3.2.4,<4"
+numpy = ">=2.4.2,<3"
+"ruamel.yaml" = ">=0.19.1,<0.20"
+pip = ">=26.0.1,<27"
+cmake = ">=3.27,<4"
+ninja = ">=1.13.2,<2"
+nodejs = ">=25.2.1,<25.8"
+
+[feature.pyodide.pypi-dependencies]
+build = ">=1.2.2.post1, <2"
+scikit-build-core = ">=0.12.1, <0.13"
+pyodide-build = ">=0.33.0, <0.34"
+
+[environments]
+pyodide = { features = ["pyodide"], no-default-feature = true }
+docs = { features = ["docs"], no-default-feature = false }
+devtools = { features = ["devtools"], no-default-feature = false }
+
+[feature.docs.tasks]
+docs = "scons sphinx doxygen"

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -2,7 +2,6 @@ import numpy as np
 import pytest
 from pytest import approx
 import re
-pd = pytest.importorskip("pandas")
 
 import cantera as ct
 
@@ -399,8 +398,8 @@ class TestFreeFlame:
         # restart from HDF format
         self.run_restart("h5")
 
-    @pytest.mark.skipif(not pd, reason="Pandas not installed")
     def test_restart_pandas(self):
+        pd = pytest.importorskip("pandas")
         # restart from Pandas DataFrame
         self.run_restart("pandas", auto=True)
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Enable sdist compilation targeting Pyodide 
- Add Pixi config file with separate features to compartmentalize requirements for documentation and Pyodide builds
- Add CI job to build Pyodide wheel and run the Python test suite

**If applicable, fill in the issue number this pull request is fixing**

This is somewhat related to Cantera/enhancements#254, but not aimed at completing that Enhancement. What this does do is show that there are essentially no issues with compiling Cantera and its dependencies as a WASM library.

**If applicable, provide an example illustrating new features this pull request is introducing**

The wheels targeting Pyodide allow you to run Cantera in your browser. With a few additional steps (manual for the moment), you can set up a Jupyterlite site with the Cantera module and examples available, for example: https://cantera.org/~speth/live-demo/

**AI Statement (required)**

- **Extensive use of generative AI.**
  Significant portions of code or documentation were generated with AI, including logic and implementation decisions. All generated code and documentation were reviewed and understood by the contributor. *ChatGPT Codex 5.3 was used extensively in preparing this PR*.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
