### PR TITLE
Return variable-length coefficient list from falloff rates

### DIFF
--- a/doc/sphinx/yaml/reactions.md
+++ b/doc/sphinx/yaml/reactions.md
@@ -379,7 +379,7 @@ Includes field for specifying {ref}`efficiencies <sec-yaml-efficiencies>` as wel
 
 `Tsang`
 : Parameters for the [Tsang](sec-tsang-falloff) falloff function. A mapping containing
-  the keys `A` and `B`. The default value for `B` is 0.0.
+  the keys `A` and optionally `B`. The default value for `B` is 0.0.
 
 Examples:
 

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -541,7 +541,7 @@ public:
     }
 
     size_t nParameters() const override {
-        return 2;
+        return (m_b == 0.0) ? 1 : 2;
     }
 
     void setParameters(const AnyMap& node, const UnitStack& rate_units) override;

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -347,7 +347,7 @@ public:
     }
 
     size_t nParameters() const override {
-        return 4;
+        return (m_t2 == 0) ? 3 : 4;
     }
 
     void setParameters(const AnyMap& node, const UnitStack& rate_units) override;
@@ -448,7 +448,7 @@ public:
     }
 
     size_t nParameters() const override {
-        return 5;
+        return (m_d == 1.0 && m_e == 0.0) ? 3 : 5;
     }
 
     void setParameters(const AnyMap& node, const UnitStack& rate_units) override;
@@ -467,7 +467,7 @@ protected:
     //! parameter d in the 5-parameter SRI falloff function. Dimensionless.
     double m_d;
 
-    //! parameter d in the 5-parameter SRI falloff function. Dimensionless.
+    //! parameter e in the 5-parameter SRI falloff function. Dimensionless.
     double m_e;
 };
 

--- a/src/kinetics/Falloff.cpp
+++ b/src/kinetics/Falloff.cpp
@@ -462,8 +462,7 @@ void TsangRate::setFalloffCoeffs(span<const double> c)
 
     if (c.size() == 2) {
         m_b = c[1];
-    }
-    else {
+    } else {
         m_b = 0.0;
     }
     m_valid = true;
@@ -473,7 +472,9 @@ void TsangRate::getFalloffCoeffs(span<double> c) const
 {
     checkArraySize("TsangRate::getFalloffCoeffs", c.size(), nParameters());
     c[0] = m_a;
-    c[1] = m_b;
+    if (c.size() >= 2) {
+        c[1] = m_b;
+    }
 }
 
 void TsangRate::updateTemp(double T, span<double> work) const
@@ -505,7 +506,7 @@ void TsangRate::setParameters(const AnyMap& node, const UnitStack& rate_units)
     }
     vector<double> params{
         f["A"].asDouble(),
-        f["B"].asDouble()
+        f.getDouble("B", 0.0)
     };
     setFalloffCoeffs(params);
 }
@@ -520,7 +521,9 @@ void TsangRate::getParameters(AnyMap& node) const
     } else {
         // Parameters do not have unit system (yet)
         params["A"] = m_a;
-        params["B"] = m_b;
+        if (m_b != 0.0) {
+            params["B"] = m_b;
+        }
     }
     params.setFlowStyle();
     node["Tsang"] = std::move(params);

--- a/src/kinetics/Falloff.cpp
+++ b/src/kinetics/Falloff.cpp
@@ -275,7 +275,9 @@ void TroeRate::getFalloffCoeffs(span<double> c) const
     c[0] = m_a;
     c[1] = 1.0 / m_rt3;
     c[2] = 1.0 / m_rt1;
-    c[3] = m_t2;
+    if (c.size() >= 4) {
+        c[3] = m_t2;
+    }
 }
 
 void TroeRate::updateTemp(double T, span<double> work) const
@@ -378,8 +380,10 @@ void SriRate::getFalloffCoeffs(span<double> c) const
     c[0] = m_a;
     c[1] = m_b;
     c[2] = m_c;
-    c[3] = m_d;
-    c[4] = m_e;
+    if (c.size() >= 5) {
+        c[3] = m_d;
+        c[4] = m_e;
+    }
 }
 
 void SriRate::updateTemp(double T, span<double> work) const

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -336,12 +336,17 @@ TEST(Reaction, FalloffFromYaml2)
     EXPECT_DOUBLE_EQ(rate->lowRate().preExponentialFactor(), 1.04e20);
     EXPECT_DOUBLE_EQ(rate->lowRate().activationEnergy(), 1600);
     vector<double> params(rate->nParameters());
