### PR TITLE
Fix duplicate YAML map keys revealed by yaml-cpp post-merge tests

### DIFF
--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -740,6 +740,10 @@ def regression_test(target: "LFSNode", source: "LFSNode", env: "SCEnvironment"):
     )
     if ret.returncode:
         logger.error("FAILED (program exit code:{})", ret.returncode)
+        if ret.stdout:
+            logger.error("program stdout:\n{}", ret.stdout, print_level=False)
+        if ret.stderr:
+            logger.error("program stderr:\n{}", ret.stderr, print_level=False)
     dir.joinpath(output_name).write_text(ret.stdout)
 
     diff = 0

--- a/test/data/debye-huckel-all.yaml
+++ b/test/data/debye-huckel-all.yaml
@@ -23,7 +23,6 @@ phases:
 - name: debye-huckel-dilute-IAPWS
   elements: [O, H, C, E, Fe, Si, N, Na, Cl]
   species:
-  species:
   - water_IAPWS: [H2O(L)]
   - species_waterSolution: [Na+, Cl-, H+, OH-, NaCl(aq), NaOH(aq), SiO2(aq),
       NaH3SiO4(aq), H3SiO4-]

--- a/test/python/test_reaction.py
+++ b/test/python/test_reaction.py
@@ -1,4 +1,5 @@
 import gc
+import re
 import numpy as np
 from pathlib import Path
 import pytest
@@ -252,9 +253,10 @@ class ReactionRateTests:
 
     def test_with_units(self):
         # test custom units. Sticking coefficients are dimensionless, so this is only
-        # a concern for other rate types
+        # a concern for other rate types. Strip any existing custom units first.
         units = "units: {length: cm, quantity: mol}"
-        yaml = f"{textwrap.dedent(self._yaml)}\n{units}"
+        yaml = re.sub(r"units:.*", "", self._yaml)
+        yaml = f"{textwrap.dedent(yaml)}\n{units}"
         if "sticking" not in yaml:
             with pytest.raises(Exception, match="undefined units"):
                 ct.ReactionRate.from_yaml(yaml)


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Print stdout/stderr output from `test_problems` tests that exit with a non-zero error code. This helps provide more useful logs when these tests fail.
- Fix duplicate YAML map keys in a couple of test data files. These are now being caught as errors by the latest development version of `yaml-cpp`.

**If applicable, fill in the issue number this pull request is fixing**

Fixes recent CI failures of the `post-merge-tests` workflow.

**AI Statement (required)**

- **No generative AI was used.** This contribution was written entirely without AI assistance.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
