### PR TITLE
Multiphase equilibrium solver fixes

### DIFF
--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -363,7 +363,7 @@ void MultiPhase::setMoles(span<const double> n)
         }
         m_moles[ip] = phasemoles;
         if (nsp > 1) {
-            if (phasemoles > 0.0) {
+            if (phasemoles > SmallNumber) {
                 p->setState_TPX(m_temp, m_press, n.subspan(loc, nsp));
                 p->getMoleFractions(span<double>(&m_moleFractions[loc], nsp));
             } else {

--- a/src/equil/MultiPhaseEquil.cpp
+++ b/src/equil/MultiPhaseEquil.cpp
@@ -321,12 +321,26 @@ void MultiPhaseEquil::getComponents(span<const size_t> order)
                 }
             }
             if (m != n) {
-                // Swap this row with the last non-zero row
+                // Swap this row with the last non-zero row, and keep m_element
+                // in sync so that the element index matches its A matrix row.
                 for (size_t k = 0; k < nColumns; k++) {
                     std::swap(m_A(n,k), m_A(m,k));
                 }
+                std::swap(m_element[m], m_element[n]);
             } else {
                 // All remaining rows are zero. Elimination is complete.
+                // The rank of the element matrix is m, which may be less than
+                // m_nel when some element constraints are linearly dependent
+                // (e.g., all species share a fixed H/C ratio). Update m_nel
+                // and resize arrays that depend on nFree().
+                if (m < m_nel) {
+                    m_nel = m;
+                    m_dxi.resize(nFree());
+                    m_deltaG_RT.assign(nFree(), 0.0);
+                    m_solnrxn.resize(nFree());
+                    m_N.resize(m_nsp, nFree());
+                    m_lastsort.resize(m_nel);
+                }
                 break;
             }
         }

--- a/src/equil/MultiPhaseEquil.cpp
+++ b/src/equil/MultiPhaseEquil.cpp
@@ -696,6 +696,15 @@ double MultiPhaseEquil::error()
 {
     double err, maxerr = 0.0;
 
+    // Total moles in the mixture; used to scale the "negligible reaction" check
+    // below: a reaction whose maximum possible Gibbs reduction is far below the
+    // mixture scale cannot meaningfully change the composition and should not
+    // block convergence.
+    double total_moles = 0.0;
+    for (size_t k = 0; k < m_nsp; k++) {
+        total_moles += std::max(0.0, m_moles[k]);
+    }
+
     // examine every reaction
     for (size_t j = 0; j < nFree(); j++) {
         size_t ik = j + m_nel;
@@ -711,6 +720,30 @@ double MultiPhaseEquil::error()
             err = 0.0;
         } else {
             err = fabs(m_deltaG_RT[j]);
+            // For an unfavorable (dG > 0) solution-phase formation reaction,
+            // the maximum extent achievable in a single step is bounded by
+            // the noncomponent's own moles (which the reaction is consuming)
+            // and by the components that the reaction would produce
+            // (m_N(n,j) > 0 in the same direction). If this maximum extent is
+            // far below the mixture scale, the reaction cannot meaningfully
+            // change the composition and its dG/RT — which can be set by
+            // floating-point noise in trace mole fractions — should not block
+            // convergence. We do not apply the same bound to favorable
+            // reactions because they can still grow a species from trace
+            // through repeated 10× steps of the exponential update formula.
+            if (!isStoichPhase(ik) && m_deltaG_RT[j] > 0.0) {
+                double max_extent = fabs(moles(ik));
+                for (size_t n = 0; n < m_nel; n++) {
+                    double nu = m_N(n, j);
+                    if (nu > 0.0) {
+                        double mc = std::max(0.0, m_moles[m_order[n]]);
+                        max_extent = std::min(max_extent, mc / nu);
+                    }
+                }
+                if (max_extent * err < 1.0e-15 * total_moles) {
+                    err = 0.0;
+                }
+            }
         }
         maxerr = std::max(maxerr, err);
     }

--- a/src/equil/MultiPhaseEquil.cpp
+++ b/src/equil/MultiPhaseEquil.cpp
@@ -69,17 +69,31 @@ MultiPhaseEquil::MultiPhaseEquil(MultiPhase* mix, bool start, int loglevel) : m_
     // only extend to 273.15 K, and give unphysical results above this
     // temperature, leading (incorrectly) to Gibbs free energies at high
     // temperature lower than for liquid water.
