### PR TITLE
Vectorize Redlich-Kwong property calculations

### DIFF
--- a/include/cantera/numerics/eigen_dense.h
+++ b/include/cantera/numerics/eigen_dense.h
@@ -56,6 +56,29 @@ inline span<const double> asSpan(const Eigen::DenseBase<Derived>& v)
     return span<const double>(v.derived().data(), v.size());
 }
 
+//! Convenience wrapper for accessing std::vector as an Eigen VectorXd
+inline MappedVector asVectorXd(vector<double>& v)
+{
+    return MappedVector(v.data(), static_cast<Eigen::Index>(v.size()));
 }
 
+//! Convenience wrapper for accessing std::vector as an Eigen VectorXd
+inline ConstMappedVector asVectorXd(const vector<double>& v)
+{
+    return ConstMappedVector(v.data(), static_cast<Eigen::Index>(v.size()));
+}
+
+//! Convenience wrapper for accessing std::span as an Eigen VectorXd
+inline MappedVector asVectorXd(span<double> v)
+{
+    return MappedVector(v.data(), static_cast<Eigen::Index>(v.size()));
+}
+
+//! Convenience wrapper for accessing std::span as an Eigen VectorXd
+inline ConstMappedVector asVectorXd(span<const double> v)
+{
+    return ConstMappedVector(v.data(), static_cast<Eigen::Index>(v.size()));
+}
+
+}
 #endif

--- a/include/cantera/thermo/RedlichKwongMFTP.h
+++ b/include/cantera/thermo/RedlichKwongMFTP.h
@@ -439,13 +439,14 @@ protected:
 
     double Vroot_[3] = {0.0, 0.0, 0.0};
 
-    //! Temporary storage - length = m_kk.
-    mutable Eigen::VectorXd m_pp;
+    //! @f$ A_k = \sum_i X_i a_{ki} @f$. Length #m_kk.
+    mutable Eigen::VectorXd m_Ak;
 
     // Partial molar volumes of the species
     mutable vector<double> m_partialMolarVolumes;
 
-    mutable Eigen::VectorXd m_dAkdT; //!< Temporary storage for dA_k/dT; length #m_kk.
+    //! @f$ A'_k = dA_k/dT = \sum_i X_i a_{ki,1} @f$. Length #m_kk.
+    mutable Eigen::VectorXd m_dAkdT;
 
     //! The derivative of the pressure wrt the volume
     /*!

--- a/include/cantera/thermo/RedlichKwongMFTP.h
+++ b/include/cantera/thermo/RedlichKwongMFTP.h
@@ -7,7 +7,7 @@
 #define CT_REDLICHKWONGMFTP_H
 
 #include "MixtureFugacityTP.h"
-#include "cantera/base/Array.h"
+#include "cantera/numerics/eigen_dense.h"
 
 namespace Cantera
 {
@@ -413,10 +413,11 @@ protected:
      */
     double m_a_current = 0.0;
 
-    vector<double> a_vec_Curr_;
-    vector<double> b_vec_Curr_;
+    Eigen::MatrixXd a_vec_Curr_;
+    Eigen::VectorXd b_vec_Curr_;
 
-    Array2D a_coeff_vec;
+    Eigen::MatrixXd m_a_coeff_0;
+    Eigen::MatrixXd m_a_coeff_1;
 
     //! Explicitly-specified binary interaction parameters
     map<string, map<string, pair<double, double>>> m_binaryParameters;
@@ -430,12 +431,12 @@ protected:
     double Vroot_[3] = {0.0, 0.0, 0.0};
 
     //! Temporary storage - length = m_kk.
-    mutable vector<double> m_pp;
+    mutable Eigen::VectorXd m_pp;
 
     // Partial molar volumes of the species
     mutable vector<double> m_partialMolarVolumes;
 
-    mutable vector<double> m_dAkdT; //!< Temporary storage for dA_k/dT; length #m_kk.
+    mutable Eigen::VectorXd m_dAkdT; //!< Temporary storage for dA_k/dT; length #m_kk.
 
     //! The derivative of the pressure wrt the volume
     /*!
@@ -456,7 +457,7 @@ protected:
      *  Calculated at the current conditions. Total volume, temperature and
      *  other mole number kept constant
      */
-    mutable vector<double> dpdni_;
+    mutable Eigen::VectorXd m_dpdni;
 
 private:
     //! Omega constant for a -> value of a in terms of critical properties

--- a/include/cantera/thermo/RedlichKwongMFTP.h
+++ b/include/cantera/thermo/RedlichKwongMFTP.h
@@ -403,21 +403,30 @@ protected:
 
     //! Value of b in the equation of state
     /*!
-     *  m_b is a function of the temperature and the mole fraction.
+     *  `m_bMix` is a function of the temperature and the mole fraction.
      */
-    double m_b_current = 0.0;
+    double m_bMix = 0.0;
 
     //! Value of a in the equation of state
     /*!
-     *  a_b is a function of the temperature and the mole fraction.
+     *  `m_aMix` is a function of the temperature and the mole fraction.
      */
-    double m_a_current = 0.0;
+    double m_aMix = 0.0;
 
-    Eigen::MatrixXd a_vec_Curr_;
-    Eigen::VectorXd b_vec_Curr_;
+    //! Current temperature-dependent value of @f$ a_{jk} @f$ for each species pair.
+    //! Size #m_kk by #m_kk.
+    Eigen::MatrixXd m_a;
 
-    Eigen::MatrixXd m_a_coeff_0;
-    Eigen::MatrixXd m_a_coeff_1;
+    //! Coefficients @f$ b_k @f$ for each species. Size #m_kk.
+    Eigen::VectorXd m_b;
+
+    //! Constant term in the expression for @f$ a_{jk} @f$ for each species pair.
+    //! Size #m_kk by #m_kk.
+    Eigen::MatrixXd m_a0;
+
+    //! Temperature coefficient in the expression for @f$ a_{jk} @f$.
+    //! Size #m_kk by #m_kk.
+    Eigen::MatrixXd m_a1;
 
     //! Explicitly-specified binary interaction parameters
     map<string, map<string, pair<double, double>>> m_binaryParameters;

--- a/include/cantera/thermo/RedlichKwongMFTP.h
+++ b/include/cantera/thermo/RedlichKwongMFTP.h
@@ -418,7 +418,7 @@ protected:
     Eigen::MatrixXd m_a;
 
     //! Coefficients @f$ b_k @f$ for each species. Size #m_kk.
-    Eigen::VectorXd m_b;
+    Eigen::ArrayXd m_b;
 
     //! Constant term in the expression for @f$ a_{jk} @f$ for each species pair.
     //! Size #m_kk by #m_kk.
@@ -440,13 +440,13 @@ protected:
     double Vroot_[3] = {0.0, 0.0, 0.0};
 
     //! @f$ A_k = \sum_i X_i a_{ki} @f$. Length #m_kk.
-    mutable Eigen::VectorXd m_Ak;
+    mutable Eigen::ArrayXd m_Ak;
 
     // Partial molar volumes of the species
     mutable vector<double> m_partialMolarVolumes;
 
     //! @f$ A'_k = dA_k/dT = \sum_i X_i a_{ki,1} @f$. Length #m_kk.
-    mutable Eigen::VectorXd m_dAkdT;
+    mutable Eigen::ArrayXd m_dAkdT;
 
     //! The derivative of the pressure wrt the volume
     /*!
@@ -467,7 +467,7 @@ protected:
      *  Calculated at the current conditions. Total volume, temperature and
      *  other mole number kept constant
      */
-    mutable Eigen::VectorXd m_dpdni;
+    mutable Eigen::ArrayXd m_dpdni;
 
 private:
     //! Omega constant for a -> value of a in terms of critical properties

--- a/include/cantera/thermo/RedlichKwongMFTP.h
+++ b/include/cantera/thermo/RedlichKwongMFTP.h
@@ -350,9 +350,9 @@ protected:
     double hresid() const override;
 
 public:
-    double liquidVolEst(double TKelvin, double& pres) const override;
+    double liquidVolEst(double T, double& pres) const override;
     double densityCalc(double T, double pressure, int phase, double rhoguess) override;
-    double dpdVCalc(double TKelvin, double molarVol, double& presCalc) const override;
+    double dpdVCalc(double T, double molarVol, double& presCalc) const override;
 
     double isothermalCompressibility() const override;
     double thermalExpansionCoeff() const override;
@@ -378,11 +378,11 @@ public:
      * This function doesn't change the internal state of the object, so it is a
      * const function.  It does use the stored mole fractions in the object.
      *
-     * @param temp  Temperature (TKelvin)
+     * @param T  Temperature
      * @param aCalc (output)  Returns the a value
      * @param bCalc (output)  Returns the b value.
      */
-    void calculateAB(double temp, double& aCalc, double& bCalc) const;
+    void calculateAB(double T, double& aCalc, double& bCalc) const;
 
     // Special functions not inherited from MixtureFugacityTP
 

--- a/src/thermo/EEDFTwoTermApproximation.cpp
+++ b/src/thermo/EEDFTwoTermApproximation.cpp
@@ -407,9 +407,7 @@ double EEDFTwoTermApproximation::electronMobility(const Eigen::VectorXd& f0)
         }
     }
     double nDensity = m_phase->molarDensity() * Avogadro;
-    auto f = ConstMappedVector(y.data(), y.size());
-    auto x = ConstMappedVector(m_gridEdge.data(), m_gridEdge.size());
-    return -1./3. * m_gamma * simpson(f, x) / nDensity;
+    return -1./3. * m_gamma * simpson(asVectorXd(y), asVectorXd(m_gridEdge)) / nDensity;
 }
 
 void EEDFTwoTermApproximation::initSpeciesIndexCrossSections()

--- a/src/thermo/PlasmaPhase.cpp
+++ b/src/thermo/PlasmaPhase.cpp
@@ -36,7 +36,7 @@ PlasmaPhase::PlasmaPhase(const string& inputFile, const string& id_)
     size_t nGridCells = 301;
     m_nPoints = nGridCells + 1;
     m_eedfSolver->setLinearGrid(kTe_max, nGridCells);
-    m_electronEnergyLevels = MappedVector(m_eedfSolver->getGridEdge().data(), m_nPoints);
+    m_electronEnergyLevels = asVectorXd(m_eedfSolver->getGridEdge());
     m_electronEnergyDist.setZero(m_nPoints);
 }
 
@@ -179,12 +179,10 @@ void PlasmaPhase::electronEnergyLevelChanged()
     m_levelNum++;
     // Cross sections are interpolated on the energy levels
     if (m_collisions.size() > 0) {
-        vector<double> energyLevels(m_nPoints);
-        MappedVector(energyLevels.data(), m_nPoints) = m_electronEnergyLevels;
         for (shared_ptr<Reaction> collision : m_collisions) {
             const auto& rate = boost::polymorphic_pointer_downcast
                 <ElectronCollisionPlasmaRate>(collision->rate());
-            rate->updateInterpolatedCrossSection(energyLevels);
+            rate->updateInterpolatedCrossSection(asSpan(m_electronEnergyLevels));
         }
     }
 }