-    ASSERT_EQ(params.size(), (size_t) 4);
+    ASSERT_EQ(params.size(), 3U);
     rate->getFalloffCoeffs(params);
     EXPECT_DOUBLE_EQ(params[0], 0.562);
     EXPECT_DOUBLE_EQ(params[1], 91.0);
     EXPECT_DOUBLE_EQ(params[2], 5836.0);
+
+    params.resize(4);
+    params[3] = 1234.0;
+    rate->getFalloffCoeffs(params);
     EXPECT_DOUBLE_EQ(params[3], 0.0);
+
     EXPECT_EQ(R->input["source"].asString(), "somewhere");
 }
 
@@ -402,6 +407,29 @@ TEST(Reaction, FalloffFromYaml5)
     auto R = newReaction(rxn, *(sol->kinetics()));
     EXPECT_TRUE(R->usesThirdBody());
     EXPECT_EQ(R->type(), "falloff-Lindemann");
+}
+
+TEST(Reaction, FalloffFromYaml6)
+{
+    auto sol = newSolution("gri30.yaml", "", "none");
+    AnyMap rxn = AnyMap::fromYamlString(
+        "{equation: N2O (+M) = N2 + O (+ M),"
+        " type: falloff,"
+        " high-P-rate-constant: [7.91000E+10, 0, 56020],"
+        " low-P-rate-constant: [6.37000E+14, 0, 56640],"
+        " SRI: {A: 1.1, B: 700.0, C: 1234.0},"
+        " efficiencies: {AR: 0.625}}");
+
+    auto R = newReaction(rxn, *(sol->kinetics()));
+    const auto& rate = std::dynamic_pointer_cast<SriRate>(R->rate());
+    ASSERT_EQ(rate->nParameters(), 3U);
+    vector<double> params(rate->nParameters());
+    rate->getFalloffCoeffs(params);
+    EXPECT_DOUBLE_EQ(params[0], 1.1);
+    params.resize(5);
+    rate->getFalloffCoeffs(params);
+    EXPECT_DOUBLE_EQ(params[3], 1.0);
+    EXPECT_DOUBLE_EQ(params[4], 0.0);
 }
 
 TEST(Reaction, ChemicallyActivatedFromYaml)

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -432,6 +432,28 @@ TEST(Reaction, FalloffFromYaml6)
     EXPECT_DOUBLE_EQ(params[4], 0.0);
 }
 
+TEST(Reaction, FalloffFromYaml7)
+{
+    auto sol = newSolution("gri30.yaml", "", "none");
+    AnyMap rxn = AnyMap::fromYamlString(
+        "{equation: HCN (+ M) <=> H + CN (+ M),"
+        " type: falloff,"
+        " low-P-rate-constant: {A: 3.57e+26, b: -2.6, Ea: 1.249e+05},"
+        " high-P-rate-constant: {A: 8.3e+17, b: -0.93, Ea: 1.238e+05},"
+        " Tsang: {A: 0.95}}");
+
+    auto R = newReaction(rxn, *(sol->kinetics()));
+    ASSERT_EQ(R->type(), "falloff-Tsang");
+    const auto rate = std::dynamic_pointer_cast<TsangRate>(R->rate());
+    vector<double> params(1);
+    rate->getFalloffCoeffs(params);
+    EXPECT_DOUBLE_EQ(params[0], 0.95);
+    params.resize(2);
+    params[1] = 1234.0;
+    rate->getFalloffCoeffs(params);
+    EXPECT_DOUBLE_EQ(params[1], 0.0);
+}
+
 TEST(Reaction, ChemicallyActivatedFromYaml)
 {
     auto sol = newSolution("gri30.yaml", "", "none");

--- a/test/python/test_reaction.py
+++ b/test/python/test_reaction.py
@@ -559,7 +559,10 @@ class TestTroeRate(FalloffRateTests):
             """
 
         with pytest.warns(UserWarning, match="Unexpected parameter value T2=0"):
-            ct.ReactionRate.from_yaml(yaml)
+            rate = ct.ReactionRate.from_yaml(yaml)
+
+        assert len(rate.falloff_coeffs) == 3
+
 
 class TestSriRate(FalloffRateTests):
     """Test SRI rate expressions"""


### PR DESCRIPTION
This restores the behavior from before 3377c037 / #2085 and eliminates a warning about zero values for the Troe "T2" coefficient that were being issued by some tests.

**AI Statement (required)**

- **No generative AI was used.** This contribution was written entirely without AI assistance.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
