### PR TITLE
Fix cloning/serializing phases with custom element definitions

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -258,6 +258,16 @@ if "pyodide-wheel" in COMMAND_LINE_TARGETS:
     logger.info(message, print_level=False)
     sys.exit(0)
 
+
+def add_rpath_link_flags(env, paths):
+    """Add ELF linker search paths for indirect shared library dependencies."""
+    if env["OS"] != "Linux" or not env["use_rpath_linkage"]:
+        return
+    if isinstance(paths, str):
+        paths = [paths]
+    env.AppendUnique(LINKFLAGS=[f"-Wl,-rpath-link,{p}" for p in paths if p])
+
+
 # ******************************************
 # *** Specify defaults for SCons options ***
 # ******************************************
@@ -1107,6 +1117,7 @@ env.Append(LIBPATH=env['extra_lib_dirs'])
 
 if env['use_rpath_linkage']:
     env.Append(RPATH=env['extra_lib_dirs'])
+    add_rpath_link_flags(env, env['extra_lib_dirs'])
 
 if env['CC'] == 'cl':
     # embed manifest file
@@ -1127,6 +1138,7 @@ if env['blas_lapack_dir']:
     env.Append(LIBPATH=[env['blas_lapack_dir']])
     if env['use_rpath_linkage']:
         env.Append(RPATH=env['blas_lapack_dir'])
+        add_rpath_link_flags(env, env['blas_lapack_dir'])
 
 if env['system_sundials'] in ('y','default'):
     if env['sundials_include']:
@@ -1139,6 +1151,7 @@ if env['system_sundials'] in ('y','default'):
         env['system_sundials'] = 'y'
         if env['use_rpath_linkage']:
             env.Append(RPATH=env['sundials_libdir'])
+            add_rpath_link_flags(env, env['sundials_libdir'])
 
 # BLAS / LAPACK configuration
 if env['blas_lapack_libs'] != '':
@@ -1502,6 +1515,7 @@ if env["hdf_libdir"] and env["hdf_support"] in ("y", "default"):
     env["hdf_support"] = "y"
     if env["use_rpath_linkage"]:
         env.Append(RPATH=env["hdf_libdir"])
+        add_rpath_link_flags(env, env["hdf_libdir"])
 
 if env["hdf_support"] == "n":
     env["use_hdf5"] = False
@@ -1823,6 +1837,7 @@ for loc in locations:
 
 if env['use_rpath_linkage']:
     env.Append(RPATH=env['ct_libdir'])
+    add_rpath_link_flags(env, env['ct_libdir'])
 
 # **************************************
 # *** Set options needed in config.h ***

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -10,6 +10,7 @@
 #define CT_PHASE_H
 
 #include "cantera/base/ctexceptions.h"
+#include "cantera/base/AnyMap.h"
 #include "cantera/thermo/Elements.h"
 #include "cantera/base/ValueCache.h"
 
@@ -706,6 +707,12 @@ public:
     size_t addElement(const string& symbol, double weight=-12345.0,
                       int atomicNumber=0, double entropy298=ENTROPY298_UNKNOWN,
                       int elem_type=CT_ELEM_TYPE_ABSPOS);
+
+    //! Return explicit element definitions needed to reconstruct this phase.
+    //! Elements that can be recreated unambiguously from the default database
+    //! are omitted.
+    //! @since New in %Cantera 4.0.
+    vector<AnyMap> elementDefinitions() const;
 
     //! Add a Species to this Phase. Returns `true` if the species was
     //! successfully added, or `false` if the species was ignored.