+    //
+    // When start=true (the default for TP equilibration), the solver computes
+    // its own initial composition from elemental totals. In that case, if an
+    // excluded species has non-zero initial moles, its elemental contribution
+    // is tracked in b_missing and redistributed to valid component species
+    // before calling setInitialMoles.
+    vector<double> b_missing(m_nel, 0.0);
+    bool has_excluded_moles = false;
     for (size_t k = 0; k < m_nsp_mix; k++) {
         size_t ip = m_mix->speciesPhaseIndex(k);
         if (!m_mix->solutionSpecies(k) &&
                 !m_mix->tempOK(ip)) {
             m_incl_species[k] = 0;
             if (m_mix->speciesMoles(k) > 0.0) {
-                throw CanteraError("MultiPhaseEquil::MultiPhaseEquil",
-                                   "condensed-phase species"+ m_mix->speciesName(k)
-                                   + " is excluded since its thermo properties are \n"
-                                   "not valid at this temperature, but it has "
-                                   "non-zero moles in the initial state.");
+                if (!start) {
+                    throw CanteraError("MultiPhaseEquil::MultiPhaseEquil",
+                        "condensed-phase species {} is excluded since its thermo "
+                        "properties are\nnot valid at this temperature, but it has "
+                        "non-zero moles in the initial state.", m_mix->speciesName(k));
+                }
+                for (size_t m = 0; m < m_nel; m++) {
+                    b_missing[m] += m_mix->speciesMoles(k) *
+                                    m_mix->nAtoms(k, m_element[m]);
+                }
+                has_excluded_moles = true;
             }
         }
     }
@@ -123,6 +137,17 @@ MultiPhaseEquil::MultiPhaseEquil(MultiPhase* mix, bool start, int loglevel) : m_
     // linear Gibbs minimization. In this case, only the elemental composition
     // of the initial mixture state matters.
     if (start) {
+        if (has_excluded_moles) {
+            // Adjust m_moles to restore element contributions from excluded
+            // condensed-phase species. After Gaussian elimination, m_A has an identity
+            // matrix in the component-species columns, so adding b_missing[m] to
+            // m_moles[m_order[m]] changes only element m's total.
+            computeN();
+            for (size_t m = 0; m < m_nel; m++) {
+                m_moles[m_order[m]] += b_missing[m];
+            }
+            updateMixMoles();
+        }
         setInitialMoles(loglevel-1);
     }
     computeN();

--- a/src/equil/MultiPhaseEquil.cpp
+++ b/src/equil/MultiPhaseEquil.cpp
@@ -580,29 +580,44 @@ double MultiPhaseEquil::computeReactionSteps(span<double> dxi)
 
             // noncomponent term
             size_t kc = m_order[j + m_nel];
-            double nmoles = fabs(m_mix->speciesMoles(m_species[kc])) + Tiny;
-            double term1 = m_dsoln[kc]/nmoles;
+            size_t ip_kc = m_mix->speciesPhaseIndex(m_species[kc]);
+            double nmoles_kc = fabs(m_mix->speciesMoles(m_species[kc])) + Tiny;
+            double pm_kc = fabs(m_mix->phaseMoles(ip_kc)) + Tiny;
 
-            // sum over solution phases
+            // Phase correction: subtract (sum_{k in phase} nu_k)^2 / n_phase for
+            // each solution phase, which is the Hessian term for an ideal phase.
+            //
+            // For the phase containing kc, combine term1 = dsoln/nmoles_kc with
+            // the phase correction -nu_sum^2/pm_kc into a single fraction. This is
+            // algebraically equivalent but avoids catastrophic cancellation when
+            // pm_kc ≈ nmoles_kc (a trace single-species phase).
+            double nu_sum_kc = 0.0;
             double sum = 0.0;
             for (size_t ip = 0; ip < m_mix->nPhases(); ip++) {
-                ThermoPhase& p = m_mix->phase(ip);
-                if (p.nSpecies() > 1) {
-                    double psum = 0.0;
+                double pm = fabs(m_mix->phaseMoles(ip));
+                if (m_mix->phase(ip).nSpecies() > 1 && pm > 0.0) {
+                    double nu_sum = 0.0;
                     for (k = 0; k < m_nsp; k++) {
                         kc = m_species[k];
                         if (m_mix->speciesPhaseIndex(kc) == ip) {
-                            psum += pow(nu[k], 2);
+                            nu_sum += nu[k];
                         }
                     }
-                    sum -= psum / (fabs(m_mix->phaseMoles(ip)) + Tiny);
+                    if (ip == ip_kc) {
+                        nu_sum_kc = nu_sum;
+                    } else {
+                        sum -= nu_sum * nu_sum / (pm + Tiny);
+                    }
                 }
             }
+            kc = m_order[j + m_nel];
+            double term1 = (m_dsoln[kc]*pm_kc - nu_sum_kc*nu_sum_kc*nmoles_kc)
+                           / (nmoles_kc*pm_kc);
             double rfctr = term1 + csum + sum;
             if (fabs(rfctr) < Tiny) {
                 fctr = 1.0;
             } else {
-                fctr = 1.0/(term1 + csum + sum);
+                fctr = 1.0/rfctr;
             }
         }
         dxi[j] = -fctr*dg_rt;