@@ -222,10 +220,8 @@ void PlasmaPhase::setDiscretizedElectronEnergyDist(span<const double> levels,
 {
     m_distributionType = "discretized";
     m_nPoints = levels.size();
-    m_electronEnergyLevels =
-        Eigen::Map<const Eigen::ArrayXd>(levels.data(), m_nPoints);
-    m_electronEnergyDist =
-        Eigen::Map<const Eigen::ArrayXd>(dist.data(), m_nPoints);
+    m_electronEnergyLevels = asVectorXd(levels);
+    m_electronEnergyDist = asVectorXd(dist);
     checkElectronEnergyLevels();
     if (m_do_normalizeElectronEnergyDist) {
         normalizeElectronEnergyDistribution();

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -33,8 +33,8 @@ void RedlichKwongMFTP::setSpeciesCoeffs(const string& species,
         m_formTempParam = 1; // expression is temperature-dependent
     }
 
-    m_a_coeff_0(k, k) = a0;
-    m_a_coeff_1(k, k) = a1;
+    m_a0(k, k) = a0;
+    m_a1(k, k) = a1;
 
     // standard mixing rule for cross-species interaction term
     for (size_t j = 0; j < m_kk; j++) {
@@ -42,23 +42,19 @@ void RedlichKwongMFTP::setSpeciesCoeffs(const string& species,
             continue;
         }
 
-        // m_a_coeff_0 is initialized to NaN to mark uninitialized species
-        if (isnan(m_a_coeff_0(j, j))) {
+        // m_a0 is initialized to NaN to mark uninitialized species
+        if (isnan(m_a0(j, j))) {
             // The diagonal element of the jth species has not yet been defined.
             continue;
-        } else if (isnan(m_a_coeff_0(j, k))) {
+        } else if (isnan(m_a0(j, k))) {
             // Only use the mixing rules if the off-diagonal element has not already been defined by a
             // user-specified crossFluidParameters entry:
-            double a0kj = sqrt(m_a_coeff_0(j, j) * a0);
-            double a1kj = sqrt(m_a_coeff_1(j, j) * a1);
-            m_a_coeff_0(j, k) = a0kj;
-            m_a_coeff_1(j, k) = a1kj;
-            m_a_coeff_0(k, j) = a0kj;
-            m_a_coeff_1(k, j) = a1kj;
+            m_a0(j, k) = m_a0(k, j) = sqrt(m_a0(j, j) * a0);
+            m_a1(j, k) = m_a1(k, j) = sqrt(m_a1(j, j) * a1);
         }
     }
-    a_vec_Curr_ = m_a_coeff_0;
-    b_vec_Curr_[k] = b;
+    m_a = m_a0;
+    m_b[k] = b;
 }
 
 void RedlichKwongMFTP::setBinaryCoeffs(const string& species_i, const string& species_j,
@@ -73,9 +69,9 @@ void RedlichKwongMFTP::setBinaryCoeffs(const string& species_i, const string& sp
 
     m_binaryParameters[species_i][species_j] = {a0, a1};
     m_binaryParameters[species_j][species_i] = {a0, a1};
-    m_a_coeff_0(ki, kj) = m_a_coeff_0(kj, ki) = a0;
-    m_a_coeff_1(ki, kj) = m_a_coeff_1(kj, ki) = a1;
-    a_vec_Curr_(ki, kj) = a_vec_Curr_(kj, ki) = a0;
+    m_a0(ki, kj) = m_a0(kj, ki) = a0;
+    m_a1(ki, kj) = m_a1(kj, ki) = a1;
+    m_a(ki, kj) = m_a(kj, ki) = a0;
 }
 
 // ------------Molar Thermodynamic Properties -------------------------
@@ -84,18 +80,18 @@ double RedlichKwongMFTP::cp_mole() const
 {
     _updateReferenceStateThermo();
     double cpref = GasConstant * mean_X(m_cp0_R);
-    if (m_b_current == 0.0) {
+    if (m_bMix == 0.0) {
         return cpref;
     }
     double TKelvin = temperature();
     double sqt = sqrt(TKelvin);
     double mv = molarVolume();
-    double vpb = mv + m_b_current;
+    double vpb = mv + m_bMix;
     pressureDerivatives();
     double dadt = da_dt();
-    double fac = TKelvin * dadt - 3.0 * m_a_current / 2.0;
-    double dHdT_V = (cpref + mv * dpdT_ - GasConstant - 1.0 / (2.0 * m_b_current * TKelvin * sqt) * log(vpb/mv) * fac
-                         +1.0/(m_b_current * sqt) * log(vpb/mv) * (-0.5 * dadt));
+    double fac = TKelvin * dadt - 3.0 * m_aMix / 2.0;
+    double dHdT_V = (cpref + mv * dpdT_ - GasConstant - 1.0 / (2.0 * m_bMix * TKelvin * sqt) * log(vpb/mv) * fac
+                         +1.0/(m_bMix * sqt) * log(vpb/mv) * (-0.5 * dadt));
     return dHdT_V - (mv + TKelvin * dpdT_ / dpdV_) * dpdT_;
 }
 
@@ -103,17 +99,17 @@ double RedlichKwongMFTP::cv_mole() const
 {
     _updateReferenceStateThermo();
     double cvref = GasConstant * (mean_X(m_cp0_R) - 1.0);
-    if (m_b_current == 0.0) {
+    if (m_bMix == 0.0) {
         return cvref;
     }
     double TKelvin = temperature();
     double sqt = sqrt(TKelvin);
     double mv = molarVolume();
-    double vpb = mv + m_b_current;
+    double vpb = mv + m_bMix;
     double dadt = da_dt();
-    double fac = TKelvin * dadt - 3.0 * m_a_current / 2.0;
-    return (cvref - 1.0/(2.0 * m_b_current * TKelvin * sqt) * log(vpb/mv)*fac
-            +1.0/(m_b_current * sqt) * log(vpb/mv)*(-0.5*dadt));
+    double fac = TKelvin * dadt - 3.0 * m_aMix / 2.0;
+    return (cvref - 1.0/(2.0 * m_bMix * TKelvin * sqt) * log(vpb/mv)*fac
+            +1.0/(m_bMix * sqt) * log(vpb/mv)*(-0.5*dadt));
 }
 
 double RedlichKwongMFTP::pressure() const
@@ -123,7 +119,7 @@ double RedlichKwongMFTP::pressure() const
     //  Get a copy of the private variables stored in the State object
     double T = temperature();
     double molarV = meanMolecularWeight() / density();
-    double pp = GasConstant * T/(molarV - m_b_current) - m_a_current/(sqrt(T) * molarV * (molarV + m_b_current));
+    double pp = GasConstant * T/(molarV - m_bMix) - m_aMix/(sqrt(T) * molarV * (molarV + m_bMix));
     return pp;
 }
 
@@ -139,25 +135,25 @@ void RedlichKwongMFTP::getActivityCoefficients(span<double> ac) const
     for (size_t k = 0; k < m_kk; k++) {
         ac[k] = 1.0;
     }
-    if (m_b_current == 0.0) {
+    if (m_bMix == 0.0) {
         return;
     }
     double mv = molarVolume();
     double sqt = sqrt(temperature());
-    double vpb = mv + m_b_current;
-    double vmb = mv - m_b_current;
+    double vpb = mv + m_bMix;
+    double vmb = mv - m_bMix;
 
     auto x = asVectorXd(moleFractions_);
-    m_pp = a_vec_Curr_ * x;
+    m_pp = m_a * x;
     double pres = pressure();
 
     for (size_t k = 0; k < m_kk; k++) {
         ac[k] = (- RT() * log(pres * mv / RT())
                  + RT() * log(mv / vmb)
-                 + RT() * b_vec_Curr_[k] / vmb
-                 - 2.0 * m_pp[k] / (m_b_current * sqt) * log(vpb/mv)
-                 + m_a_current * b_vec_Curr_[k] / (m_b_current * m_b_current * sqt) * log(vpb/mv)
-                 - m_a_current / (m_b_current * sqt) * (b_vec_Curr_[k]/vpb)
+                 + RT() * m_b[k] / vmb
+                 - 2.0 * m_pp[k] / (m_bMix * sqt) * log(vpb/mv)
+                 + m_aMix * m_b[k] / (m_bMix * m_bMix * sqt) * log(vpb/mv)
+                 - m_aMix / (m_bMix * sqt) * (m_b[k]/vpb)
                 );
     }
     for (size_t k = 0; k < m_kk; k++) {
@@ -174,25 +170,25 @@ void RedlichKwongMFTP::getChemPotentials(span<double> mu) const
         double xx = std::max(SmallNumber, moleFraction(k));
         mu[k] += RT() * log(xx);
     }
-    if (m_b_current == 0.0) {
+    if (m_bMix == 0.0) {
         return;
     }
 
     double mv = molarVolume();
     double sqt = sqrt(temperature());
-    double vpb = mv + m_b_current;
-    double vmb = mv - m_b_current;
+    double vpb = mv + m_bMix;
+    double vmb = mv - m_bMix;
 
-    m_pp = a_vec_Curr_ * asVectorXd(moleFractions_);
+    m_pp = m_a * asVectorXd(moleFractions_);
     double pres = pressure();
 
     for (size_t k = 0; k < m_kk; k++) {
         mu[k] += (- RT() * log(pres * mv / RT())
                   + RT() * log(mv / vmb)
-                  + RT() * b_vec_Curr_[k] / vmb
-                  - 2.0 * m_pp[k] / (m_b_current * sqt) * log(vpb/mv)
-                  + m_a_current * b_vec_Curr_[k] / (m_b_current * m_b_current * sqt) * log(vpb/mv)
-                  - m_a_current / (m_b_current * sqt) * (b_vec_Curr_[k]/vpb)
+                  + RT() * m_b[k] / vmb
+                  - 2.0 * m_pp[k] / (m_bMix * sqt) * log(vpb/mv)
+                  + m_aMix * m_b[k] / (m_bMix * m_bMix * sqt) * log(vpb/mv)
+                  - m_aMix / (m_bMix * sqt) * (m_b[k]/vpb)
                  );
     }
 }
@@ -202,7 +198,7 @@ void RedlichKwongMFTP::getPartialMolarEnthalpies(span<double> hbar) const
     // First we get the reference state contributions
     getEnthalpy_RT_ref(hbar);
     scale(hbar.begin(), hbar.end(), hbar.begin(), RT());
-    if (m_b_current == 0.0) {
+    if (m_bMix == 0.0) {
         return;
     }
 
@@ -210,17 +206,17 @@ void RedlichKwongMFTP::getPartialMolarEnthalpies(span<double> hbar) const
     double TKelvin = temperature();
     double mv = molarVolume();
     double sqt = sqrt(TKelvin);
-    double vpb = mv + m_b_current;
-    double vmb = mv - m_b_current;
+    double vpb = mv + m_bMix;
+    double vmb = mv - m_bMix;
     auto x = asVectorXd(moleFractions_);
-    m_pp = a_vec_Curr_ * x;
-    m_dAkdT = m_a_coeff_1 * x;
+    m_pp = m_a * x;
+    m_dAkdT = m_a1 * x;
     for (size_t k = 0; k < m_kk; k++) {
-        m_dpdni[k] = RT()/vmb + RT() * b_vec_Curr_[k] / (vmb * vmb) - 2.0 * m_pp[k] / (sqt * mv * vpb)
-                    + m_a_current * b_vec_Curr_[k]/(sqt * mv * vpb * vpb);
+        m_dpdni[k] = RT()/vmb + RT() * m_b[k] / (vmb * vmb) - 2.0 * m_pp[k] / (sqt * mv * vpb)
+                    + m_aMix * m_b[k]/(sqt * mv * vpb * vpb);
     }
     double dadt = da_dt();
-    double fac = TKelvin * dadt - 3.0 * m_a_current / 2.0;
+    double fac = TKelvin * dadt - 3.0 * m_aMix / 2.0;
 
     for (size_t k = 0; k < m_kk; k++) {
         m_workS[k] = 2.0 * TKelvin * m_dAkdT[k] - 3.0 * m_pp[k];
@@ -229,9 +225,9 @@ void RedlichKwongMFTP::getPartialMolarEnthalpies(span<double> hbar) const
     pressureDerivatives();
     double fac2 = mv + TKelvin * dpdT_ / dpdV_;
     for (size_t k = 0; k < m_kk; k++) {
-        double hE_v = (mv * m_dpdni[k] - RT() - b_vec_Curr_[k]/ (m_b_current * m_b_current * sqt) * log(vpb/mv)*fac
-                       + 1.0 / (m_b_current * sqt) * log(vpb/mv) * m_workS[k]
-                       +  b_vec_Curr_[k] / vpb / (m_b_current * sqt) * fac);
+        double hE_v = (mv * m_dpdni[k] - RT() - m_b[k]/ (m_bMix * m_bMix * sqt) * log(vpb/mv)*fac
+                       + 1.0 / (m_bMix * sqt) * log(vpb/mv) * m_workS[k]
+                       +  m_b[k] / vpb / (m_bMix * sqt) * fac);
         hbar[k] = hbar[k] + hE_v;
         hbar[k] -= fac2 * m_dpdni[k];
     }
@@ -251,29 +247,29 @@ void RedlichKwongMFTP::getPartialMolarEntropies(span<double> sbar) const
         double xx = std::max(SmallNumber, moleFraction(k));
         sbar[k] -= GasConstant * (log(xx) + logPres);
     }
-    if (m_b_current == 0.0) {
+    if (m_bMix == 0.0) {
         return;
     }
     auto x = asVectorXd(moleFractions_);
-    m_pp = a_vec_Curr_ * x;
-    m_dAkdT = m_a_coeff_1 * x;
+    m_pp = m_a * x;
+    m_dAkdT = m_a1 * x;
     for (size_t k = 0; k < m_kk; k++) {
         m_workS[k] = m_dAkdT[k];
     }
 
     double dadt = da_dt();
-    double fac = dadt - m_a_current / (2.0 * TKelvin);
-    double vmb = mv - m_b_current;
-    double vpb = mv + m_b_current;
+    double fac = dadt - m_aMix / (2.0 * TKelvin);
+    double vmb = mv - m_bMix;
+    double vpb = mv + m_bMix;
     for (size_t k = 0; k < m_kk; k++) {
         sbar[k] += (GasConstant * log(pres * mv / RT())
                     - GasConstant
                     - GasConstant * log(mv/vmb)
-                    - GasConstant * b_vec_Curr_[k]/vmb
-                    - m_pp[k]/(m_b_current * TKelvin * sqt) * log(vpb/mv)
-                    + 2.0 * m_workS[k]/(m_b_current * sqt) * log(vpb/mv)
-                    - b_vec_Curr_[k] / (m_b_current * m_b_current * sqt) * log(vpb/mv) * fac
-                    + 1.0 / (m_b_current * sqt) * b_vec_Curr_[k] / vpb * fac);
+                    - GasConstant * m_b[k]/vmb
+                    - m_pp[k]/(m_bMix * TKelvin * sqt) * log(vpb/mv)
+                    + 2.0 * m_workS[k]/(m_bMix * sqt) * log(vpb/mv)
+                    - m_b[k] / (m_bMix * m_bMix * sqt) * log(vpb/mv) * fac
+                    + 1.0 / (m_bMix * sqt) * m_b[k] / vpb * fac);
     }
 
     pressureDerivatives();
@@ -302,8 +298,8 @@ void RedlichKwongMFTP::getPartialMolarIntEnergies_TV(span<double> utilde) const
     double T = temperature();
     double sqt = sqrt(T);
     double mv = molarVolume();
-    double b = m_b_current;
-    double a = m_a_current;
+    double b = m_bMix;
+    double a = m_aMix;
     double dadt = da_dt();
 
     for (size_t k = 0; k < m_kk; k++) {
@@ -316,8 +312,8 @@ void RedlichKwongMFTP::getPartialMolarIntEnergies_TV(span<double> utilde) const
 
     // A_k = sum_i x_i a_ki and A'_k = dA_k/dT = sum_i x_i a_ki,1
     auto x = asVectorXd(moleFractions_);
-    m_pp = a_vec_Curr_ * x;
-    m_dAkdT = m_a_coeff_1 * x;
+    m_pp = m_a * x;
+    m_dAkdT = m_a1 * x;
 
     double vpb = mv + b;
     double logv = log(vpb / mv);
@@ -327,7 +323,7 @@ void RedlichKwongMFTP::getPartialMolarIntEnergies_TV(span<double> utilde) const
 
     for (size_t k = 0; k < m_kk; k++) {
         double Sk = 2.0 * T * m_dAkdT[k] - 3.0 * m_pp[k];
-        double ures = pref * (logv * Sk + b_vec_Curr_[k] * F * C);
+        double ures = pref * (logv * Sk + m_b[k] * F * C);
         utilde[k] += ures;
     }
 }
@@ -340,8 +336,8 @@ void RedlichKwongMFTP::getPartialMolarCp(span<double> cpbar) const
     double T = temperature();
     double sqt = sqrt(T);
     double v = molarVolume();
-    double b = m_b_current;
-    double a = m_a_current;
+    double b = m_bMix;
+    double a = m_aMix;
     double dadt = da_dt();
     double d2adt2 = 0.0; // current RK model uses a(T)=a0+a1*T
 
@@ -374,8 +370,8 @@ void RedlichKwongMFTP::getPartialMolarCp(span<double> cpbar) const
 
     // Species-dependent A_k and dA_k/dT
     auto x = asVectorXd(moleFractions_);
-    m_pp = a_vec_Curr_ * x;
-    m_dAkdT = m_a_coeff_1 * x;
+    m_pp = m_a * x;
+    m_dAkdT = m_a1 * x;
 
     double F = T * dadt - 1.5 * a;
     double dF_dT = -0.5 * dadt + T * d2adt2;
@@ -383,7 +379,7 @@ void RedlichKwongMFTP::getPartialMolarCp(span<double> cpbar) const
     double termLPrime = -b * dvdT_P / (v * vpb);
 
     for (size_t k = 0; k < m_kk; k++) {
-        double bk = b_vec_Curr_[k];
+        double bk = m_b[k];
         double Ak = m_pp[k];
         double dAk = m_dAkdT[k];
         double Sk = 2.0 * T * dAk - 3.0 * Ak;
@@ -430,8 +426,8 @@ void RedlichKwongMFTP::getPartialMolarCv_TV(span<double> cvtilde) const
     double T = temperature();
     double sqt = sqrt(T);
     double mv = molarVolume();
-    double b = m_b_current;
-    double a = m_a_current;
+    double b = m_bMix;
+    double a = m_aMix;
     double dadt = da_dt();
 
     for (size_t k = 0; k < m_kk; k++) {
@@ -444,8 +440,8 @@ void RedlichKwongMFTP::getPartialMolarCv_TV(span<double> cvtilde) const
 
     // A_k = sum_i x_i a_ki and A'_k = dA_k/dT = sum_i x_i a_ki,1
     auto x = asVectorXd(moleFractions_);
-    m_pp = a_vec_Curr_ * x;
-    m_dAkdT = m_a_coeff_1 * x;
+    m_pp = m_a * x;
+    m_dAkdT = m_a1 * x;
 
     // Residual contribution for
     // \tilde{u}_k = (\partial U / \partial n_k)_{T,V,n_j}
@@ -458,8 +454,8 @@ void RedlichKwongMFTP::getPartialMolarCv_TV(span<double> cvtilde) const
 
     for (size_t k = 0; k < m_kk; k++) {
         double Sk = 2.0 * T * m_dAkdT[k] - 3.0 * m_pp[k];
-        double ures = pref * (logv * Sk + b_vec_Curr_[k] * F * C);
-        double dresdT = pref * (-logv * m_dAkdT[k] - 0.5 * b_vec_Curr_[k] * dadt * C)
+        double ures = pref * (logv * Sk + m_b[k] * F * C);
+        double dresdT = pref * (-logv * m_dAkdT[k] - 0.5 * m_b[k] * dadt * C)
             - 0.5 * ures / T;
         cvtilde[k] += dresdT;
     }
@@ -469,23 +465,23 @@ void RedlichKwongMFTP::getPartialMolarVolumes(span<double> vbar) const
 {
     checkArraySize("RedlichKwongMFTP::getPartialMolarVolumes", vbar.size(), m_kk);
     auto x = asVectorXd(moleFractions_);
-    m_pp = a_vec_Curr_ * x;
-    m_dAkdT = m_a_coeff_1 * x;
+    m_pp = m_a * x;
+    m_dAkdT = m_a1 * x;
     for (size_t k = 0; k < m_kk; k++) {
         m_workS[k] = m_dAkdT[k];
     }
 
     double sqt = sqrt(temperature());
     double mv = molarVolume();
-    double vmb = mv - m_b_current;
-    double vpb = mv + m_b_current;
+    double vmb = mv - m_bMix;
+    double vpb = mv + m_bMix;
     for (size_t k = 0; k < m_kk; k++) {
-        double num = (RT() + RT() * m_b_current/ vmb + RT() * b_vec_Curr_[k] / vmb
-                          + RT() * m_b_current * b_vec_Curr_[k] /(vmb * vmb)
+        double num = (RT() + RT() * m_bMix/ vmb + RT() * m_b[k] / vmb
+                          + RT() * m_bMix * m_b[k] /(vmb * vmb)
                           - 2.0 * m_pp[k] / (sqt * vpb)
-                          + m_a_current * b_vec_Curr_[k] / (sqt * vpb * vpb)
+                          + m_aMix * m_b[k] / (sqt * vpb * vpb)
                          );
-        double denom = (pressure() + RT() * m_b_current/(vmb * vmb) - m_a_current / (sqt * vpb * vpb)
+        double denom = (pressure() + RT() * m_bMix/(vmb * vmb) - m_aMix / (sqt * vpb * vpb)
                            );
         vbar[k] = num / denom;
     }
@@ -497,20 +493,20 @@ bool RedlichKwongMFTP::addSpecies(shared_ptr<Species> spec)
     if (added) {
         size_t k = m_kk - 1;
 
-        a_vec_Curr_.conservativeResize(m_kk, m_kk);
-        a_vec_Curr_.row(k).setZero();
-        a_vec_Curr_.col(k).setZero();
+        m_a.conservativeResize(m_kk, m_kk);
+        m_a.row(k).setZero();
+        m_a.col(k).setZero();
 
         // Initialize new entries to NaN to screen for species with undefined
         // pure-fluid parameters in the input file.
-        b_vec_Curr_.conservativeResize(m_kk);
-        b_vec_Curr_[k] = NAN;
-        m_a_coeff_0.conservativeResize(m_kk, m_kk);
-        m_a_coeff_0.row(k).setConstant(NAN);
-        m_a_coeff_0.col(k).setConstant(NAN);
-        m_a_coeff_1.conservativeResize(m_kk, m_kk);
-        m_a_coeff_1.row(k).setConstant(NAN);
-        m_a_coeff_1.col(k).setConstant(NAN);
+        m_b.conservativeResize(m_kk);
+        m_b[k] = NAN;
+        m_a0.conservativeResize(m_kk, m_kk);
+        m_a0.row(k).setConstant(NAN);
+        m_a0.col(k).setConstant(NAN);
+        m_a1.conservativeResize(m_kk, m_kk);
+        m_a1.row(k).setConstant(NAN);
+        m_a1.col(k).setConstant(NAN);
 
         m_pp.conservativeResizeLike(Eigen::VectorXd::Zero(m_kk));
         m_dAkdT.conservativeResizeLike(Eigen::VectorXd::Zero(m_kk));
@@ -530,7 +526,7 @@ void RedlichKwongMFTP::initThermo()
     for (auto& [name, species] : m_species) {
         auto& data = species->input;
         size_t k = speciesIndex(name, true);
-        if (!isnan(m_a_coeff_0(k, k)) && !isnan(b_vec_Curr_[k])) {
+        if (!isnan(m_a0(k, k)) && !isnan(m_b[k])) {
             continue;
         }
         bool foundCoeffs = false;
@@ -629,20 +625,20 @@ void RedlichKwongMFTP::getSpeciesParameters(const string& name,
         auto& eosNode = speciesNode["equation-of-state"].getMapWhere(
             "model", "Redlich-Kwong", true);
 
-        if (m_a_coeff_1(k, k) != 0.0) {
+        if (m_a1(k, k) != 0.0) {
             vector<AnyValue> coeffs(2);
-            coeffs[0].setQuantity(m_a_coeff_0(k, k), "Pa*m^6/kmol^2*K^0.5");
-            coeffs[1].setQuantity(m_a_coeff_1(k, k), "Pa*m^6/kmol^2/K^0.5");
+            coeffs[0].setQuantity(m_a0(k, k), "Pa*m^6/kmol^2*K^0.5");
+            coeffs[1].setQuantity(m_a1(k, k), "Pa*m^6/kmol^2/K^0.5");
             eosNode["a"] = std::move(coeffs);
         } else {
-            eosNode["a"].setQuantity(m_a_coeff_0(k, k),
+            eosNode["a"].setQuantity(m_a0(k, k),
                                     "Pa*m^6/kmol^2*K^0.5");
         }
-        eosNode["b"].setQuantity(b_vec_Curr_[k], "m^3/kmol");
+        eosNode["b"].setQuantity(m_b[k], "m^3/kmol");
     } else if (m_coeffSource[k] == CoeffSource::CritProps) {
         auto& critProps = speciesNode["critical-parameters"];
-        double a = m_a_coeff_0(k, k);
-        double b = b_vec_Curr_[k];
+        double a = m_a0(k, k);
+        double b = m_b[k];
         double Tc = pow(a * omega_b / (b * omega_a * GasConstant), 2.0/3.0);
         double Pc = omega_b * GasConstant * Tc / b;
         critProps["critical-temperature"].setQuantity(Tc, "K");
@@ -669,44 +665,44 @@ void RedlichKwongMFTP::getSpeciesParameters(const string& name,
 
 double RedlichKwongMFTP::sresid() const
 {
-    if (m_b_current == 0.0) {
+    if (m_bMix == 0.0) {
         return 0.0;
     }
     // note this agrees with tpx
     double rho = density();
     double mmw = meanMolecularWeight();
     double molarV = mmw / rho;
-    double hh = m_b_current / molarV;
+    double hh = m_bMix / molarV;
     double zz = z();
     double dadt = da_dt();
     double T = temperature();
     double sqT = sqrt(T);
-    double fac = dadt - m_a_current / (2.0 * T);
-    double sresid_mol_R = log(zz*(1.0 - hh)) + log(1.0 + hh) * fac / (sqT * GasConstant * m_b_current);
+    double fac = dadt - m_aMix / (2.0 * T);
+    double sresid_mol_R = log(zz*(1.0 - hh)) + log(1.0 + hh) * fac / (sqT * GasConstant * m_bMix);
     return GasConstant * sresid_mol_R;
 }
 
 double RedlichKwongMFTP::hresid() const
 {
-    if (m_b_current == 0.0) {
+    if (m_bMix == 0.0) {
         return 0.0;
     }
     // note this agrees with tpx
     double rho = density();
     double mmw = meanMolecularWeight();
     double molarV = mmw / rho;
-    double hh = m_b_current / molarV;
+    double hh = m_bMix / molarV;
     double zz = z();
     double dadt = da_dt();
     double T = temperature();
     double sqT = sqrt(T);
-    double fac = T * dadt - 3.0 *m_a_current / (2.0);
-    return GasConstant * T * (zz - 1.0) + fac * log(1.0 + hh) / (sqT * m_b_current);
+    double fac = T * dadt - 3.0 *m_aMix / (2.0);
+    return GasConstant * T * (zz - 1.0) + fac * log(1.0 + hh) / (sqT * m_bMix);
 }
 
 double RedlichKwongMFTP::liquidVolEst(double TKelvin, double& presGuess) const
 {
-    double v = m_b_current * 1.1;
+    double v = m_bMix * 1.1;
     double atmp;
     double btmp;
     calculateAB(TKelvin, atmp, btmp);
@@ -755,10 +751,10 @@ double RedlichKwongMFTP::densityCalc(double TKelvin, double presPa, int phaseReq
 
 
     double volguess = mmw / rhoguess;
-    NSolns_ = solveCubic(TKelvin, presPa, m_a_current, m_b_current, Vroot_);
+    NSolns_ = solveCubic(TKelvin, presPa, m_aMix, m_bMix, Vroot_);
 
     // Ensure root ordering used for branch selection only contains physical roots.
-    double vmin = std::max(0.0, m_b_current * (1.0 + 1e-12));
+    double vmin = std::max(0.0, m_bMix * (1.0 + 1e-12));
     vector<double> physicalRoots;
     for (double root : Vroot_) {
         if (std::isfinite(root) && root > vmin) {
@@ -826,13 +822,13 @@ double RedlichKwongMFTP::densityCalc(double TKelvin, double presPa, int phaseReq
 double RedlichKwongMFTP::dpdVCalc(double TKelvin, double molarVol, double& presCalc) const
 {
     double sqt = sqrt(TKelvin);
-    presCalc = GasConstant * TKelvin / (molarVol - m_b_current)
-               - m_a_current / (sqt * molarVol * (molarVol + m_b_current));
+    presCalc = GasConstant * TKelvin / (molarVol - m_bMix)
+               - m_aMix / (sqt * molarVol * (molarVol + m_bMix));
 
-    double vpb = molarVol + m_b_current;
-    double vmb = molarVol - m_b_current;
+    double vpb = molarVol + m_bMix;
+    double vmb = molarVol - m_bMix;
     double dpdv = (- GasConstant * TKelvin / (vmb * vmb)
-                       + m_a_current * (2 * molarVol + m_b_current) / (sqt * molarVol * molarVol * vpb * vpb));
+                       + m_aMix * (2 * molarVol + m_bMix) / (sqt * molarVol * molarVol * vpb * vpb));
     return dpdv;
 }
 
@@ -868,10 +864,10 @@ void RedlichKwongMFTP::pressureDerivatives() const
 
     dpdV_ = dpdVCalc(TKelvin, mv, pres);
     double sqt = sqrt(TKelvin);
-    double vpb = mv + m_b_current;
-    double vmb = mv - m_b_current;
+    double vpb = mv + m_bMix;
+    double vmb = mv - m_bMix;
     double dadt = da_dt();
-    double fac = dadt - m_a_current/(2.0 * TKelvin);
+    double fac = dadt - m_aMix/(2.0 * TKelvin);
     dpdT_ = (GasConstant / vmb - fac / (sqt * mv * vpb));
 }
 
@@ -879,19 +875,19 @@ void RedlichKwongMFTP::updateMixingExpressions()
 {
     double temp = temperature();
     if (m_formTempParam == 1) {
-        a_vec_Curr_ = m_a_coeff_0 + temp * m_a_coeff_1;
+        m_a = m_a0 + temp * m_a1;
     }
 
     auto x = asVectorXd(moleFractions_);
-    const auto& b_k = b_vec_Curr_;
-    m_b_current = 0.0;
-    m_b_current = b_k.dot(x);
-    m_a_current = x.dot(a_vec_Curr_ * x);
-    if (isnan(m_b_current)) {
+    const auto& b_k = m_b;
+    m_bMix = 0.0;
+    m_bMix = b_k.dot(x);
+    m_aMix = x.dot(m_a * x);
+    if (isnan(m_bMix)) {
         // One or more species do not have specified coefficients.
         fmt::memory_buffer b;
         for (size_t k = 0; k < m_kk; k++) {
-            if (isnan(b_vec_Curr_[k])) {
+            if (isnan(m_b[k])) {
                 if (b.size() > 0) {
                     fmt_append(b, ", {}", speciesName(k));
                 } else {
@@ -907,12 +903,12 @@ void RedlichKwongMFTP::updateMixingExpressions()
 void RedlichKwongMFTP::calculateAB(double temp, double& aCalc, double& bCalc) const
 {
     auto x = asVectorXd(moleFractions_);
-    const auto& b_k = b_vec_Curr_;
+    const auto& b_k = m_b;
     bCalc = b_k.dot(x);
     if (m_formTempParam == 1) {
-        aCalc = x.dot((m_a_coeff_0 + temp * m_a_coeff_1) * x);
+        aCalc = x.dot((m_a0 + temp * m_a1) * x);
     } else {
-        aCalc = x.dot(m_a_coeff_0 * x);
+        aCalc = x.dot(m_a0 * x);
     }
 }
 
@@ -922,16 +918,16 @@ double RedlichKwongMFTP::da_dt() const
         return 0.0;
     }
     auto x = asVectorXd(moleFractions_);
-    return x.dot(m_a_coeff_1 * x);
+    return x.dot(m_a1 * x);
 }
 
 void RedlichKwongMFTP::calcCriticalConditions(double& pc, double& tc, double& vc) const
 {
     auto x = asVectorXd(moleFractions_);
-    double a0 = x.dot(m_a_coeff_0 * x);
-    double aT = x.dot(m_a_coeff_1 * x);
-    double a = m_a_current;
-    double b = m_b_current;
+    double a0 = x.dot(m_a0 * x);
+    double aT = x.dot(m_a1 * x);
+    double a = m_aMix;
+    double b = m_bMix;
     if (m_formTempParam != 0) {
         a = a0;
     }

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -33,9 +33,8 @@ void RedlichKwongMFTP::setSpeciesCoeffs(const string& species,
         m_formTempParam = 1; // expression is temperature-dependent
     }
 
-    size_t counter = k + m_kk * k;
-    a_coeff_vec(0, counter) = a0;
-    a_coeff_vec(1, counter) = a1;
+    m_a_coeff_0(k, k) = a0;
+    m_a_coeff_1(k, k) = a1;
 
     // standard mixing rule for cross-species interaction term
     for (size_t j = 0; j < m_kk; j++) {
@@ -43,22 +42,22 @@ void RedlichKwongMFTP::setSpeciesCoeffs(const string& species,
             continue;
         }
 
-        // a_coeff_vec(0) is initialized to NaN to mark uninitialized species
-        if (isnan(a_coeff_vec(0, j + m_kk * j))) {
+        // m_a_coeff_0 is initialized to NaN to mark uninitialized species
+        if (isnan(m_a_coeff_0(j, j))) {
             // The diagonal element of the jth species has not yet been defined.
             continue;
-        } else if (isnan(a_coeff_vec(0, j + m_kk * k))) {
+        } else if (isnan(m_a_coeff_0(j, k))) {
             // Only use the mixing rules if the off-diagonal element has not already been defined by a
             // user-specified crossFluidParameters entry:
-            double a0kj = sqrt(a_coeff_vec(0, j + m_kk * j) * a0);
-            double a1kj = sqrt(a_coeff_vec(1, j + m_kk * j) * a1);
-            a_coeff_vec(0, j + m_kk * k) = a0kj;
-            a_coeff_vec(1, j + m_kk * k) = a1kj;
-            a_coeff_vec(0, k + m_kk * j) = a0kj;
-            a_coeff_vec(1, k + m_kk * j) = a1kj;
+            double a0kj = sqrt(m_a_coeff_0(j, j) * a0);
+            double a1kj = sqrt(m_a_coeff_1(j, j) * a1);
+            m_a_coeff_0(j, k) = a0kj;
+            m_a_coeff_1(j, k) = a1kj;
+            m_a_coeff_0(k, j) = a0kj;
+            m_a_coeff_1(k, j) = a1kj;
         }
     }
-    a_coeff_vec.getRow(0, a_vec_Curr_);
+    a_vec_Curr_ = m_a_coeff_0;
     b_vec_Curr_[k] = b;
 }
 
@@ -74,11 +73,9 @@ void RedlichKwongMFTP::setBinaryCoeffs(const string& species_i, const string& sp
 
     m_binaryParameters[species_i][species_j] = {a0, a1};
     m_binaryParameters[species_j][species_i] = {a0, a1};
-    size_t counter1 = ki + m_kk * kj;
-    size_t counter2 = kj + m_kk * ki;
-    a_coeff_vec(0, counter1) = a_coeff_vec(0, counter2) = a0;
-    a_coeff_vec(1, counter1) = a_coeff_vec(1, counter2) = a1;
-    a_vec_Curr_[counter1] = a_vec_Curr_[counter2] = a0;
+    m_a_coeff_0(ki, kj) = m_a_coeff_0(kj, ki) = a0;
+    m_a_coeff_1(ki, kj) = m_a_coeff_1(kj, ki) = a1;
+    a_vec_Curr_(ki, kj) = a_vec_Curr_(kj, ki) = a0;
 }
 
 // ------------Molar Thermodynamic Properties -------------------------
@@ -150,13 +147,8 @@ void RedlichKwongMFTP::getActivityCoefficients(span<double> ac) const
     double vpb = mv + m_b_current;
     double vmb = mv - m_b_current;
 
-    for (size_t k = 0; k < m_kk; k++) {
-        m_pp[k] = 0.0;
-        for (size_t i = 0; i < m_kk; i++) {
-            size_t counter = k + m_kk*i;
-            m_pp[k] += moleFractions_[i] * a_vec_Curr_[counter];
-        }
-    }
+    auto x = asVectorXd(moleFractions_);
+    m_pp = a_vec_Curr_ * x;
     double pres = pressure();
 
     for (size_t k = 0; k < m_kk; k++) {
@@ -191,13 +183,7 @@ void RedlichKwongMFTP::getChemPotentials(span<double> mu) const
     double vpb = mv + m_b_current;
     double vmb = mv - m_b_current;
 
-    for (size_t k = 0; k < m_kk; k++) {
-        m_pp[k] = 0.0;
-        for (size_t i = 0; i < m_kk; i++) {
-            size_t counter = k + m_kk*i;
-            m_pp[k] += moleFractions_[i] * a_vec_Curr_[counter];
-        }
-    }
+    m_pp = a_vec_Curr_ * asVectorXd(moleFractions_);
     double pres = pressure();
 
     for (size_t k = 0; k < m_kk; k++) {
@@ -220,42 +206,34 @@ void RedlichKwongMFTP::getPartialMolarEnthalpies(span<double> hbar) const
         return;
     }
 
-    // We calculate dpdni_
+    // We calculate m_dpdni
     double TKelvin = temperature();
     double mv = molarVolume();
     double sqt = sqrt(TKelvin);
     double vpb = mv + m_b_current;
     double vmb = mv - m_b_current;
+    auto x = asVectorXd(moleFractions_);
+    m_pp = a_vec_Curr_ * x;
+    m_dAkdT = m_a_coeff_1 * x;
     for (size_t k = 0; k < m_kk; k++) {
-        m_pp[k] = 0.0;
-        for (size_t i = 0; i < m_kk; i++) {
-            size_t counter = k + m_kk*i;
-            m_pp[k] += moleFractions_[i] * a_vec_Curr_[counter];
-        }
-    }
-    for (size_t k = 0; k < m_kk; k++) {
-        dpdni_[k] = RT()/vmb + RT() * b_vec_Curr_[k] / (vmb * vmb) - 2.0 * m_pp[k] / (sqt * mv * vpb)
+        m_dpdni[k] = RT()/vmb + RT() * b_vec_Curr_[k] / (vmb * vmb) - 2.0 * m_pp[k] / (sqt * mv * vpb)
                     + m_a_current * b_vec_Curr_[k]/(sqt * mv * vpb * vpb);
     }
     double dadt = da_dt();
     double fac = TKelvin * dadt - 3.0 * m_a_current / 2.0;
 
     for (size_t k = 0; k < m_kk; k++) {
-        m_workS[k] = 0.0;
-        for (size_t i = 0; i < m_kk; i++) {
-            size_t counter = k + m_kk*i;
-            m_workS[k] += 2.0 * moleFractions_[i] * TKelvin * a_coeff_vec(1,counter) - 3.0 * moleFractions_[i] * a_vec_Curr_[counter];
-        }
+        m_workS[k] = 2.0 * TKelvin * m_dAkdT[k] - 3.0 * m_pp[k];
     }
 
     pressureDerivatives();
     double fac2 = mv + TKelvin * dpdT_ / dpdV_;
     for (size_t k = 0; k < m_kk; k++) {
-        double hE_v = (mv * dpdni_[k] - RT() - b_vec_Curr_[k]/ (m_b_current * m_b_current * sqt) * log(vpb/mv)*fac
+        double hE_v = (mv * m_dpdni[k] - RT() - b_vec_Curr_[k]/ (m_b_current * m_b_current * sqt) * log(vpb/mv)*fac
                        + 1.0 / (m_b_current * sqt) * log(vpb/mv) * m_workS[k]
                        +  b_vec_Curr_[k] / vpb / (m_b_current * sqt) * fac);
         hbar[k] = hbar[k] + hE_v;
-        hbar[k] -= fac2 * dpdni_[k];
+        hbar[k] -= fac2 * m_dpdni[k];
     }
 }
 
@@ -276,19 +254,11 @@ void RedlichKwongMFTP::getPartialMolarEntropies(span<double> sbar) const
     if (m_b_current == 0.0) {
         return;
     }
+    auto x = asVectorXd(moleFractions_);
+    m_pp = a_vec_Curr_ * x;
+    m_dAkdT = m_a_coeff_1 * x;
     for (size_t k = 0; k < m_kk; k++) {
-        m_pp[k] = 0.0;
-        for (size_t i = 0; i < m_kk; i++) {
-            size_t counter = k + m_kk*i;
-            m_pp[k] += moleFractions_[i] * a_vec_Curr_[counter];
-        }
-    }
-    for (size_t k = 0; k < m_kk; k++) {
-        m_workS[k] = 0.0;
-        for (size_t i = 0; i < m_kk; i++) {
-            size_t counter = k + m_kk*i;
-            m_workS[k] += moleFractions_[i] * a_coeff_vec(1,counter);
-        }
+        m_workS[k] = m_dAkdT[k];
     }
 
     double dadt = da_dt();
@@ -345,15 +315,9 @@ void RedlichKwongMFTP::getPartialMolarIntEnergies_TV(span<double> utilde) const
     }
 
     // A_k = sum_i x_i a_ki and A'_k = dA_k/dT = sum_i x_i a_ki,1
-    for (size_t k = 0; k < m_kk; k++) {
-        m_pp[k] = 0.0;
-        m_dAkdT[k] = 0.0;
-        for (size_t i = 0; i < m_kk; i++) {
-            size_t counter = k + m_kk * i;
-            m_pp[k] += moleFractions_[i] * a_vec_Curr_[counter];
-            m_dAkdT[k] += moleFractions_[i] * a_coeff_vec(1, counter);
-        }
-    }
+    auto x = asVectorXd(moleFractions_);
+    m_pp = a_vec_Curr_ * x;
+    m_dAkdT = m_a_coeff_1 * x;
 
     double vpb = mv + b;
     double logv = log(vpb / mv);
@@ -409,15 +373,9 @@ void RedlichKwongMFTP::getPartialMolarCp(span<double> cpbar) const
     double d2vdT2_P = -(pTT + 2.0 * pTV * dvdT_P + pVV * dvdT_P * dvdT_P) / pV;
 
     // Species-dependent A_k and dA_k/dT
-    for (size_t k = 0; k < m_kk; k++) {
-        m_pp[k] = 0.0;
-        m_dAkdT[k] = 0.0;
-        for (size_t i = 0; i < m_kk; i++) {
-            size_t counter = k + m_kk * i;
-            m_pp[k] += moleFractions_[i] * a_vec_Curr_[counter];
-            m_dAkdT[k] += moleFractions_[i] * a_coeff_vec(1, counter);
-        }
-    }
+    auto x = asVectorXd(moleFractions_);
+    m_pp = a_vec_Curr_ * x;
+    m_dAkdT = m_a_coeff_1 * x;
 
     double F = T * dadt - 1.5 * a;
     double dF_dT = -0.5 * dadt + T * d2adt2;
@@ -485,15 +443,9 @@ void RedlichKwongMFTP::getPartialMolarCv_TV(span<double> cvtilde) const
     }
 
     // A_k = sum_i x_i a_ki and A'_k = dA_k/dT = sum_i x_i a_ki,1
-    for (size_t k = 0; k < m_kk; k++) {
-        m_pp[k] = 0.0;
-        m_dAkdT[k] = 0.0;
-        for (size_t i = 0; i < m_kk; i++) {
-            size_t counter = k + m_kk * i;
-            m_pp[k] += moleFractions_[i] * a_vec_Curr_[counter];
-            m_dAkdT[k] += moleFractions_[i] * a_coeff_vec(1, counter);
-        }
-    }
+    auto x = asVectorXd(moleFractions_);
+    m_pp = a_vec_Curr_ * x;
+    m_dAkdT = m_a_coeff_1 * x;
 
     // Residual contribution for
     // \tilde{u}_k = (\partial U / \partial n_k)_{T,V,n_j}
@@ -516,19 +468,11 @@ void RedlichKwongMFTP::getPartialMolarCv_TV(span<double> cvtilde) const
 void RedlichKwongMFTP::getPartialMolarVolumes(span<double> vbar) const
 {
     checkArraySize("RedlichKwongMFTP::getPartialMolarVolumes", vbar.size(), m_kk);
+    auto x = asVectorXd(moleFractions_);
+    m_pp = a_vec_Curr_ * x;
+    m_dAkdT = m_a_coeff_1 * x;
     for (size_t k = 0; k < m_kk; k++) {
-        m_pp[k] = 0.0;
-        for (size_t i = 0; i < m_kk; i++) {
-            size_t counter = k + m_kk*i;
-            m_pp[k] += moleFractions_[i] * a_vec_Curr_[counter];
-        }
-    }
-    for (size_t k = 0; k < m_kk; k++) {
-        m_workS[k] = 0.0;
-        for (size_t i = 0; i < m_kk; i++) {
-            size_t counter = k + m_kk*i;
-            m_workS[k] += moleFractions_[i] * a_coeff_vec(1,counter);
-        }
+        m_workS[k] = m_dAkdT[k];
     }
 
     double sqt = sqrt(temperature());
@@ -551,18 +495,28 @@ bool RedlichKwongMFTP::addSpecies(shared_ptr<Species> spec)
 {
     bool added = MixtureFugacityTP::addSpecies(spec);
     if (added) {
-        a_vec_Curr_.resize(m_kk * m_kk, 0.0);
+        size_t k = m_kk - 1;
 
-        // Initialize a_vec and b_vec to NaN, to screen for species with
-        //     pureFluidParameters which are undefined in the input file:
-        b_vec_Curr_.push_back(NAN);
-        a_coeff_vec.resize(2, m_kk * m_kk, NAN);
+        a_vec_Curr_.conservativeResize(m_kk, m_kk);
+        a_vec_Curr_.row(k).setZero();
+        a_vec_Curr_.col(k).setZero();
 
-        m_pp.push_back(0.0);
-        m_dAkdT.push_back(0.0);
+        // Initialize new entries to NaN to screen for species with undefined
+        // pure-fluid parameters in the input file.
+        b_vec_Curr_.conservativeResize(m_kk);
+        b_vec_Curr_[k] = NAN;
+        m_a_coeff_0.conservativeResize(m_kk, m_kk);
+        m_a_coeff_0.row(k).setConstant(NAN);
+        m_a_coeff_0.col(k).setConstant(NAN);
+        m_a_coeff_1.conservativeResize(m_kk, m_kk);
+        m_a_coeff_1.row(k).setConstant(NAN);
+        m_a_coeff_1.col(k).setConstant(NAN);
+
+        m_pp.conservativeResizeLike(Eigen::VectorXd::Zero(m_kk));
+        m_dAkdT.conservativeResizeLike(Eigen::VectorXd::Zero(m_kk));
         m_coeffSource.push_back(CoeffSource::EoS);
         m_partialMolarVolumes.push_back(0.0);
-        dpdni_.push_back(0.0);
+        m_dpdni.conservativeResizeLike(Eigen::VectorXd::Zero(m_kk));
     }
     return added;
 }
@@ -576,7 +530,7 @@ void RedlichKwongMFTP::initThermo()
     for (auto& [name, species] : m_species) {
         auto& data = species->input;
         size_t k = speciesIndex(name, true);
-        if (!isnan(a_coeff_vec(0, k + m_kk * k))) {
+        if (!isnan(m_a_coeff_0(k, k)) && !isnan(b_vec_Curr_[k])) {
             continue;
         }
         bool foundCoeffs = false;
@@ -675,20 +629,19 @@ void RedlichKwongMFTP::getSpeciesParameters(const string& name,
         auto& eosNode = speciesNode["equation-of-state"].getMapWhere(
             "model", "Redlich-Kwong", true);
 
-        size_t counter = k + m_kk * k;
-        if (a_coeff_vec(1, counter) != 0.0) {
+        if (m_a_coeff_1(k, k) != 0.0) {
             vector<AnyValue> coeffs(2);
-            coeffs[0].setQuantity(a_coeff_vec(0, counter), "Pa*m^6/kmol^2*K^0.5");
-            coeffs[1].setQuantity(a_coeff_vec(1, counter), "Pa*m^6/kmol^2/K^0.5");
+            coeffs[0].setQuantity(m_a_coeff_0(k, k), "Pa*m^6/kmol^2*K^0.5");
+            coeffs[1].setQuantity(m_a_coeff_1(k, k), "Pa*m^6/kmol^2/K^0.5");
             eosNode["a"] = std::move(coeffs);
         } else {
-            eosNode["a"].setQuantity(a_coeff_vec(0, counter),
+            eosNode["a"].setQuantity(m_a_coeff_0(k, k),
                                     "Pa*m^6/kmol^2*K^0.5");
         }
         eosNode["b"].setQuantity(b_vec_Curr_[k], "m^3/kmol");
     } else if (m_coeffSource[k] == CoeffSource::CritProps) {
         auto& critProps = speciesNode["critical-parameters"];
-        double a = a_coeff_vec(0, k + m_kk * k);
+        double a = m_a_coeff_0(k, k);
         double b = b_vec_Curr_[k];
         double Tc = pow(a * omega_b / (b * omega_a * GasConstant), 2.0/3.0);
         double Pc = omega_b * GasConstant * Tc / b;
@@ -926,22 +879,14 @@ void RedlichKwongMFTP::updateMixingExpressions()
 {
     double temp = temperature();
     if (m_formTempParam == 1) {
-        for (size_t i = 0; i < m_kk; i++) {
-            for (size_t j = 0; j < m_kk; j++) {
-                size_t counter = i * m_kk + j;
-                a_vec_Curr_[counter] = a_coeff_vec(0,counter) + a_coeff_vec(1,counter) * temp;
-            }
-        }
+        a_vec_Curr_ = m_a_coeff_0 + temp * m_a_coeff_1;
     }
 
+    auto x = asVectorXd(moleFractions_);
+    const auto& b_k = b_vec_Curr_;
     m_b_current = 0.0;
-    m_a_current = 0.0;
-    for (size_t i = 0; i < m_kk; i++) {
-        m_b_current += moleFractions_[i] * b_vec_Curr_[i];
-        for (size_t j = 0; j < m_kk; j++) {
-            m_a_current += a_vec_Curr_[i * m_kk + j] * moleFractions_[i] * moleFractions_[j];
-        }
-    }
+    m_b_current = b_k.dot(x);
+    m_a_current = x.dot(a_vec_Curr_ * x);
     if (isnan(m_b_current)) {
         // One or more species do not have specified coefficients.
         fmt::memory_buffer b;
@@ -961,54 +906,30 @@ void RedlichKwongMFTP::updateMixingExpressions()
 
 void RedlichKwongMFTP::calculateAB(double temp, double& aCalc, double& bCalc) const
 {
-    bCalc = 0.0;
-    aCalc = 0.0;
+    auto x = asVectorXd(moleFractions_);
+    const auto& b_k = b_vec_Curr_;
+    bCalc = b_k.dot(x);
     if (m_formTempParam == 1) {
-        for (size_t i = 0; i < m_kk; i++) {
-            bCalc += moleFractions_[i] * b_vec_Curr_[i];
-            for (size_t j = 0; j < m_kk; j++) {
-                size_t counter = i * m_kk + j;
-                double a_vec_Curr = a_coeff_vec(0,counter) + a_coeff_vec(1,counter) * temp;
-                aCalc += a_vec_Curr * moleFractions_[i] * moleFractions_[j];
-            }
-        }
+        aCalc = x.dot((m_a_coeff_0 + temp * m_a_coeff_1) * x);
     } else {
-        for (size_t i = 0; i < m_kk; i++) {
-            bCalc += moleFractions_[i] * b_vec_Curr_[i];
-            for (size_t j = 0; j < m_kk; j++) {
-                size_t counter = i * m_kk + j;
-                double a_vec_Curr = a_coeff_vec(0,counter);
-                aCalc += a_vec_Curr * moleFractions_[i] * moleFractions_[j];
-            }
-        }
+        aCalc = x.dot(m_a_coeff_0 * x);
     }
 }
 
 double RedlichKwongMFTP::da_dt() const
 {
-    double dadT = 0.0;
-    if (m_formTempParam == 1) {
-        for (size_t i = 0; i < m_kk; i++) {
-            for (size_t j = 0; j < m_kk; j++) {
-                size_t counter = i * m_kk + j;
-                dadT+= a_coeff_vec(1,counter) * moleFractions_[i] * moleFractions_[j];
-            }
-        }
+    if (m_formTempParam == 0) {
+        return 0.0;
     }
-    return dadT;
+    auto x = asVectorXd(moleFractions_);
+    return x.dot(m_a_coeff_1 * x);
 }
 
 void RedlichKwongMFTP::calcCriticalConditions(double& pc, double& tc, double& vc) const
 {
-    double a0 = 0.0;
-    double aT = 0.0;
-    for (size_t i = 0; i < m_kk; i++) {
-        for (size_t j = 0; j <m_kk; j++) {
-            size_t counter = i + m_kk * j;
-            a0 += moleFractions_[i] * moleFractions_[j] * a_coeff_vec(0, counter);
-            aT += moleFractions_[i] * moleFractions_[j] * a_coeff_vec(1, counter);
-        }
-    }
+    auto x = asVectorXd(moleFractions_);
+    double a0 = x.dot(m_a_coeff_0 * x);
+    double aT = x.dot(m_a_coeff_1 * x);
     double a = m_a_current;
     double b = m_b_current;
     if (m_formTempParam != 0) {

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -83,16 +83,16 @@ double RedlichKwongMFTP::cp_mole() const
     if (m_bMix == 0.0) {
         return cpref;
     }
-    double TKelvin = temperature();
-    double sqt = sqrt(TKelvin);
+    double T = temperature();
+    double sqt = sqrt(T);
     double mv = molarVolume();
     double vpb = mv + m_bMix;
     pressureDerivatives();
     double dadt = da_dt();
-    double fac = TKelvin * dadt - 3.0 * m_aMix / 2.0;
-    double dHdT_V = (cpref + mv * dpdT_ - GasConstant - 1.0 / (2.0 * m_bMix * TKelvin * sqt) * log(vpb/mv) * fac
-                         +1.0/(m_bMix * sqt) * log(vpb/mv) * (-0.5 * dadt));
-    return dHdT_V - (mv + TKelvin * dpdT_ / dpdV_) * dpdT_;
+    double fac = T * dadt - 3.0 * m_aMix / 2.0;
+    double dHdT_V = cpref - 0.5 * dadt * log(vpb/mv) / (m_bMix * sqt)
+        + mv * dpdT_ - GasConstant - log(vpb/mv) * fac / (2.0 * m_bMix * T * sqt);
+    return dHdT_V - (mv + T * dpdT_ / dpdV_) * dpdT_;
 }
 
 double RedlichKwongMFTP::cv_mole() const
@@ -102,13 +102,13 @@ double RedlichKwongMFTP::cv_mole() const
     if (m_bMix == 0.0) {
         return cvref;
     }
-    double TKelvin = temperature();
-    double sqt = sqrt(TKelvin);
+    double T = temperature();
+    double sqt = sqrt(T);
     double mv = molarVolume();
     double vpb = mv + m_bMix;
     double dadt = da_dt();
-    double fac = TKelvin * dadt - 3.0 * m_aMix / 2.0;
-    return (cvref - 1.0/(2.0 * m_bMix * TKelvin * sqt) * log(vpb/mv)*fac
+    double fac = T * dadt - 3.0 * m_aMix / 2.0;
+    return (cvref - 1.0/(2.0 * m_bMix * T * sqt) * log(vpb/mv)*fac
             +1.0/(m_bMix * sqt) * log(vpb/mv)*(-0.5*dadt));
 }
 
@@ -119,7 +119,8 @@ double RedlichKwongMFTP::pressure() const
     //  Get a copy of the private variables stored in the State object
     double T = temperature();
     double molarV = meanMolecularWeight() / density();
-    double pp = GasConstant * T/(molarV - m_bMix) - m_aMix/(sqrt(T) * molarV * (molarV + m_bMix));
+    double pp = GasConstant * T/(molarV - m_bMix)
+        - m_aMix/(sqrt(T) * molarV * (molarV + m_bMix));
     return pp;
 }
 
@@ -142,9 +143,8 @@ void RedlichKwongMFTP::getActivityCoefficients(span<double> ac) const
     double sqt = sqrt(temperature());
     double vpb = mv + m_bMix;
     double vmb = mv - m_bMix;
-    double pres = pressure();
     double logv = log(vpb / mv);
-    Eigen::ArrayXd g = RT() * (log(RT() / (vmb * pres)) + m_b / vmb)
+    Eigen::ArrayXd g = RT() * (log(RT() / (vmb * pressure())) + m_b / vmb)
         - 2.0 * m_Ak / (m_bMix * sqt) * logv
         + m_aMix * m_b / (m_bMix * m_bMix * sqt) * logv
         - m_aMix * m_b / (m_bMix * sqt * vpb);
@@ -185,20 +185,20 @@ void RedlichKwongMFTP::getPartialMolarEnthalpies(span<double> hbar) const
     }
 
     // We calculate m_dpdni
-    double TKelvin = temperature();
+    double T = temperature();
     double mv = molarVolume();
-    double sqt = sqrt(TKelvin);
+    double sqt = sqrt(T);
     double vpb = mv + m_bMix;
     double vmb = mv - m_bMix;
     m_dpdni = RT() / vmb * (1.0 + m_b / vmb)
         - 2.0 * m_Ak / (sqt * mv * vpb)
         + m_aMix * m_b / (sqt * mv * vpb * vpb);
     double dadt = da_dt();
-    double fac = TKelvin * dadt - 3.0 * m_aMix / 2.0;
-    Eigen::ArrayXd Sk = 2.0 * TKelvin * m_dAkdT - 3.0 * m_Ak;
+    double fac = T * dadt - 3.0 * m_aMix / 2.0;
+    Eigen::ArrayXd Sk = 2.0 * T * m_dAkdT - 3.0 * m_Ak;
 
     pressureDerivatives();
-    double fac2 = mv + TKelvin * dpdT_ / dpdV_;
+    double fac2 = mv + T * dpdT_ / dpdV_;
     double logv = log(vpb / mv);
     Eigen::ArrayXd hE_v = mv * m_dpdni
         - RT()
@@ -211,8 +211,8 @@ void RedlichKwongMFTP::getPartialMolarEnthalpies(span<double> hbar) const
 void RedlichKwongMFTP::getPartialMolarEntropies(span<double> sbar) const
 {
     getEntropy_R_ref(sbar);
-    double TKelvin = temperature();
-    double sqt = sqrt(TKelvin);
+    double T = temperature();
+    double sqt = sqrt(T);
     double mv = molarVolume();
     double pres = pressure();
 
@@ -223,13 +223,13 @@ void RedlichKwongMFTP::getPartialMolarEntropies(span<double> sbar) const
     if (m_bMix == 0.0) {
         return;
     }
-    double fac = da_dt() - m_aMix / (2.0 * TKelvin);
+    double fac = da_dt() - m_aMix / (2.0 * T);
     double vmb = mv - m_bMix;
     double vpb = mv + m_bMix;
     double logv = log(vpb / mv);
     Eigen::ArrayXd sdep = GasConstant * (log(RT() / (pres * vmb)) + 1)
         + GasConstant * m_b / vmb
-        + m_Ak / (m_bMix * TKelvin * sqt) * logv
+        + m_Ak / (m_bMix * T * sqt) * logv
         - 2.0 * m_dAkdT / (m_bMix * sqt) * logv
         + m_b / (m_bMix * m_bMix * sqt) * logv * fac
         - m_b / (m_bMix * sqt * vpb) * fac;
@@ -256,25 +256,20 @@ void RedlichKwongMFTP::getPartialMolarIntEnergies_TV(span<double> utilde) const
     checkArraySize("RedlichKwongMFTP::getPartialMolarIntEnergies_TV", utilde.size(), m_kk);
     _updateReferenceStateThermo();
 
-    double T = temperature();
-    double sqt = sqrt(T);
-    double mv = molarVolume();
-    double b = m_bMix;
-    double a = m_aMix;
-    double dadt = da_dt();
-
     Eigen::Map<Eigen::ArrayXd> utildeVec(utilde.data(), m_kk);
     utildeVec = RT() * (asVectorXd(m_h0_RT).array() - 1.0);
 
-    if (fabs(b) < SmallNumber) {
+    if (fabs(m_bMix) < SmallNumber) {
         return;
     }
 
-    double vpb = mv + b;
+    double T = temperature();
+    double mv = molarVolume();
+    double vpb = mv + m_bMix;
     double logv = log(vpb / mv);
-    double F = T * dadt - 1.5 * a;
-    double C = -logv / b + 1.0 / vpb;
-    double pref = 1.0 / (b * sqt);
+    double F = T * da_dt() - 1.5 * m_aMix;
+    double C = -logv / m_bMix + 1.0 / vpb;
+    double pref = 1.0 / (m_bMix * sqrt(T));
 
     Eigen::ArrayXd Sk = 2.0 * T * m_dAkdT - 3.0 * m_Ak;
     utildeVec += pref * (logv * Sk + m_b * F * C);
@@ -284,46 +279,40 @@ void RedlichKwongMFTP::getPartialMolarCp(span<double> cpbar) const
 {
     checkArraySize("RedlichKwongMFTP::getPartialMolarCp", cpbar.size(), m_kk);
     _updateReferenceStateThermo();
-
-    double T = temperature();
-    double sqt = sqrt(T);
-    double v = molarVolume();
-    double b = m_bMix;
-    double a = m_aMix;
-    double dadt = da_dt();
-    double d2adt2 = 0.0; // current RK model uses a(T)=a0+a1*T
-
     for (size_t k = 0; k < m_kk; k++) {
         cpbar[k] = GasConstant * m_cp0_R[k];
     }
 
-    if (fabs(b) < SmallNumber) {
+    if (fabs(m_bMix) < SmallNumber) {
         return;
     }
 
+    double T = temperature();
+    double sqt = sqrt(T);
+    double v = molarVolume();
+    double dadt = da_dt();
+    double d2adt2 = 0.0; // current RK model uses a(T)=a0+a1*T
+
     // Mixture pressure derivatives
     pressureDerivatives();
-    double pT = dpdT_;
-    double pV = dpdV_;
-    double dvdT_P = -pT / pV;
-
-    double vpb = v + b;
-    double vmb = v - b;
+    double dvdT_P = -dpdT_ / dpdV_;
+    double vpb = v + m_bMix;
+    double vmb = v - m_bMix;
 
     // P_TT, P_TV and P_VV for v''(T)|P from EOS:
     // v'' = -(P_TT + 2 P_TV v' + P_VV v'^2) / P_V
-    double pTT = (-d2adt2 + dadt / T - 3.0 * a / (4.0 * T * T)) / (sqt * v * vpb);
+    double pTT = (-d2adt2 + dadt / T - 3.0 * m_aMix / (4.0 * T * T)) / (sqt * v * vpb);
     double pTV = -GasConstant / (vmb * vmb)
-        + (dadt - a / (2.0 * T)) * (2.0 * v + b) / (sqt * v * v * vpb * vpb);
+        + (dadt - m_aMix / (2.0 * T)) * (2.0 * v + m_bMix) / (sqt * v * v * vpb * vpb);
     double pVV = 2.0 * GasConstant * T / (vmb * vmb * vmb)
-        - 2.0 * a * (3.0 * v * v + 3.0 * b * v + b * b)
+        - 2.0 * m_aMix * (3.0 * v * v + 3.0 * m_bMix * v + m_bMix * m_bMix)
             / (sqt * v * v * v * vpb * vpb * vpb);
-    double d2vdT2_P = -(pTT + 2.0 * pTV * dvdT_P + pVV * dvdT_P * dvdT_P) / pV;
+    double d2vdT2_P = -(pTT + 2.0 * pTV * dvdT_P + pVV * dvdT_P * dvdT_P) / dpdV_;
 
-    double F = T * dadt - 1.5 * a;
+    double F = T * dadt - 1.5 * m_aMix;
     double dF_dT = -0.5 * dadt + T * d2adt2;
     double logvpv = log(vpb / v);
-    double termLPrime = -b * dvdT_P / (v * vpb);
+    double termLPrime = -m_bMix * dvdT_P / (v * vpb);
 
     for (size_t k = 0; k < m_kk; k++) {
         double bk = m_b[k];
@@ -335,7 +324,7 @@ void RedlichKwongMFTP::getPartialMolarCp(span<double> cpbar) const
         // dp/dn_k at constant T,V,n_j
         double dpdni = RT() / vmb + RT() * bk / (vmb * vmb)
             - 2.0 * Ak / (sqt * v * vpb)
-            + a * bk / (sqt * v * vpb * vpb);
+            + m_aMix * bk / (sqt * v * vpb * vpb);
 
         // d/dT|P [dp/dn_k]
         double d_dpdni_dT = GasConstant / vmb
@@ -344,17 +333,17 @@ void RedlichKwongMFTP::getPartialMolarCp(span<double> cpbar) const
             - 2.0 * GasConstant * T * bk * dvdT_P / (vmb * vmb * vmb)
             - 2.0 * dAk / (sqt * v * vpb)
             + Ak / (T * sqt * v * vpb)
-            + 2.0 * Ak * (2.0 * v + b) * dvdT_P / (sqt * v * v * vpb * vpb)
-            + bk * dadt / (sqt * v * vpb * vpb)
-            - bk * a / (2.0 * T * sqt * v * vpb * vpb)
-            - bk * a * (3.0 * v + b) * dvdT_P / (sqt * v * v * vpb * vpb * vpb);
+            + 2.0 * Ak * (2.0 * v + m_bMix) * dvdT_P / (sqt * v * v * vpb * vpb)
+            + bk * da_dt() / (sqt * v * vpb * vpb)
+            - bk * m_aMix / (2.0 * T * sqt * v * vpb * vpb)
+            - bk * m_aMix * (3.0 * v + m_bMix) * dvdT_P / (sqt * v * v * vpb * vpb * vpb);
 
         // d/dT|P of departure terms used in getPartialMolarEnthalpies
-        double dterm1 = -bk / (b * b * sqt)
+        double dterm1 = -bk / (m_bMix * m_bMix * sqt)
             * (termLPrime * F + logvpv * dF_dT - logvpv * F / (2.0 * T));
-        double dterm2 = 1.0 / (b * sqt)
+        double dterm2 = 1.0 / (m_bMix * sqt)
             * (termLPrime * Sk + logvpv * dSk_dT - logvpv * Sk / (2.0 * T));
-        double dterm3 = bk / (b * sqt)
+        double dterm3 = bk / (m_bMix * sqt)
             * (dF_dT / vpb - F * dvdT_P / (vpb * vpb) - F / (2.0 * T * vpb));
 
         // cp_k = d hbar_k / dT at constant P and composition
@@ -370,28 +359,26 @@ void RedlichKwongMFTP::getPartialMolarCv_TV(span<double> cvtilde) const
     checkArraySize("RedlichKwongMFTP::getPartialMolarCv_TV", cvtilde.size(), m_kk);
     _updateReferenceStateThermo();
 
-    double T = temperature();
-    double sqt = sqrt(T);
-    double mv = molarVolume();
-    double b = m_bMix;
-    double a = m_aMix;
-    double dadt = da_dt();
-
     Eigen::Map<Eigen::ArrayXd> cvtildeVec(cvtilde.data(), m_kk);
     cvtildeVec = GasConstant * (asVectorXd(m_cp0_R).array() - 1.0);
 
-    if (fabs(b) < SmallNumber) {
+    if (fabs(m_bMix) < SmallNumber) {
         return;
     }
+
+    double T = temperature();
+    double sqt = sqrt(T);
+    double mv = molarVolume();
+    double dadt = da_dt();
 
     // Residual contribution for
     // \tilde{u}_k = (\partial U / \partial n_k)_{T,V,n_j}
     // with linear a(T): a_ij = a_ij,0 + a_ij,1 T
-    double vpb = mv + b;
+    double vpb = mv + m_bMix;
     double logv = log(vpb / mv);
-    double F = T * dadt - 1.5 * a;
-    double C = -logv / b + 1.0 / vpb;
-    double pref = 1.0 / (b * sqt);
+    double F = T * dadt - 1.5 * m_aMix;
+    double C = -logv / m_bMix + 1.0 / vpb;
+    double pref = 1.0 / (m_bMix * sqt);
 
     Eigen::ArrayXd Sk = 2.0 * T * m_dAkdT - 3.0 * m_Ak;
     Eigen::ArrayXd ures = pref * (logv * Sk + m_b * F * C);
@@ -596,16 +583,12 @@ double RedlichKwongMFTP::sresid() const
         return 0.0;
     }
     // note this agrees with tpx
-    double rho = density();
-    double mmw = meanMolecularWeight();
-    double molarV = mmw / rho;
-    double hh = m_bMix / molarV;
+    double hh = m_bMix / molarVolume();
     double zz = z();
-    double dadt = da_dt();
     double T = temperature();
-    double sqT = sqrt(T);
-    double fac = dadt - m_aMix / (2.0 * T);
-    double sresid_mol_R = log(zz*(1.0 - hh)) + log(1.0 + hh) * fac / (sqT * GasConstant * m_bMix);
+    double fac = da_dt() - m_aMix / (2.0 * T);
+    double sresid_mol_R = log(zz*(1.0 - hh))
+        + log(1.0 + hh) * fac / (sqrt(T) * GasConstant * m_bMix);
     return GasConstant * sresid_mol_R;
 }
 
@@ -615,30 +598,25 @@ double RedlichKwongMFTP::hresid() const
         return 0.0;
     }
     // note this agrees with tpx
-    double rho = density();
-    double mmw = meanMolecularWeight();
-    double molarV = mmw / rho;
-    double hh = m_bMix / molarV;
+    double hh = m_bMix / molarVolume();
     double zz = z();
-    double dadt = da_dt();
     double T = temperature();
-    double sqT = sqrt(T);
-    double fac = T * dadt - 3.0 *m_aMix / (2.0);
-    return GasConstant * T * (zz - 1.0) + fac * log(1.0 + hh) / (sqT * m_bMix);
+    double fac = T * da_dt() - 3.0 *m_aMix / (2.0);
+    return GasConstant * T * (zz - 1.0) + fac * log(1.0 + hh) / (sqrt(T) * m_bMix);
 }
 
-double RedlichKwongMFTP::liquidVolEst(double TKelvin, double& presGuess) const
+double RedlichKwongMFTP::liquidVolEst(double T, double& presGuess) const
 {
     double v = m_bMix * 1.1;
     double atmp;
     double btmp;
-    calculateAB(TKelvin, atmp, btmp);
-    double pres = std::max(psatEst(TKelvin), presGuess);
+    calculateAB(T, atmp, btmp);
+    double pres = std::max(psatEst(T), presGuess);
     double Vroot[3];
     bool foundLiq = false;
     int m = 0;
     while (m < 100 && !foundLiq) {
-        int nsol = solveCubic(TKelvin, pres, atmp, btmp, Vroot);
+        int nsol = solveCubic(T, pres, atmp, btmp, Vroot);
         if (nsol == 1 || nsol == 2) {
             double pc = critPressure();
             if (pres > pc) {
@@ -659,26 +637,26 @@ double RedlichKwongMFTP::liquidVolEst(double TKelvin, double& presGuess) const
     return v;
 }
 
-double RedlichKwongMFTP::densityCalc(double TKelvin, double presPa, int phaseRequested,
+double RedlichKwongMFTP::densityCalc(double T, double presPa, int phaseRequested,
                                      double rhoguess)
 {
     // It's necessary to set the temperature so that m_a_current is set correctly.
-    setTemperature(TKelvin);
+    setTemperature(T);
     double tcrit = critTemperature();
     double mmw = meanMolecularWeight();
     if (rhoguess == -1.0) {
         if (phaseRequested >= FLUID_LIQUID_0) {
-                    double lqvol = liquidVolEst(TKelvin, presPa);
+                    double lqvol = liquidVolEst(T, presPa);
                     rhoguess = mmw / lqvol;
                 }
         } else {
             // Assume the Gas phase initial guess, if nothing is specified to the routine
-            rhoguess = presPa * mmw / (GasConstant * TKelvin);
+            rhoguess = presPa * mmw / (GasConstant * T);
     }
 
 
     double volguess = mmw / rhoguess;
-    NSolns_ = solveCubic(TKelvin, presPa, m_aMix, m_bMix, Vroot_);
+    NSolns_ = solveCubic(T, presPa, m_aMix, m_bMix, Vroot_);
 
     // Ensure root ordering used for branch selection only contains physical roots.
     double vmin = std::max(0.0, m_bMix * (1.0 + 1e-12));
@@ -734,7 +712,7 @@ double RedlichKwongMFTP::densityCalc(double TKelvin, double presPa, int phaseReq
     } else if (NSolns_ == -1) {
         if (phaseRequested >= FLUID_LIQUID_0 || phaseRequested == FLUID_UNDEFINED || phaseRequested == FLUID_SUPERCRIT) {
             molarVolLast = Vroot_[0];
-        } else if (TKelvin > tcrit) {
+        } else if (T > tcrit) {
             molarVolLast = Vroot_[0];
         } else {
             return -2.0;
@@ -746,15 +724,15 @@ double RedlichKwongMFTP::densityCalc(double TKelvin, double presPa, int phaseReq
     return mmw / molarVolLast;
 }
 
-double RedlichKwongMFTP::dpdVCalc(double TKelvin, double molarVol, double& presCalc) const
+double RedlichKwongMFTP::dpdVCalc(double T, double molarVol, double& presCalc) const
 {
-    double sqt = sqrt(TKelvin);
-    presCalc = GasConstant * TKelvin / (molarVol - m_bMix)
+    double sqt = sqrt(T);
+    presCalc = GasConstant * T / (molarVol - m_bMix)
                - m_aMix / (sqt * molarVol * (molarVol + m_bMix));
 
     double vpb = molarVol + m_bMix;
     double vmb = molarVol - m_bMix;
-    return - GasConstant * TKelvin / (vmb * vmb)
+    return - GasConstant * T / (vmb * vmb)
         + m_aMix * (2 * molarVol + m_bMix) / (sqt * molarVol * molarVol * vpb * vpb);
 }
 
@@ -784,25 +762,21 @@ double RedlichKwongMFTP::soundSpeed() const
 
 void RedlichKwongMFTP::pressureDerivatives() const
 {
-    double TKelvin = temperature();
+    double T = temperature();
     double mv = molarVolume();
     double pres;
 
-    dpdV_ = dpdVCalc(TKelvin, mv, pres);
-    double sqt = sqrt(TKelvin);
-    double vpb = mv + m_bMix;
-    double vmb = mv - m_bMix;
-    double dadt = da_dt();
-    double fac = dadt - m_aMix/(2.0 * TKelvin);
-    dpdT_ = (GasConstant / vmb - fac / (sqt * mv * vpb));
+    dpdV_ = dpdVCalc(T, mv, pres);
+    double fac = da_dt() - m_aMix/(2.0 * T);
+    dpdT_ = (GasConstant / (mv - m_bMix) - fac / (sqrt(T) * mv * (mv + m_bMix)));
 }
 
 void RedlichKwongMFTP::updateMixingExpressions()
 {
-    double temp = temperature();
+    double T = temperature();
     auto x = asVectorXd(moleFractions_);
     if (m_formTempParam == 1) {
-        m_a = m_a0 + temp * m_a1;
+        m_a = m_a0 + T * m_a1;
         m_dAkdT = m_a1 * x;
     }
 
@@ -826,12 +800,12 @@ void RedlichKwongMFTP::updateMixingExpressions()
     }
 }
 
-void RedlichKwongMFTP::calculateAB(double temp, double& aCalc, double& bCalc) const
+void RedlichKwongMFTP::calculateAB(double T, double& aCalc, double& bCalc) const
 {
     auto x = asVectorXd(moleFractions_);
     bCalc = m_b.matrix().dot(x);
     if (m_formTempParam == 1) {
-        aCalc = x.dot((m_a0 + temp * m_a1) * x);
+        aCalc = x.dot((m_a0 + T * m_a1) * x);
     } else {
         aCalc = x.dot(m_a0 * x);
     }
@@ -852,11 +826,10 @@ void RedlichKwongMFTP::calcCriticalConditions(double& pc, double& tc, double& vc
     double a0 = x.dot(m_a0 * x);
     double aT = x.dot(m_a1 * x);
     double a = m_aMix;
-    double b = m_bMix;
     if (m_formTempParam != 0) {
         a = a0;
     }
-    if (b <= 0.0) {
+    if (m_bMix <= 0.0) {
         tc = 1000000.;
         pc = 1.0E13;
         vc = omega_vc * GasConstant * tc / pc;
@@ -865,10 +838,10 @@ void RedlichKwongMFTP::calcCriticalConditions(double& pc, double& tc, double& vc
     if (a <= 0.0) {
         tc = 0.0;
         pc = 0.0;
-        vc = 2.0 * b;
+        vc = 2.0 * m_bMix;
         return;
     }
-    double tmp = a * omega_b / (b * omega_a * GasConstant);
+    double tmp = a * omega_b / (m_bMix * omega_a * GasConstant);
     double pp = 2./3.;
     double sqrttc, f, dfdt, deltatc;
 
@@ -878,8 +851,8 @@ void RedlichKwongMFTP::calcCriticalConditions(double& pc, double& tc, double& vc
         tc = pow(tmp, pp);
         for (int j = 0; j < 10; j++) {
             sqrttc = sqrt(tc);
-            f = omega_a * b * GasConstant * tc * sqrttc / omega_b - aT * tc - a0;
-            dfdt = 1.5 * omega_a * b * GasConstant * sqrttc / omega_b - aT;
+            f = omega_a * m_bMix * GasConstant * tc * sqrttc / omega_b - aT * tc - a0;
+            dfdt = 1.5 * omega_a * m_bMix * GasConstant * sqrttc / omega_b - aT;
             deltatc = - f / dfdt;
             tc += deltatc;
         }
@@ -889,7 +862,7 @@ void RedlichKwongMFTP::calcCriticalConditions(double& pc, double& tc, double& vc
         }
     }
 
-    pc = omega_b * GasConstant * tc / b;
+    pc = omega_b * GasConstant * tc / m_bMix;
     vc = omega_vc * GasConstant * tc / pc;
 }
 

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -143,15 +143,13 @@ void RedlichKwongMFTP::getActivityCoefficients(span<double> ac) const
     double vpb = mv + m_bMix;
     double vmb = mv - m_bMix;
 
-    auto x = asVectorXd(moleFractions_);
-    m_pp = m_a * x;
     double pres = pressure();
 
     for (size_t k = 0; k < m_kk; k++) {
         ac[k] = (- RT() * log(pres * mv / RT())
                  + RT() * log(mv / vmb)
                  + RT() * m_b[k] / vmb
-                 - 2.0 * m_pp[k] / (m_bMix * sqt) * log(vpb/mv)
+                 - 2.0 * m_Ak[k] / (m_bMix * sqt) * log(vpb/mv)
                  + m_aMix * m_b[k] / (m_bMix * m_bMix * sqt) * log(vpb/mv)
                  - m_aMix / (m_bMix * sqt) * (m_b[k]/vpb)
                 );
@@ -178,15 +176,13 @@ void RedlichKwongMFTP::getChemPotentials(span<double> mu) const
     double sqt = sqrt(temperature());
     double vpb = mv + m_bMix;
     double vmb = mv - m_bMix;
-
-    m_pp = m_a * asVectorXd(moleFractions_);
     double pres = pressure();
 
     for (size_t k = 0; k < m_kk; k++) {
         mu[k] += (- RT() * log(pres * mv / RT())
                   + RT() * log(mv / vmb)
                   + RT() * m_b[k] / vmb
-                  - 2.0 * m_pp[k] / (m_bMix * sqt) * log(vpb/mv)
+                  - 2.0 * m_Ak[k] / (m_bMix * sqt) * log(vpb/mv)
                   + m_aMix * m_b[k] / (m_bMix * m_bMix * sqt) * log(vpb/mv)
                   - m_aMix / (m_bMix * sqt) * (m_b[k]/vpb)
                  );
@@ -208,18 +204,15 @@ void RedlichKwongMFTP::getPartialMolarEnthalpies(span<double> hbar) const
     double sqt = sqrt(TKelvin);
     double vpb = mv + m_bMix;
     double vmb = mv - m_bMix;
-    auto x = asVectorXd(moleFractions_);
-    m_pp = m_a * x;
-    m_dAkdT = m_a1 * x;
     for (size_t k = 0; k < m_kk; k++) {
-        m_dpdni[k] = RT()/vmb + RT() * m_b[k] / (vmb * vmb) - 2.0 * m_pp[k] / (sqt * mv * vpb)
+        m_dpdni[k] = RT()/vmb + RT() * m_b[k] / (vmb * vmb) - 2.0 * m_Ak[k] / (sqt * mv * vpb)
                     + m_aMix * m_b[k]/(sqt * mv * vpb * vpb);
     }
     double dadt = da_dt();
     double fac = TKelvin * dadt - 3.0 * m_aMix / 2.0;
 
     for (size_t k = 0; k < m_kk; k++) {
-        m_workS[k] = 2.0 * TKelvin * m_dAkdT[k] - 3.0 * m_pp[k];
+        m_workS[k] = 2.0 * TKelvin * m_dAkdT[k] - 3.0 * m_Ak[k];
     }
 
     pressureDerivatives();
@@ -250,12 +243,6 @@ void RedlichKwongMFTP::getPartialMolarEntropies(span<double> sbar) const
     if (m_bMix == 0.0) {
         return;
     }
-    auto x = asVectorXd(moleFractions_);
-    m_pp = m_a * x;
-    m_dAkdT = m_a1 * x;
-    for (size_t k = 0; k < m_kk; k++) {
-        m_workS[k] = m_dAkdT[k];
-    }
 
     double dadt = da_dt();
     double fac = dadt - m_aMix / (2.0 * TKelvin);
@@ -266,8 +253,8 @@ void RedlichKwongMFTP::getPartialMolarEntropies(span<double> sbar) const
                     - GasConstant
                     - GasConstant * log(mv/vmb)
                     - GasConstant * m_b[k]/vmb
-                    - m_pp[k]/(m_bMix * TKelvin * sqt) * log(vpb/mv)
-                    + 2.0 * m_workS[k]/(m_bMix * sqt) * log(vpb/mv)
+                    - m_Ak[k]/(m_bMix * TKelvin * sqt) * log(vpb/mv)
+                    + 2.0 * m_dAkdT[k]/(m_bMix * sqt) * log(vpb/mv)
                     - m_b[k] / (m_bMix * m_bMix * sqt) * log(vpb/mv) * fac
                     + 1.0 / (m_bMix * sqt) * m_b[k] / vpb * fac);
     }
@@ -310,11 +297,6 @@ void RedlichKwongMFTP::getPartialMolarIntEnergies_TV(span<double> utilde) const
         return;
     }
 
-    // A_k = sum_i x_i a_ki and A'_k = dA_k/dT = sum_i x_i a_ki,1
-    auto x = asVectorXd(moleFractions_);
-    m_pp = m_a * x;
-    m_dAkdT = m_a1 * x;
-
     double vpb = mv + b;
     double logv = log(vpb / mv);
     double F = T * dadt - 1.5 * a;
@@ -322,7 +304,7 @@ void RedlichKwongMFTP::getPartialMolarIntEnergies_TV(span<double> utilde) const
     double pref = 1.0 / (b * sqt);
 
     for (size_t k = 0; k < m_kk; k++) {
-        double Sk = 2.0 * T * m_dAkdT[k] - 3.0 * m_pp[k];
+        double Sk = 2.0 * T * m_dAkdT[k] - 3.0 * m_Ak[k];
         double ures = pref * (logv * Sk + m_b[k] * F * C);
         utilde[k] += ures;
     }
@@ -368,11 +350,6 @@ void RedlichKwongMFTP::getPartialMolarCp(span<double> cpbar) const
             / (sqt * v * v * v * vpb * vpb * vpb);
     double d2vdT2_P = -(pTT + 2.0 * pTV * dvdT_P + pVV * dvdT_P * dvdT_P) / pV;
 
-    // Species-dependent A_k and dA_k/dT
-    auto x = asVectorXd(moleFractions_);
-    m_pp = m_a * x;
-    m_dAkdT = m_a1 * x;
-
     double F = T * dadt - 1.5 * a;
     double dF_dT = -0.5 * dadt + T * d2adt2;
     double logvpv = log(vpb / v);
@@ -380,7 +357,7 @@ void RedlichKwongMFTP::getPartialMolarCp(span<double> cpbar) const
 
     for (size_t k = 0; k < m_kk; k++) {
         double bk = m_b[k];
-        double Ak = m_pp[k];
+        double Ak = m_Ak[k];
         double dAk = m_dAkdT[k];
         double Sk = 2.0 * T * dAk - 3.0 * Ak;
         double dSk_dT = -dAk; // for linear a(T)
@@ -438,11 +415,6 @@ void RedlichKwongMFTP::getPartialMolarCv_TV(span<double> cvtilde) const
         return;
     }
 
-    // A_k = sum_i x_i a_ki and A'_k = dA_k/dT = sum_i x_i a_ki,1
-    auto x = asVectorXd(moleFractions_);
-    m_pp = m_a * x;
-    m_dAkdT = m_a1 * x;
-
     // Residual contribution for
     // \tilde{u}_k = (\partial U / \partial n_k)_{T,V,n_j}
     // with linear a(T): a_ij = a_ij,0 + a_ij,1 T
@@ -453,7 +425,7 @@ void RedlichKwongMFTP::getPartialMolarCv_TV(span<double> cvtilde) const
     double pref = 1.0 / (b * sqt);
 
     for (size_t k = 0; k < m_kk; k++) {
-        double Sk = 2.0 * T * m_dAkdT[k] - 3.0 * m_pp[k];
+        double Sk = 2.0 * T * m_dAkdT[k] - 3.0 * m_Ak[k];
         double ures = pref * (logv * Sk + m_b[k] * F * C);
         double dresdT = pref * (-logv * m_dAkdT[k] - 0.5 * m_b[k] * dadt * C)
             - 0.5 * ures / T;
@@ -464,13 +436,6 @@ void RedlichKwongMFTP::getPartialMolarCv_TV(span<double> cvtilde) const
 void RedlichKwongMFTP::getPartialMolarVolumes(span<double> vbar) const
 {
     checkArraySize("RedlichKwongMFTP::getPartialMolarVolumes", vbar.size(), m_kk);
-    auto x = asVectorXd(moleFractions_);
-    m_pp = m_a * x;
-    m_dAkdT = m_a1 * x;
-    for (size_t k = 0; k < m_kk; k++) {
-        m_workS[k] = m_dAkdT[k];
-    }
-
     double sqt = sqrt(temperature());
     double mv = molarVolume();
     double vmb = mv - m_bMix;
@@ -478,7 +443,7 @@ void RedlichKwongMFTP::getPartialMolarVolumes(span<double> vbar) const
     for (size_t k = 0; k < m_kk; k++) {
         double num = (RT() + RT() * m_bMix/ vmb + RT() * m_b[k] / vmb
                           + RT() * m_bMix * m_b[k] /(vmb * vmb)
-                          - 2.0 * m_pp[k] / (sqt * vpb)
+                          - 2.0 * m_Ak[k] / (sqt * vpb)
                           + m_aMix * m_b[k] / (sqt * vpb * vpb)
                          );
         double denom = (pressure() + RT() * m_bMix/(vmb * vmb) - m_aMix / (sqt * vpb * vpb)
@@ -508,7 +473,7 @@ bool RedlichKwongMFTP::addSpecies(shared_ptr<Species> spec)
         m_a1.row(k).setConstant(NAN);
         m_a1.col(k).setConstant(NAN);
 
-        m_pp.conservativeResizeLike(Eigen::VectorXd::Zero(m_kk));
+        m_Ak.conservativeResizeLike(Eigen::VectorXd::Zero(m_kk));
         m_dAkdT.conservativeResizeLike(Eigen::VectorXd::Zero(m_kk));
         m_coeffSource.push_back(CoeffSource::EoS);
         m_partialMolarVolumes.push_back(0.0);
@@ -874,15 +839,15 @@ void RedlichKwongMFTP::pressureDerivatives() const
 void RedlichKwongMFTP::updateMixingExpressions()
 {
     double temp = temperature();
+    auto x = asVectorXd(moleFractions_);
     if (m_formTempParam == 1) {
         m_a = m_a0 + temp * m_a1;
+        m_dAkdT = m_a1 * x;
     }
 
-    auto x = asVectorXd(moleFractions_);
-    const auto& b_k = m_b;
-    m_bMix = 0.0;
-    m_bMix = b_k.dot(x);
-    m_aMix = x.dot(m_a * x);
+    m_bMix = m_b.dot(x);
+    m_Ak = m_a * x;
+    m_aMix = x.dot(m_Ak);
     if (isnan(m_bMix)) {
         // One or more species do not have specified coefficients.
         fmt::memory_buffer b;

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -142,21 +142,13 @@ void RedlichKwongMFTP::getActivityCoefficients(span<double> ac) const
     double sqt = sqrt(temperature());
     double vpb = mv + m_bMix;
     double vmb = mv - m_bMix;
-
     double pres = pressure();
-
-    for (size_t k = 0; k < m_kk; k++) {
-        ac[k] = (- RT() * log(pres * mv / RT())
-                 + RT() * log(mv / vmb)
-                 + RT() * m_b[k] / vmb
-                 - 2.0 * m_Ak[k] / (m_bMix * sqt) * log(vpb/mv)
-                 + m_aMix * m_b[k] / (m_bMix * m_bMix * sqt) * log(vpb/mv)
-                 - m_aMix / (m_bMix * sqt) * (m_b[k]/vpb)
-                );
-    }
-    for (size_t k = 0; k < m_kk; k++) {
-        ac[k] = exp(ac[k]/RT());
-    }
+    double logv = log(vpb / mv);
+    Eigen::ArrayXd g = RT() * (log(RT() / (vmb * pres)) + m_b / vmb)
+        - 2.0 * m_Ak / (m_bMix * sqt) * logv
+        + m_aMix * m_b / (m_bMix * m_bMix * sqt) * logv
+        - m_aMix * m_b / (m_bMix * sqt * vpb);
+    MappedVector(ac.data(), m_kk) = (g / RT()).exp();
 }
 
 // ---- Partial Molar Properties of the Solution -----------------
@@ -164,10 +156,9 @@ void RedlichKwongMFTP::getActivityCoefficients(span<double> ac) const
 void RedlichKwongMFTP::getChemPotentials(span<double> mu) const
 {
     getStandardChemPotentials(mu);
-    for (size_t k = 0; k < m_kk; k++) {
-        double xx = std::max(SmallNumber, moleFraction(k));
-        mu[k] += RT() * log(xx);
-    }
+    Eigen::Map<Eigen::ArrayXd> muVec(mu.data(), m_kk);
+    auto x = asVectorXd(moleFractions_);
+    muVec += RT() * x.array().max(SmallNumber).log();
     if (m_bMix == 0.0) {
         return;
     }
@@ -176,17 +167,12 @@ void RedlichKwongMFTP::getChemPotentials(span<double> mu) const
     double sqt = sqrt(temperature());
     double vpb = mv + m_bMix;
     double vmb = mv - m_bMix;
-    double pres = pressure();
-
-    for (size_t k = 0; k < m_kk; k++) {
-        mu[k] += (- RT() * log(pres * mv / RT())
-                  + RT() * log(mv / vmb)
-                  + RT() * m_b[k] / vmb
-                  - 2.0 * m_Ak[k] / (m_bMix * sqt) * log(vpb/mv)
-                  + m_aMix * m_b[k] / (m_bMix * m_bMix * sqt) * log(vpb/mv)
-                  - m_aMix / (m_bMix * sqt) * (m_b[k]/vpb)
-                 );
-    }
+    double logv = log(vpb / mv);
+    muVec += RT() * log(RT() / (vmb * pressure()))
+        + RT() * m_b / vmb
+        - 2.0 * m_Ak / (m_bMix * sqt) * logv
+        + m_aMix * m_b / (m_bMix * m_bMix * sqt) * logv
+        - m_aMix * m_b / (m_bMix * sqt * vpb);
 }
 
 void RedlichKwongMFTP::getPartialMolarEnthalpies(span<double> hbar) const
@@ -204,66 +190,54 @@ void RedlichKwongMFTP::getPartialMolarEnthalpies(span<double> hbar) const
     double sqt = sqrt(TKelvin);
     double vpb = mv + m_bMix;
     double vmb = mv - m_bMix;
-    for (size_t k = 0; k < m_kk; k++) {
-        m_dpdni[k] = RT()/vmb + RT() * m_b[k] / (vmb * vmb) - 2.0 * m_Ak[k] / (sqt * mv * vpb)
-                    + m_aMix * m_b[k]/(sqt * mv * vpb * vpb);
-    }
+    m_dpdni = RT() / vmb * (1.0 + m_b / vmb)
+        - 2.0 * m_Ak / (sqt * mv * vpb)
+        + m_aMix * m_b / (sqt * mv * vpb * vpb);
     double dadt = da_dt();
     double fac = TKelvin * dadt - 3.0 * m_aMix / 2.0;
-
-    for (size_t k = 0; k < m_kk; k++) {
-        m_workS[k] = 2.0 * TKelvin * m_dAkdT[k] - 3.0 * m_Ak[k];
-    }
+    Eigen::ArrayXd Sk = 2.0 * TKelvin * m_dAkdT - 3.0 * m_Ak;
 
     pressureDerivatives();
     double fac2 = mv + TKelvin * dpdT_ / dpdV_;
-    for (size_t k = 0; k < m_kk; k++) {
-        double hE_v = (mv * m_dpdni[k] - RT() - m_b[k]/ (m_bMix * m_bMix * sqt) * log(vpb/mv)*fac
-                       + 1.0 / (m_bMix * sqt) * log(vpb/mv) * m_workS[k]
-                       +  m_b[k] / vpb / (m_bMix * sqt) * fac);
-        hbar[k] = hbar[k] + hE_v;
-        hbar[k] -= fac2 * m_dpdni[k];
-    }
+    double logv = log(vpb / mv);
+    Eigen::ArrayXd hE_v = mv * m_dpdni
+        - RT()
+        - m_b / (m_bMix * m_bMix * sqt) * logv * fac
+        + (1.0 / (m_bMix * sqt) * logv) * Sk
+        + m_b / (vpb * m_bMix * sqt) * fac;
+    Eigen::Map<Eigen::ArrayXd>(hbar.data(), m_kk) += hE_v - fac2 * m_dpdni;
 }
 
 void RedlichKwongMFTP::getPartialMolarEntropies(span<double> sbar) const
 {
     getEntropy_R_ref(sbar);
-    scale(sbar.begin(), sbar.end(), sbar.begin(), GasConstant);
     double TKelvin = temperature();
     double sqt = sqrt(TKelvin);
     double mv = molarVolume();
     double pres = pressure();
-    double logPres = log(pres / refPressure());
 
-    for (size_t k = 0; k < m_kk; k++) {
-        double xx = std::max(SmallNumber, moleFraction(k));
-        sbar[k] -= GasConstant * (log(xx) + logPres);
-    }
+    MappedVector sbarVec(sbar.data(), m_kk);
+    sbarVec -= asVectorXd(moleFractions_).array().max(SmallNumber).log().matrix();
+    sbarVec.array() -= log(pres / refPressure());
+    sbarVec *= GasConstant;
     if (m_bMix == 0.0) {
         return;
     }
-
-    double dadt = da_dt();
-    double fac = dadt - m_aMix / (2.0 * TKelvin);
+    double fac = da_dt() - m_aMix / (2.0 * TKelvin);
     double vmb = mv - m_bMix;
     double vpb = mv + m_bMix;
-    for (size_t k = 0; k < m_kk; k++) {
-        sbar[k] += (GasConstant * log(pres * mv / RT())
-                    - GasConstant
-                    - GasConstant * log(mv/vmb)
-                    - GasConstant * m_b[k]/vmb
-                    - m_Ak[k]/(m_bMix * TKelvin * sqt) * log(vpb/mv)
-                    + 2.0 * m_dAkdT[k]/(m_bMix * sqt) * log(vpb/mv)
-                    - m_b[k] / (m_bMix * m_bMix * sqt) * log(vpb/mv) * fac
-                    + 1.0 / (m_bMix * sqt) * m_b[k] / vpb * fac);
-    }
+    double logv = log(vpb / mv);
+    Eigen::ArrayXd sdep = GasConstant * (log(RT() / (pres * vmb)) + 1)
+        + GasConstant * m_b / vmb
+        + m_Ak / (m_bMix * TKelvin * sqt) * logv
+        - 2.0 * m_dAkdT / (m_bMix * sqt) * logv
+        + m_b / (m_bMix * m_bMix * sqt) * logv * fac
+        - m_b / (m_bMix * sqt * vpb) * fac;
+    sbarVec -= sdep.matrix();
 
     pressureDerivatives();
     getPartialMolarVolumes(m_partialMolarVolumes);
-    for (size_t k = 0; k < m_kk; k++) {
-        sbar[k] += m_partialMolarVolumes[k] * dpdT_;
-    }
+    sbarVec += dpdT_ * asVectorXd(m_partialMolarVolumes);
 }
 
 void RedlichKwongMFTP::getPartialMolarIntEnergies(span<double> ubar) const
@@ -289,9 +263,8 @@ void RedlichKwongMFTP::getPartialMolarIntEnergies_TV(span<double> utilde) const
     double a = m_aMix;
     double dadt = da_dt();
 
-    for (size_t k = 0; k < m_kk; k++) {
-        utilde[k] = RT() * (m_h0_RT[k] - 1.0);
-    }
+    Eigen::Map<Eigen::ArrayXd> utildeVec(utilde.data(), m_kk);
+    utildeVec = RT() * (asVectorXd(m_h0_RT).array() - 1.0);
 
     if (fabs(b) < SmallNumber) {
         return;
@@ -303,11 +276,8 @@ void RedlichKwongMFTP::getPartialMolarIntEnergies_TV(span<double> utilde) const
     double C = -logv / b + 1.0 / vpb;
     double pref = 1.0 / (b * sqt);
 
-    for (size_t k = 0; k < m_kk; k++) {
-        double Sk = 2.0 * T * m_dAkdT[k] - 3.0 * m_Ak[k];
-        double ures = pref * (logv * Sk + m_b[k] * F * C);
-        utilde[k] += ures;
-    }
+    Eigen::ArrayXd Sk = 2.0 * T * m_dAkdT - 3.0 * m_Ak;
+    utildeVec += pref * (logv * Sk + m_b * F * C);
 }
 
 void RedlichKwongMFTP::getPartialMolarCp(span<double> cpbar) const
@@ -407,9 +377,8 @@ void RedlichKwongMFTP::getPartialMolarCv_TV(span<double> cvtilde) const
     double a = m_aMix;
     double dadt = da_dt();
 
-    for (size_t k = 0; k < m_kk; k++) {
-        cvtilde[k] = GasConstant * (m_cp0_R[k] - 1.0);
-    }
+    Eigen::Map<Eigen::ArrayXd> cvtildeVec(cvtilde.data(), m_kk);
+    cvtildeVec = GasConstant * (asVectorXd(m_cp0_R).array() - 1.0);
 
     if (fabs(b) < SmallNumber) {
         return;
@@ -424,13 +393,11 @@ void RedlichKwongMFTP::getPartialMolarCv_TV(span<double> cvtilde) const
     double C = -logv / b + 1.0 / vpb;
     double pref = 1.0 / (b * sqt);
 
-    for (size_t k = 0; k < m_kk; k++) {
-        double Sk = 2.0 * T * m_dAkdT[k] - 3.0 * m_Ak[k];
-        double ures = pref * (logv * Sk + m_b[k] * F * C);
-        double dresdT = pref * (-logv * m_dAkdT[k] - 0.5 * m_b[k] * dadt * C)
-            - 0.5 * ures / T;
-        cvtilde[k] += dresdT;
-    }
+    Eigen::ArrayXd Sk = 2.0 * T * m_dAkdT - 3.0 * m_Ak;
+    Eigen::ArrayXd ures = pref * (logv * Sk + m_b * F * C);
+    Eigen::ArrayXd dresdT = - pref * (logv * m_dAkdT + 0.5 * m_b * dadt * C)
+        - 0.5 * ures / T;
+    cvtildeVec += dresdT;
 }
 
 void RedlichKwongMFTP::getPartialMolarVolumes(span<double> vbar) const
@@ -440,16 +407,11 @@ void RedlichKwongMFTP::getPartialMolarVolumes(span<double> vbar) const
     double mv = molarVolume();
     double vmb = mv - m_bMix;
     double vpb = mv + m_bMix;
-    for (size_t k = 0; k < m_kk; k++) {
-        double num = (RT() + RT() * m_bMix/ vmb + RT() * m_b[k] / vmb
-                          + RT() * m_bMix * m_b[k] /(vmb * vmb)
-                          - 2.0 * m_Ak[k] / (sqt * vpb)
-                          + m_aMix * m_b[k] / (sqt * vpb * vpb)
-                         );
-        double denom = (pressure() + RT() * m_bMix/(vmb * vmb) - m_aMix / (sqt * vpb * vpb)
-                           );
-        vbar[k] = num / denom;
-    }
+    Eigen::ArrayXd num = RT() * (1.0 + (m_bMix + m_b) / vmb + m_bMix * m_b / (vmb * vmb))
+        - 2.0 * m_Ak / (sqt * vpb)
+        + m_aMix * m_b / (sqt * vpb * vpb);
+    double denom = pressure() + RT() * m_bMix / (vmb * vmb) - m_aMix / (sqt * vpb * vpb);
+    MappedVector(vbar.data(), m_kk) = num / denom;
 }
 
 bool RedlichKwongMFTP::addSpecies(shared_ptr<Species> spec)
@@ -792,9 +754,8 @@ double RedlichKwongMFTP::dpdVCalc(double TKelvin, double molarVol, double& presC
 
     double vpb = molarVol + m_bMix;
     double vmb = molarVol - m_bMix;
-    double dpdv = (- GasConstant * TKelvin / (vmb * vmb)
-                       + m_aMix * (2 * molarVol + m_bMix) / (sqt * molarVol * molarVol * vpb * vpb));
-    return dpdv;
+    return - GasConstant * TKelvin / (vmb * vmb)
+        + m_aMix * (2 * molarVol + m_bMix) / (sqt * molarVol * molarVol * vpb * vpb);
 }
 
 double RedlichKwongMFTP::isothermalCompressibility() const
@@ -845,9 +806,9 @@ void RedlichKwongMFTP::updateMixingExpressions()
         m_dAkdT = m_a1 * x;
     }
 
-    m_bMix = m_b.dot(x);
+    m_bMix = m_b.matrix().dot(x);
     m_Ak = m_a * x;
-    m_aMix = x.dot(m_Ak);
+    m_aMix = x.dot(m_Ak.matrix());
     if (isnan(m_bMix)) {
         // One or more species do not have specified coefficients.
         fmt::memory_buffer b;
@@ -868,8 +829,7 @@ void RedlichKwongMFTP::updateMixingExpressions()
 void RedlichKwongMFTP::calculateAB(double temp, double& aCalc, double& bCalc) const
 {
     auto x = asVectorXd(moleFractions_);
-    const auto& b_k = m_b;
-    bCalc = b_k.dot(x);
+    bCalc = m_b.matrix().dot(x);
     if (m_formTempParam == 1) {
         aCalc = x.dot((m_a0 + temp * m_a1) * x);
     } else {


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Use Eigen to vectorize most property calculations in `RedlichKwongMFTP`
- Rename some internal variables in `RedlichKwongMFTP` to have simpler, more clear names

**If applicable, provide an example illustrating new features this pull request is introducing**

Besides simplifying the implementation, this provides a substantial speed benefit to the calculations -- more than I was expecting. Average time for the cases in the `non_ideal_shock_tube.py` example (using the `main` branch after merging #2094 as a baseline):

- *Baseline*
  - `MoleReactor` (no preconditioner): 5.525 s
  - `IdealGasMoleReactor` without preconditioner: 1.988 s
  - `IdealGasMoleReactor` with preconditioner: 1.004 s
- *Vectorized*
  - `MoleReactor` (no preconditioner): 1.131 s
  - `IdealGasMoleReactor` without preconditioner: 0.345 s
  - `IdealGasMoleReactor` with preconditioner: 0.228 s

So this provides another factor of 4 speed up, on top of the performance gains from #2094, and brings the Redlich-Kwong integration time to within about a factor of 2 compared to a calculation using the ideal gas model.

Some ad hoc testing suggests that there are similar speed ups for calculations like constant HP equilibrium.

**AI Statement (required)**

- **Extensive use of generative AI.** Significant portions of code or documentation were generated with AI, including
  logic and implementation decisions. All generated code and documentation were reviewed and understood by the contributor. *Prepared with the help of ChatGPT Codex 5.3*.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