--- a/interfaces/cython/cantera/composite.pyi
+++ b/interfaces/cython/cantera/composite.pyi
@@ -165,7 +165,7 @@ class Quantity:
     def write_yaml(
         self,
         filename: None,
-        phases: Sequence[ThermoPhase] | None = None,
+        phases: Sequence[ThermoPhase] | ThermoPhase | None = None,
         units: UnitSystem | _UnitDict | None = None,
         precision: int | None = None,
         skip_user_defined: bool | None = None,
@@ -175,7 +175,7 @@ class Quantity:
     def write_yaml(
         self,
         filename: str | Path,
-        phases: Sequence[ThermoPhase] | None = None,
+        phases: Sequence[ThermoPhase] | ThermoPhase | None = None,
         units: UnitSystem | _UnitDict | None = None,
         precision: int | None = None,
         skip_user_defined: bool | None = None,
@@ -185,7 +185,7 @@ class Quantity:
     def write_yaml(
         self,
         filename: str | Path | None = None,
-        phases: Sequence[ThermoPhase] | None = None,
+        phases: Sequence[ThermoPhase] | ThermoPhase | None = None,
         units: UnitSystem | _UnitDict | None = None,
         precision: int | None = None,
         skip_user_defined: bool | None = None,

--- a/interfaces/cython/cantera/kinetics.pyi
+++ b/interfaces/cython/cantera/kinetics.pyi
@@ -184,7 +184,7 @@ class InterfaceKinetics(Kinetics):
     def write_yaml(  # type: ignore[override]
         self,
         filename: Path | str,
-        phases: Sequence[ThermoPhase] | None = None,
+        phases: Sequence[ThermoPhase] | ThermoPhase | None = None,
         units: UnitSystem | _UnitDict | None = None,
         precision: int | None = None,
         skip_user_defined: bool | None = None,

--- a/interfaces/cython/cantera/solutionbase.pyi
+++ b/interfaces/cython/cantera/solutionbase.pyi
@@ -76,7 +76,7 @@ class _SolutionBase:
     def write_yaml(
         self,
         filename: None = None,
-        phases: Sequence[ThermoPhase] | None = None,
+        phases: Sequence[ThermoPhase] | ThermoPhase |None = None,
         units: UnitSystem | _UnitDict | None = None,
         precision: int | None = None,
         skip_user_defined: bool | None = None,
@@ -86,7 +86,7 @@ class _SolutionBase:
     def write_yaml(
         self,
         filename: str | Path,
-        phases: Sequence[ThermoPhase] | None = None,
+        phases: Sequence[ThermoPhase] | ThermoPhase | None = None,
         units: UnitSystem | _UnitDict | None = None,
         precision: int | None = None,
         skip_user_defined: bool | None = None,

--- a/pixi.toml
+++ b/pixi.toml
@@ -31,6 +31,9 @@ pytest = ">=9.0.2,<10"
 "ruamel.yaml" = ">=0.19.1,<0.20"
 jinja2 = ">=3.1.6,<4"
 
+[feature.core.target.linux-64.dependencies]
+clangxx = ">=18.0"
+
 [feature.samples.dependencies]
 pandas = ">=3.0.0,<4"
 scipy = ">=1.17.0,<2"

--- a/src/base/YamlWriter.cpp
+++ b/src/base/YamlWriter.cpp
@@ -97,6 +97,28 @@ string YamlWriter::toYamlString() const
     }
     output["phases"] = phaseDefs;
 
+    // Build custom element definitions needed by any phase
+    vector<AnyMap> elementDefs;
+    std::unordered_map<string, size_t> elementDefIndex;
+    for (const auto& phase : m_phases) {
+        for (auto& elementDef : phase->thermo()->elementDefinitions()) {
+            const string& symbol = elementDef["symbol"].asString();
+            if (elementDefIndex.count(symbol) == 0) {
+                elementDefs.emplace_back(std::move(elementDef));
+                elementDefIndex[symbol] = elementDefs.size() - 1;
+            } else if (elementDefs[elementDefIndex[symbol]] != elementDef) {
+                throw CanteraError("YamlWriter::toYamlString",
+                    "Multiple elements with different definitions are not "
+                    "supported:\n>>>>>>\n{}\n======\n{}\n<<<<<<\n",
+                    elementDef.toYamlString(),
+                    elementDefs[elementDefIndex[symbol]].toYamlString());
+            }
+        }
+    }
+    if (!elementDefs.empty()) {
+        output["elements"] = std::move(elementDefs);
+    }
+
     // Build species definitions for all phases
     vector<AnyMap> speciesDefs;
     speciesDefs.reserve(nspecies_total);

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -705,6 +705,58 @@ size_t Phase::addElement(const string& symbol, double weight, int atomic_number,
     return m_mm-1;
 }
 
+vector<AnyMap> Phase::elementDefinitions() const
+{
+    vector<AnyMap> definitions;
+    definitions.reserve(nElements());
+    const static AnyMap db = AnyMap::fromYamlFile("element-standard-entropies.yaml");
+    const static auto standardEntropies = db["elements"].asMap("symbol");
+    const auto& weights = elementWeights();
+
+    for (size_t m = 0; m < nElements(); m++) {
+        const string& symbol = m_elementNames[m];
+        bool exportDefinition = false;
+        AnyMap element;
+        element["symbol"] = symbol;
+
+        auto weightIter = weights.find(symbol);
+        if (weightIter == weights.end()) {
+            exportDefinition = true;
+            element["atomic-weight"] = m_atomicWeights[m];
+        } else if (m_atomicWeights[m] != weightIter->second) {
+            exportDefinition = true;
+            element["atomic-weight"] = m_atomicWeights[m];
+        }
+
+        if (m_atomicNumbers[m] != 0) {
+            exportDefinition = true;
+            element["atomic-number"] = m_atomicNumbers[m];
+        }
+
+        if (m_entropy298[m] != ENTROPY298_UNKNOWN) {
+            auto entropyIter = standardEntropies.find(symbol);
+            if (entropyIter == standardEntropies.end()
+                || !entropyIter->second->hasKey("entropy298"))
+            {
+                exportDefinition = true;
+                element["entropy298"].setQuantity(m_entropy298[m], "J/kmol/K");
+            } else {
+                double defaultEntropy =
+                    entropyIter->second->convert("entropy298", "J/kmol/K");
+                if (m_entropy298[m] != defaultEntropy) {
+                    exportDefinition = true;
+                    element["entropy298"].setQuantity(m_entropy298[m], "J/kmol/K");
+                }
+            }
+        }
+
+        if (exportDefinition) {
+            definitions.push_back(std::move(element));
+        }
+    }
+    return definitions;
+}
+
 bool Phase::addSpecies(shared_ptr<Species> spec)
 {
     if (m_nSpeciesLocks) {

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -29,6 +29,10 @@ shared_ptr<ThermoPhase> ThermoPhase::clone() const
 {
     AnyMap phase = parameters();
     AnyMap root;
+    auto elementDefs = elementDefinitions();
+    if (!elementDefs.empty()) {
+        root["elements"] = std::move(elementDefs);
+    }
     vector<AnyMap> speciesDefs;
     speciesDefs.reserve(nSpecies());
     for (const auto& name : speciesNames()) {

--- a/test/data/ideal-gas.yaml
+++ b/test/data/ideal-gas.yaml
@@ -81,6 +81,47 @@ phases:
   reactions: [test_subdir/species-elements.yaml/nox-reactions]
   state: {T: 300.0, P: 1 atm, X: {N2: 1.0}}
 
+- name: custom-elements
+  thermo: ideal-gas
+  elements:
+  - custom-elements: [X, Q]
+  species:
+  - custom-elements-species: [X, Q]
+  state: {T: 300.0, P: 1 atm, X: {X: 0.5, Q: 0.5}}
+
+# Custom element definitions (not in the standard list)
+custom-elements:
+- symbol: X
+  atomic-weight: 10.0
+  entropy298: 50000.0
+- symbol: Q
+  atomic-weight: 15.0
+  atomic-number: 0
+
+# Custom species definitions
+custom-elements-species:
+- name: X
+  composition: {X: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.00, 1000.00, 5000.00]
+    data:
+    - [2.500000000E+00, 0.000000000E+00, 0.000000000E+00, 0.000000000E+00,
+       0.000000000E+00, -7.453750000E+02, 4.366000000E+00]
+    - [2.500000000E+00, 0.000000000E+00, 0.000000000E+00, 0.000000000E+00,
+       0.000000000E+00, -7.453750000E+02, 4.366000000E+00]
+
+- name: Q
+  composition: {Q: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.00, 1000.00, 5000.00]
+    data:
+    - [2.500000000E+00, 0.000000000E+00, 0.000000000E+00, 0.000000000E+00,
+       0.000000000E+00, -7.453750000E+02, 4.366000000E+00]
+    - [2.500000000E+00, 0.000000000E+00, 0.000000000E+00, 0.000000000E+00,
+       0.000000000E+00, -7.453750000E+02, 4.366000000E+00]
+
 elements:
 - symbol: Ar
   atomic-weight: 36

--- a/test/data/ideal-gas.yaml
+++ b/test/data/ideal-gas.yaml
@@ -89,6 +89,25 @@ phases:
   - custom-elements-species: [X, Q]
   state: {T: 300.0, P: 1 atm, X: {X: 0.5, Q: 0.5}}
 
+# Two phases with conflicting element definitions for 'X'.
+# Used to test YamlWriter exception when serializing multiple
+# phases that define the same element symbol differently.
+- name: conflict-phase-A
+  thermo: ideal-gas
+  elements:
+  - custom-elements-a: [X]
+  species:
+  - custom-elements-species: [X]
+  state: {T: 300.0, P: 1 atm, X: {X: 1.0}}
+
+- name: conflict-phase-B
+  thermo: ideal-gas
+  elements:
+  - custom-elements-b: [X]
+  species:
+  - custom-elements-species: [X]
+  state: {T: 300.0, P: 1 atm, X: {X: 1.0}}
+
 # Custom element definitions (not in the standard list)
 custom-elements:
 - symbol: X
@@ -121,6 +140,15 @@ custom-elements-species:
        0.000000000E+00, -7.453750000E+02, 4.366000000E+00]
     - [2.500000000E+00, 0.000000000E+00, 0.000000000E+00, 0.000000000E+00,
        0.000000000E+00, -7.453750000E+02, 4.366000000E+00]
+
+# Conflicting element definitions for testing YamlWriter exception
+custom-elements-a:
+- symbol: X
+  atomic-weight: 10.0
+
+custom-elements-b:
+- symbol: X
+  atomic-weight: 20.0
 
 elements:
 - symbol: Ar

--- a/test/thermo/thermoFromYaml.cpp
+++ b/test/thermo/thermoFromYaml.cpp
@@ -67,6 +67,36 @@ TEST(ThermoFromYaml, cloneRemoteCustomElements)
     EXPECT_DOUBLE_EQ(duplicate->cp_mass(), original->thermo()->cp_mass());
 }
 
+TEST(ThermoFromYaml, customElementDefinitions)
+{
+    auto thermo = std::dynamic_pointer_cast<Phase>(newThermo("ideal-gas.yaml",
+        "custom-elements"));
+    EXPECT_EQ(thermo->nElements(), (size_t) 2);
+
+    // Element X is not in the standard element list, has atomic-weight and entropy298
+    auto definitions = thermo->elementDefinitions();
+    ASSERT_EQ(definitions.size(), (size_t) 2);
+
+    // Find element X definition
+    bool foundX = false;
+    bool foundQ = false;
+    for (const auto& def : definitions) {
+        if (def["symbol"] == "X") {
+            foundX = true;
+            EXPECT_DOUBLE_EQ(def["atomic-weight"].asDouble(), 10.0);
+            // entropy298 should be present since X is not in standard entropies
+            EXPECT_TRUE(def.hasKey("entropy298"));
+        } else if (def["symbol"] == "Q") {
+            foundQ = true;
+            EXPECT_DOUBLE_EQ(def["atomic-weight"].asDouble(), 15.0);
+            // atomic-number should NOT be present since it was set to 0
+            EXPECT_FALSE(def.hasKey("atomic-number"));
+        }
+    }
+    EXPECT_TRUE(foundX);
+    EXPECT_TRUE(foundQ);
+}
+
 TEST(ThermoFromYaml, speciesFromDifferentFile)
 {
     IdealGasPhase thermo("ideal-gas.yaml", "species-remote");

--- a/test/thermo/thermoFromYaml.cpp
+++ b/test/thermo/thermoFromYaml.cpp
@@ -1,4 +1,5 @@
 #include "gtest/gtest.h"
+#include "cantera/base/Solution.h"
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/thermo/Elements.h"
 #include "cantera/thermo/Species.h"
@@ -39,6 +40,31 @@ TEST(ThermoFromYaml, elementFromDifferentFile)
     EXPECT_DOUBLE_EQ(thermo->atomicWeight(0), getElementWeight("N"));
     EXPECT_DOUBLE_EQ(thermo->atomicWeight(1), getElementWeight("O"));
     EXPECT_DOUBLE_EQ(thermo->atomicWeight(2), 38);
+}
+
+TEST(ThermoFromYaml, cloneCustomElements)
+{
+    auto original = newSolution("ideal-gas.yaml", "element-override", "none");
+    auto duplicate = original->clone({}, false, false)->thermo();
+
+    EXPECT_EQ(duplicate->nElements(), (size_t) 3);
+    EXPECT_DOUBLE_EQ(duplicate->atomicWeight(2), 36);
+    EXPECT_EQ(duplicate->elementName(2), "Ar");
+    EXPECT_DOUBLE_EQ(duplicate->molecularWeight(duplicate->speciesIndex("AR")), 36.0);
+    EXPECT_DOUBLE_EQ(duplicate->cp_mass(), original->thermo()->cp_mass());
+}
+
+TEST(ThermoFromYaml, cloneRemoteCustomElements)
+{
+    auto original = newSolution("ideal-gas.yaml", "element-remote", "none");
+    original->thermo()->setState_TPX(300, OneAtm, "AR:0.5, NO:0.5");
+    auto duplicate = original->clone({}, false, false)->thermo();
+
+    EXPECT_EQ(duplicate->nElements(), (size_t) 3);
+    EXPECT_DOUBLE_EQ(duplicate->atomicWeight(2), 38);
+    EXPECT_DOUBLE_EQ(duplicate->molecularWeight(duplicate->speciesIndex("AR")),
+        38);
+    EXPECT_DOUBLE_EQ(duplicate->cp_mass(), original->thermo()->cp_mass());
 }
 
 TEST(ThermoFromYaml, speciesFromDifferentFile)

--- a/test/thermo/thermoToYaml.cpp
+++ b/test/thermo/thermoToYaml.cpp
@@ -1,4 +1,5 @@
 #include "gtest/gtest.h"
+#include "cantera/base/Solution.h"
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/thermo/SurfPhase.h"
 #include "cantera/base/YamlWriter.h"
@@ -471,6 +472,44 @@ TEST_F(ThermoYamlRoundTrip, IdealSolutionVpss)
 {
     roundtrip("thermo-models.yaml", "IdealSolnGas-liquid");
     compareThermo(320, 1.5e5, "Li(l):1.0");
+}
+
+TEST(ThermoYamlWriter, preservesCustomElements)
+{
+    auto original = newSolution("ideal-gas.yaml", "element-override", "none");
+    YamlWriter writer;
+    writer.addPhase(original);
+    writer.skipUserDefined();
+
+    AnyMap root = AnyMap::fromYamlString(writer.toYamlString());
+    ASSERT_TRUE(root.hasKey("elements"));
+    const AnyMap& element = root["elements"].getMapWhere("symbol", "Ar");
+    EXPECT_DOUBLE_EQ(element["atomic-weight"].asDouble(), 36);
+
+    auto duplicate = newSolution(root["phases"].getMapWhere("name", "element-override"),
+                                 root, "none");
+    EXPECT_DOUBLE_EQ(
+        duplicate->thermo()->atomicWeight(duplicate->thermo()->elementIndex("Ar")),
+        36.0);
+}
+
+TEST(ThermoYamlWriter, preservesRemoteCustomElements)
+{
+    auto original = newSolution("ideal-gas.yaml", "element-remote", "none");
+    YamlWriter writer;
+    writer.addPhase(original);
+    writer.skipUserDefined();
+
+    AnyMap root = AnyMap::fromYamlString(writer.toYamlString());
+    ASSERT_TRUE(root.hasKey("elements"));
+    const AnyMap& element = root["elements"].getMapWhere("symbol", "Ar");
+    EXPECT_DOUBLE_EQ(element["atomic-weight"].asDouble(), 38);
+
+    auto duplicate = newSolution(root["phases"].getMapWhere("name", "element-remote"),
+                                 root, "none");
+    EXPECT_DOUBLE_EQ(
+        duplicate->thermo()->atomicWeight(duplicate->thermo()->elementIndex("Ar")),
+        38.0);
 }
 
 TEST_F(ThermoYamlRoundTrip, HMWSoln)

--- a/test/thermo/thermoToYaml.cpp
+++ b/test/thermo/thermoToYaml.cpp
@@ -512,6 +512,25 @@ TEST(ThermoYamlWriter, preservesRemoteCustomElements)
         38.0);
 }
 
+TEST(ThermoYamlWriter, conflictingElementDefinitions)
+{
+    // Create two phases that define the same element symbol 'X' with different
+    // atomic weights. Serializing them together via YamlWriter should throw.
+    auto phaseA = newSolution("ideal-gas.yaml", "conflict-phase-A", "none");
+    auto phaseB = newSolution("ideal-gas.yaml", "conflict-phase-B", "none");
+
+    EXPECT_DOUBLE_EQ(phaseA->thermo()->atomicWeight(
+        phaseA->thermo()->elementIndex("X")), 10.0);
+    EXPECT_DOUBLE_EQ(phaseB->thermo()->atomicWeight(
+        phaseB->thermo()->elementIndex("X")), 20.0);
+
+    YamlWriter writer;
+    writer.addPhase(phaseA);
+    writer.addPhase(phaseB);
+
+    EXPECT_THROW(writer.toYamlString(), CanteraError);
+}
+
 TEST_F(ThermoYamlRoundTrip, HMWSoln)
 {
     roundtrip("thermo-models.yaml", "HMW-NaCl-electrolyte");


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Handle custom element definitions in `ThermoPhase::clone` (needed for cloning `Reactor` contents)
- Handle custom element definitions when serializing to YAML (`YamlWriter`)

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

- Fixes #2100

**AI Statement (required)**

- **Extensive use of generative AI.** Significant portions of code or documentation were generated with AI, including   logic and implementation decisions. All generated code and documentation were reviewed and understood by the contributor. Implemented using Codex / ChatGPT 5.4.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