--- a/src/equil/MultiPhaseEquil.cpp
+++ b/src/equil/MultiPhaseEquil.cpp
@@ -638,14 +638,12 @@ double MultiPhaseEquil::error()
 
         // don't require formation reactions for solution species
         // present in trace amounts to be equilibrated
-        if (!isStoichPhase(ik) && fabs(moles(ik)) <= SmallNumber) {
+        if (!isStoichPhase(ik) && fabs(moles(ik)) <= Tiny) {
             err = 0.0;
-        }
-
-        // for stoichiometric phase species, no error if not present and
-        // delta G for the formation reaction is positive
-        if (isStoichPhase(ik) && moles(ik) <= 0.0 &&
+        } else if (isStoichPhase(ik) && moles(ik) <= 0.0 &&
                 m_deltaG_RT[j] >= 0.0) {
+            // for stoichiometric phase species, no error if not present and
+            // delta G for the formation reaction is positive
             err = 0.0;
         } else {
             err = fabs(m_deltaG_RT[j]);

--- a/src/equil/MultiPhaseEquil.cpp
+++ b/src/equil/MultiPhaseEquil.cpp
@@ -445,8 +445,32 @@ void MultiPhaseEquil::step(double omega, span<double> deltaN, int loglevel)
         if (m_majorsp[k]) {
             m_moles[k] += omega * deltaN[k];
         } else {
-            m_moles[k] = fabs(m_moles[k])*std::min(10.0,
-                                                   exp(-m_deltaG_RT[ik - m_nel]));
+            // Minor non-component species use a non-linear update:
+            // moles_new = |m_moles[k]| * exp(-dG/RT), capped at 10x growth for
+            // stability. When m_moles[k] is exactly zero, this degenerates to 0
+            // regardless of dG; the species stays at 0 and the component
+            // correction below suppresses the would-be formation reaction.
+            size_t j = ik - m_nel;
+            double moles_new = fabs(m_moles[k])
+                               * std::min(10.0, exp(-m_deltaG_RT[j]));
+            // The components were already updated above by omega*deltaN, which
+            // assumes each noncomponent species k changes by omega*deltaN[k].
+            // The actual change here is moles_new - m_moles[k], so element
+            // balance has an "excess" error that should be corrected on the
+            // components. We only apply the correction when the imbalance is
+            // catastrophic — i.e., the Newton step expects a large change in
+            // this species but the exponential formula caps it at a small
+            // fraction. For modestly-trace species the imbalance is O(m_moles[k])
+            // and applying the correction routinely would destabilize convergence
+            // by perturbing trace component species.
+            double excess = (moles_new - m_moles[k]) - omega * deltaN[k];
+            if (fabs(excess) > 10.0 * fabs(moles_new - m_moles[k]) &&
+                    fabs(excess) > SmallNumber) {
+                for (size_t n = 0; n < m_nel; n++) {
+                    m_moles[m_order[n]] += m_N(n, j) * excess;
+                }
+            }
+            m_moles[k] = moles_new;
         }
     }
     updateMixMoles();
@@ -513,7 +537,7 @@ double MultiPhaseEquil::stepComposition(int loglevel)
     }
 
     // now take a step with this scaled omega
-    step(omegamax, m_work);
+    step(omegamax, m_work, loglevel);
     // compute the gradient of G at this new position in the current direction.
     // If it is positive, then we have overshot the minimum. In this case,
     // interpolate back.

--- a/src/equil/vcs_solve.cpp
+++ b/src/equil/vcs_solve.cpp
@@ -442,6 +442,13 @@ size_t VCS_SOLVE::vcs_popPhaseID()
             if (Vphase->m_singleSpecies) {
                 // Single Phase Stability Resolution
                 size_t kspec = Vphase->spGlobalIndexVCS(0);
+                // Skip if the species is a component: a zero-abundance element may
+                // cause its only containing species to be selected as a component with
+                // zero moles, making its phase dead while still in the component basis.
+                // Such phases can never be popped.
+                if (kspec < m_numComponents) {
+                    continue;
+                }
                 size_t irxn = kspec - m_numComponents;
                 if (irxn > m_deltaGRxn_old.size()) {
                     throw CanteraError("VCS_SOLVE::vcs_popPhaseID",
@@ -504,6 +511,8 @@ int VCS_SOLVE::vcs_popPhaseRxnStepSizes(const size_t iphasePop)
     vcs_VolPhase* Vphase = m_VolPhaseList[iphasePop].get();
     // Identify the first species in the phase
     size_t kspec = Vphase->spGlobalIndexVCS(0);
+    AssertThrowMsg(kspec >= m_numComponents, "VCS_SOLVE::vcs_popPhaseRxnStepSizes",
+        "called for a phase whose species is a component");
     // Identify the formation reaction for that species
     size_t irxn = kspec - m_numComponents;
     vector<size_t> creationGlobalRxnNumbers(Vphase->nSpecies(), npos);

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -298,6 +298,11 @@ void Phase::setMoleFractions(span<const double> x)
     // molecular weight:
     //     m_ym_k = X_k / (sum_k X_k M_k)
     const double invSum = 1.0/sum;
+    if (!std::isfinite(invSum) && m_kk != 0) {
+        throw CanteraError("Phase::setMoleFractions",
+            "The sum of the species mole fractions is zero, too small to normalize,"
+            " or not-a-number.");
+    }
     for (size_t k=0; k < m_kk; k++) {
         m_ym[k] = m_y[k]*invSum;
     }
@@ -340,8 +345,13 @@ void Phase::setMassFractions(span<const double> y)
     for (size_t k = 0; k < m_kk; k++) {
         m_y[k] = std::max(y[k], 0.0); // Ignore negative mass fractions
     }
-    double norm = accumulate(m_y.begin(), m_y.end(), 0.0);
-    scale(m_y.begin(), m_y.end(), m_y.begin(), 1.0/norm);
+    double invSum = 1.0 / accumulate(m_y.begin(), m_y.end(), 0.0);
+    if (!std::isfinite(invSum) && m_kk != 0) {
+        throw CanteraError("Phase::setMassFractions",
+            "The sum of the species mass fractions is zero, too small to normalize,"
+            " or not-a-number.");
+    }
+    scale(m_y.begin(), m_y.end(), m_y.begin(), invSum);
 
     transform(m_y.begin(), m_y.end(), m_rmolwts.begin(),
               m_ym.begin(), multiplies<double>());

--- a/test/equil/equil_gas.cpp
+++ b/test/equil/equil_gas.cpp
@@ -57,7 +57,7 @@ TEST_F(OverconstrainedEquil, VcsNonideal)
     EXPECT_NEAR(2*mu[0], mu[1], 1e-7*std::abs(mu[0]));
 }
 
-TEST_F(OverconstrainedEquil, DISABLED_MultiphaseEquil)
+TEST_F(OverconstrainedEquil, MultiphaseEquil)
 {
     setup();
     gas->equilibrate("TP", "gibbs");

--- a/test/python/test_equilibrium.py
+++ b/test/python/test_equilibrium.py
@@ -274,3 +274,60 @@ class Test_IdealSolidSolnPhase_Equil:
         gas.equilibrate('TP', solver='element_potential')
         assert gas['C-graph'].X[0] == approx(2.0 / 3.0)
         assert gas['H2-solute'].X[0] == approx(1.0 / 3.0)
+
+
+def test_excluded_species_initial():
+    """
+    Test equilibration of a Pb/O/C mixture where one of the condensed phases (PbO(yw))
+    has thermo data only valid above 762 K. When equilibrating at 400 K, the solver
+    should exclude PbO(yw) and redistribute its elemental contribution to valid species,
+    regardless of whether PbO(yw) appears in the initial composition. Adapted from
+    issue report https://github.com/Cantera/cantera/issues/160.
+    """
+
+    _pb_phases_yaml = """
+    phases:
+    - name: gas
+      thermo: ideal-gas
+      species: [{nasa_gas.yaml/species: [Pb, O, C]}]
+    - name: C_gr
+      thermo: fixed-stoichiometry
+      species: [{nasa_condensed.yaml/species: [C(gr)]}]
+    - name: Pb_s
+      thermo: fixed-stoichiometry
+      species: [{nasa_condensed.yaml/species: [Pb(cr)]}]
+    - name: PbO_rd
+      thermo: fixed-stoichiometry
+      species: [{nasa_condensed.yaml/species: [PbO(rd)]}]
+    - name: PbO_yw
+      thermo: fixed-stoichiometry
+      species: [{nasa_condensed.yaml/species: [PbO(yw)]}]
+    - name: PbO2_s
+      thermo: fixed-stoichiometry
+      species: [{nasa_condensed.yaml/species: [PbO2(s)]}]
+    - name: Pb3O4_s
+      thermo: fixed-stoichiometry
+      species: [{nasa_condensed.yaml/species: [Pb3O4(s)]}]
+    """
+    phase_names = ['gas', 'C_gr', 'Pb_s', 'PbO_rd', 'PbO_yw', 'PbO2_s', 'Pb3O4_s']
+    phases = [ct.Solution(yaml=_pb_phases_yaml, name=n) for n in phase_names]
+    mix = ct.Mixture(phases)
+    mix.T = 400
+    mix.P = ct.one_atm
+    mix.species_moles = 'O:3, Pb:1, C:1'
+    mix.equilibrate('TP', solver='gibbs', rtol=1e-10)
+    phase_moles_ref = mix.phase_moles()
+
+    # Initial composition includes PbO(yw), which has no valid thermo at 400 K and is
+    # excluded from the calculation. The solver should redistribute its Pb and O atoms
+    # to valid species and converge to the same equilibrium as when initialized with
+    # elemental species (mix1).
+    mix.T = 400
+    mix.P = ct.one_atm
+    mix.species_moles = 'O:2, PbO(yw):1, C:1'  # same element totals
+    mix.equilibrate('TP', solver='gibbs', rtol=1e-10)
+
+    # PbO2(s) and C(gr) should be present; PbO(yw) excluded and absent
+    assert mix.phase_moles("PbO_yw") == approx(0.0)
+    assert mix.phase_moles("PbO2_s") == approx(1.0, rel=1e-6)
+    assert mix.phase_moles() == approx(phase_moles_ref, rel=1e-6)

--- a/test/python/test_equilibrium.py
+++ b/test/python/test_equilibrium.py
@@ -276,20 +276,29 @@ class Test_IdealSolidSolnPhase_Equil:
         assert gas['H2-solute'].X[0] == approx(1.0 / 3.0)
 
 
-def test_excluded_species_initial():
+@pytest.mark.parametrize("solver,include_h2o",
+                         [("gibbs", False), ("vcs", False),
+                          ("gibbs", True), ("vcs", True)])
+def test_excluded_species_extra_element(solver, include_h2o):
     """
     Test equilibration of a Pb/O/C mixture where one of the condensed phases (PbO(yw))
     has thermo data only valid above 762 K. When equilibrating at 400 K, the solver
     should exclude PbO(yw) and redistribute its elemental contribution to valid species,
-    regardless of whether PbO(yw) appears in the initial composition. Adapted from
-    issue report https://github.com/Cantera/cantera/issues/160.
-    """
+    regardless of whether PbO(yw) appears in the initial composition.
 
-    _pb_phases_yaml = """
+    Also test a case when a mixture includes a phase (H2O_s) that introduces an
+    element (H) with zero abundance and only one phase containing that element.
+
+    Adapted from issue report https://github.com/Cantera/cantera/issues/160.
+    """
+    _pb_phases_yaml_with_H2O = """
     phases:
     - name: gas
       thermo: ideal-gas
       species: [{nasa_gas.yaml/species: [Pb, O, C]}]
+    - name: H2O_s
+      thermo: fixed-stoichiometry
+      species: [{nasa_condensed.yaml/species: [H2O(s)]}]
     - name: C_gr
       thermo: fixed-stoichiometry
       species: [{nasa_condensed.yaml/species: [C(gr)]}]
@@ -309,8 +318,12 @@ def test_excluded_species_initial():
       thermo: fixed-stoichiometry
       species: [{nasa_condensed.yaml/species: [Pb3O4(s)]}]
     """
-    phase_names = ['gas', 'C_gr', 'Pb_s', 'PbO_rd', 'PbO_yw', 'PbO2_s', 'Pb3O4_s']
-    phases = [ct.Solution(yaml=_pb_phases_yaml, name=n) for n in phase_names]
+    if include_h2o:
+        phase_names = ['gas', 'H2O_s', 'C_gr', 'Pb_s', 'PbO_rd', 'PbO_yw', 'PbO2_s',
+                       'Pb3O4_s']
+    else:
+        phase_names = ['gas', 'C_gr', 'Pb_s', 'PbO_rd', 'PbO_yw', 'PbO2_s', 'Pb3O4_s']
+    phases = [ct.Solution(yaml=_pb_phases_yaml_with_H2O, name=n) for n in phase_names]
     mix = ct.Mixture(phases)
     mix.T = 400
     mix.P = ct.one_atm
@@ -325,9 +338,11 @@ def test_excluded_species_initial():
     mix.T = 400
     mix.P = ct.one_atm
     mix.species_moles = 'O:2, PbO(yw):1, C:1'  # same element totals
-    mix.equilibrate('TP', solver='gibbs', rtol=1e-10)
+    mix.equilibrate('TP', solver=solver, rtol=1e-10, max_steps=10000, max_iter=10000)
 
-    # PbO2(s) and C(gr) should be present; PbO(yw) excluded and absent
+    # PbO2(s) and C(gr) should be present; PbO(yw) excluded and absent; H2O(s) absent
+    if include_h2o:
+        assert mix.phase_moles("H2O_s") == approx(0.0)
     assert mix.phase_moles("PbO_yw") == approx(0.0)
     assert mix.phase_moles("PbO2_s") == approx(1.0, rel=1e-6)
     assert mix.phase_moles() == approx(phase_moles_ref, rel=1e-6)

--- a/test/python/test_equilibrium.py
+++ b/test/python/test_equilibrium.py
@@ -92,14 +92,26 @@ class TestMultiphaseEquil(EquilTestCases):
 
     solver = 'gibbs'
 
-    @pytest.mark.xfail
+    def test_trace_solution_species(self):
+        s = """
+        phases:
+        - name: gas
+          thermo: ideal-gas
+          species: [{nasa_gas.yaml/species: [C, CO, CO2, C2]}]
+          skip-undeclared-elements: true
+          elements: [C, O]
+        """
+        gas = ct.Solution(yaml=s)
+        gas.TPX = 300, 1e5, 'CO2:1'
+        gas.equilibrate('TP', self.solver, max_steps=10000)
+        assert gas['CO2'].X[0] == approx(1.0)
+
     def test_equil_gri_stoichiometric(self):
         gas = ct.Solution('gri30.yaml', transport_model=None)
         gas.TPX = 301, 100000, 'CH4:1.0, O2:2.0'
         gas.equilibrate('TP', self.solver)
         self.check(gas, CH4=0, O2=0, H2O=2, CO2=1)
 
-    @pytest.mark.xfail
     def test_equil_gri_lean(self):
         gas = ct.Solution('gri30.yaml', transport_model=None)
         gas.TPX = 301, 100000, 'CH4:1.0, O2:3.0'

--- a/test/python/test_equilibrium.py
+++ b/test/python/test_equilibrium.py
@@ -1,3 +1,5 @@
+import itertools
+
 import numpy as np
 import pytest
 from pytest import approx
@@ -117,6 +119,110 @@ class TestMultiphaseEquil(EquilTestCases):
         gas.TPX = 301, 100000, 'CH4:1.0, O2:3.0'
         gas.equilibrate('TP', self.solver)
         self.check(gas, CH4=0, O2=1, H2O=2, CO2=1)
+
+
+class TestMultiphase_H2O2_TwoPhase:
+    """
+    Stress test for the 'gibbs' (``MultiPhaseEquil``) solver on a two-phase setup where
+    the second phase is a subset of the h2o2 mechanism species and the mixture
+    composition is stoichiometric with respect to H2 and O2. Verifies element
+    conservation and that the converged state satisfies the element-potential
+    consistency condition, sampling a range of phase2 compositions, temperatures,
+    pressures, and inert moles. Regression coverage for the cluster of MultiPhaseEquil
+    fixes addressing issue #1023.
+    """
+
+    # Spot-check conditions chosen to exercise the regimes that previously had failures
+    # (issue #1023): low T where the answer is fully-combusted, mid T where minor
+    # species start to matter, high T where dissociation becomes significant, and a
+    # high-T/high-P combination.
+    _H2O2_TPN = [
+        (400, 1.0, 0.1),
+        (500, 2.0, 0.3),
+        (1000, 5.0, 0.7),
+        (1300, 5.0, 0.7),
+        (1700, 1.0, 0.0),
+        (2000, 20.0, 0.7),
+    ]
+
+    @staticmethod
+    def _h2o2_phase2_samples(n=20):
+        """Deterministic sample of ~n phase2 species combinations from h2o2.yaml,
+        spanning all combination sizes from 2 to the full set."""
+        species = ['H2', 'H', 'O', 'O2', 'OH', 'H2O', 'HO2', 'H2O2', 'AR', 'N2']
+        combos = [c for r in range(2, len(species) + 1)
+                    for c in itertools.combinations(species, r)]
+        stride = max(1, len(combos) // n)
+        return [list(c) for c in combos[::stride][:n]]
+
+    @staticmethod
+    def _at_equilibrium(mix, abs_tol=1e-6):
+        """
+        Verify that ``mix`` is at chemical equilibrium by checking that the chemical
+        potential of each species satisfies ``mu_k = sum_e n_{e,k} * lambda_e`` where
+        ``lambda_e`` is the element potential for element e and ``n_{e,k}`` is the
+        number of atoms of element e in species k. We solve for ``lambda`` by weighted
+        least squares (weighting by moles so trace species do not dominate the fit),
+        then require ``|mu_k - sum_e n_{e,k} lambda_e| / (R T) < abs_tol`` for every
+        species whose moles are more than 1e-10 of the total. Returns the worst relative
+        residual.
+        """
+        R = ct.gas_constant
+        T = mix.T
+        n_species = mix.n_species
+        n_elements = mix.n_elements
+        mu = np.asarray(mix.chemical_potentials)
+        moles = np.asarray(mix.species_moles)
+        composition = np.array([[mix.n_atoms(k, e) for e in range(n_elements)]
+                                for k in range(n_species)])
+
+        w = np.sqrt(np.maximum(moles, 0.0))
+        mask = w > 0.0
+        Aw = composition[mask] * w[mask, None]
+        muw = mu[mask] * w[mask]
+        lam, *_ = np.linalg.lstsq(Aw, muw, rcond=None)
+
+        total = moles.sum()
+        worst = 0.0
+        for k in range(n_species):
+            if moles[k] > 1e-10 * total:
+                residual = (mu[k] - composition[k] @ lam) / (R * T)
+                assert abs(residual) < abs_tol, (
+                    f"species {mix.species_name(k)} (k={k}): "
+                    f"moles={moles[k]:.3g} of total {total:.3g}, "
+                    f"|mu_k - sum_e n_{{e,k}} lambda_e| / RT = {abs(residual):.3g}"
+                )
+                worst = max(worst, abs(residual))
+        return worst
+
+    @pytest.mark.parametrize("phase2_names", _h2o2_phase2_samples())
+    @pytest.mark.parametrize("T,P_atm,N_inert", _H2O2_TPN)
+    def test_equilibrate(self, T, P_atm, N_inert, phase2_names):
+        S = ct.Species.list_from_file('h2o2.yaml')
+        phase1 = ct.Solution('h2o2.yaml')
+        phase2 = ct.Solution(thermo='ideal-gas',
+                             species=[s for s in S if s.name in phase2_names])
+
+        P = P_atm * ct.one_atm
+        initial = {"O2": 1.0, "H2": 2.0, "N2": N_inert}
+        phase1.TPX = T, P, initial
+        mix = ct.Mixture([(phase1, sum(initial.values())), (phase2, 0.0)])
+        elements_before = np.array([mix.element_moles(e)
+                                    for e in range(mix.n_elements)])
+
+        mix.T = T
+        mix.P = P
+        # The default max_steps=1000 is not enough for a handful of corner cases (e.g.
+        # T=1700, N_inert=0 with phase2 = {H2, O, O2, OH, H2O, N2}) where atom transfer
+        # to phase2 is constrained by a single very-small species.
+        mix.equilibrate('TP', solver='gibbs', max_steps=5000)
+
+        elements_after = np.array([mix.element_moles(e)
+                                   for e in range(mix.n_elements)])
+        np.testing.assert_allclose(elements_after, elements_before, rtol=1e-7,
+                                   atol=1e-12,
+                                   err_msg="element moles changed during equilibration")
+        self._at_equilibrium(mix, abs_tol=1e-6)
 
 
 @pytest.fixture(scope='function')

--- a/test/python/test_equilibrium.py
+++ b/test/python/test_equilibrium.py
@@ -382,6 +382,86 @@ class Test_IdealSolidSolnPhase_Equil:
         assert gas['H2-solute'].X[0] == approx(1.0 / 3.0)
 
 
+class TestMultiphase_VaporLiquidHydrocarbon:
+    """
+    Regression test for element conservation in a two-phase vapor/liquid hydrocarbon
+    mixture (C8H18, C6H6, C7H8). Previously, elements were not conserved after
+    equilibration due to errors in MultiPhaseEquil with "trace" species.
+    Regression coverage for issue #425.
+    """
+
+    _gas_yaml = """
+    phases:
+    - name: vapor
+      thermo: ideal-gas
+      elements: [O, H, C]
+      species: [{nasa_gas.yaml/species: ["C8H18,n-octane", C6H6, C7H8]}]
+      state: {T: 300.0, P: 1 atm}
+    """
+
+    _liquid_yaml = """
+    phases:
+    - name: liquid
+      elements: [O, H, C]
+      thermo: ideal-condensed
+      species: ["C8H18(L),n-octa", C6H6(L), C7H8(L)]
+      state: {T: 300.0, P: 1 atm}
+
+    # Species data from nasa_condensed.yaml, augmented with (fake) density data
+    species:
+    - name: C8H18(L),n-octa
+      composition: {C: 8, H: 18}
+      thermo:
+        model: NASA7
+        temperature-ranges: [220.0, 300.0]
+        data:
+        - [71.413393, -0.5020795, 1.834199e-03, -2.0450165e-06, 0.0, -4.1243725e+04,
+          -277.2224]
+      equation-of-state:
+        model: constant-volume
+        density: 0.8765 g/cm^3
+    - name: C6H6(L)
+      composition: {C: 6, H: 6}
+      thermo:
+        model: NASA7
+        temperature-ranges: [278.68, 500.0]
+        data:
+        - [63.6690229, -0.600534398, 2.6679281e-03, -5.06308828e-06, 3.63955562e-09,
+          -1670.85472, -243.891797]
+      equation-of-state:
+        model: constant-volume
+        density: 0.8765 g/cm^3
+    - name: C7H8(L)
+      composition: {C: 7, H: 8}
+      thermo:
+        model: NASA7
+        temperature-ranges: [178.15, 500.0]
+        data:
+        - [29.3676022, -0.194722686, 9.74773096e-04, -1.91472689e-06, 1.48097019e-09,
+          -4163.18442, -112.019966]
+      equation-of-state:
+        model: constant-volume
+        density: 0.8765 g/cm^3
+    """
+
+    @pytest.mark.parametrize("n_C7H8_vapor", [1, 2, 3, 5, 9, 11, 20])
+    def test_element_conservation(self, n_C7H8_vapor):
+        liquid = ct.Solution(yaml=self._liquid_yaml)
+        vapor = ct.Solution(yaml=self._gas_yaml)
+
+        liquid.Y = {'C7H8(L)': 1.0, 'C6H6(L)': 1.0}
+        vapor.Y = {'C7H8': n_C7H8_vapor, 'C6H6': 1.0}
+        mix = ct.Mixture([(vapor, 1.0), (liquid, 1.0)])
+
+        mix.T = 373.15
+        mix.P = 101325.0
+        elements_before = [mix.element_moles(e) for e in range(mix.n_elements)]
+        mix.equilibrate('TP', solver='gibbs', max_steps=5000)
+        elements_after = [mix.element_moles(e) for e in range(mix.n_elements)]
+
+        assert elements_after == approx(elements_before, rel=1e-7)
+
+
 @pytest.mark.parametrize("solver,include_h2o",
                          [("gibbs", False), ("vcs", False),
                           ("gibbs", True), ("vcs", True)])

--- a/test/python/test_mixture.py
+++ b/test/python/test_mixture.py
@@ -171,7 +171,6 @@ class TestMixture:
         assert mix.T == approx(400)
         assert mix.P == approx(2 * ct.one_atm)
 
-    @pytest.mark.xfail(reason="See https://github.com/Cantera/cantera/issues/1023")
     def test_equilibrate2(self, mix):
         mix.species_moles = 'H2:1.0, O2:0.5, N2:1.0'
         mix.T = 400


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

This PR fixes the known issues with constant TP equilibrium solves using the `MultiPhaseEquil` solver (that is, the one used when calling `mix.equilibrate("TP", solver="gibbs")`.

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix errors due to bad logic and an incorrect tolerance related to trace species;
  - Fixes #130
  - Fixes #425
- Allow initial phases to be outside the defined temperature limits.  For constant TP equilibrium, the initial composition is usually only used to determine the element abundances, so which phases these elements come from doesn't matter.
  - Fixes #160
- Fix an error in the VCS solver involving phases where an element has zero abundance
  - Partially fixes #160 
- Protect against normalizing all-zero mass/mole fractions, which resulted in the composition turning into all NaNs.
- Fix reaction step calculation for multiphase mixtures by using correct formula for Hessian elements for species in other phases.
- Fix element conservation for trace species in `MultiPhaseEquil::step`. This requires some thresholds depending on the direction of the step (for favorable or unfavorable trace species) and depending on the amount of the trace species present.
  - Fixes #1023 
- Relax convergence criterion for thermodynamically negligible reactions, where these reactions don't have a significant effect on the composition.
- Add tests covering these failure modes that test that the resulting mixture state satisfies equilibrium and conserves the initial element abundances.
- Fix handling of mixtures dominated by species with linearly dependent elemental compositions
  - Fixes #245

**AI Statement (required)**

- **Extensive use of generative AI.** Significant portions of code or documentation were generated with AI, including logic and implementation decisions. All generated code and documentation were reviewed and understood by the contributor. These fixes and tests were developed using OpenAI Codex / GPT-5.5, Claude Code / Sonnet 4.6 and Claude Code / Opus 4.7.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
