### PR TITLE
Fix mis-named/referenced n-heptane mechanism

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -779,7 +779,7 @@ jobs:
           -exec sh -c 'for n; do echo "$n" | tee -a results.txt && python3 -u "$n" >> results.txt || exit 1; done' sh {} +
         env:
           # The pyparsing ignore setting is due to a new warning introduced in Matplotlib==3.6.0
-          # Ignore NasaPoly2 warnings from n-hexane-NUIG-2015.yaml
+          # Ignore NasaPoly2 warnings from n-heptane-NUIG-2016.yaml
           PYTHONWARNINGS: "error,ignore:warn_name_set_on_empty_Forward::pyparsing,ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:,ignore:NasaPoly2:UserWarning:"
           MPLBACKEND: Agg
       - name: Save the results file for inspection

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -893,6 +893,7 @@ jobs:
           python=${{ matrix.python-version }} scons numpy cython ruamel.yaml boost-cpp
           eigen yaml-cpp pandas pytest pytest-xdist highfive pint python-graphviz
           fmt=${{ matrix.fmt-ver }} setuptools Jinja2 doxygen openblas
+        micromamba-version: '2.6.0-0'  # Pin until mamba-org/setup-micromamba#306 is fixed
         post-cleanup: none
         init-shell: powershell
     - name: Build Cantera

--- a/doc/sphinx/develop/writing-examples.md
+++ b/doc/sphinx/develop/writing-examples.md
@@ -103,10 +103,10 @@ these files can be added to the
 [`cantera-example-data`](https://github.com/cantera/cantera-example-data) repository.
 Files in this repository will be installed with Cantera and available under the
 `example_data` subdirectory within the standard search path. For example, the mechanism
-`n-hexane-NUIG-2015.yaml` can be loaded as:
+`n-heptane-NUIG-2016.yaml` can be loaded as:
 
 ```py
-gas = ct.Solution("example_data/n-hexane-NUIG-2015.yaml")
+gas = ct.Solution("example_data/n-heptane-NUIG-2016.yaml")
 ```
 
 When developing examples, the use of well-documented mechanisms that have been published

--- a/samples/python/kinetics/mechanism_reduction.py
+++ b/samples/python/kinetics/mechanism_reduction.py
@@ -6,7 +6,7 @@ A simplistic approach to mechanism reduction which demonstrates Cantera's
 features for dynamically manipulating chemical mechanisms.
 
 Here, we use the detailed NUI Galway mechanism to simulate adiabatic, constant pressure
-ignition of a lean n-hexane/air mixture. We track the maximum reaction rates for
+ignition of a lean n-heptane/air mixture. We track the maximum reaction rates for
 each reaction to determine which reactions are the most important, according to
 a simple metric based on the relative net reaction rate.
 
@@ -37,8 +37,8 @@ class Result:
 ct.suppress_thermo_warnings()
 T0 = 975
 P0 = 5 * ct.one_atm
-gas = ct.Solution('example_data/n-hexane-NUIG-2015.yaml')
-gas.set_equivalence_ratio(0.8, 'NC6H14:1.0', 'O2:1.0, N2:3.76')
+gas = ct.Solution('example_data/n-heptane-NUIG-2016.yaml')
+gas.set_equivalence_ratio(0.8, 'NC7H16:1.0', 'O2:1.0, N2:3.76')
 X0 = gas.mole_fraction_dict()
 gas.TP = T0, P0
 
@@ -76,7 +76,7 @@ for i, N in enumerate([100, 200, 300, 400, 600, 800]):
 
     # find the species involved in these reactions. At a minimum, include all
     # species in the reactant mixture
-    species_names = {'N2', 'NC6H14', 'O2'}
+    species_names = {'N2', 'NC7H16', 'O2'}
     for reaction in reactions:
         species_names.update(reaction.reactants)
         species_names.update(reaction.products)
@@ -89,7 +89,7 @@ for i, N in enumerate([100, 200, 300, 400, 600, 800]):
                        species=species, reactions=reactions)
 
     # save the reduced mechanism for later use
-    gas2.write_yaml(f"hexane-reduced-{N}-reaction.yaml")
+    gas2.write_yaml(f"heptane-reduced-{N}-reaction.yaml")
 
     # Re-run the ignition problem with the reduced mechanism
     gas2.TPX = T0, P0, X0

--- a/samples/python/reactors/continuous_reactor.py
+++ b/samples/python/reactors/continuous_reactor.py
@@ -284,8 +284,9 @@ plt.show()
 # References
 # ----------
 #
-# .. [1] K. Zhang, C. Banyon, C. Togbé, P. Dagaut, J. Bugler, H. J. Curran (2015). "An
-#        experimental and kinetic modeling study of n-hexane oxidation," *Combustion and
-#        Flame* 162:11, 4194-4207, https://doi.org/10.1016/j.combustflame.2015.08.001.
+# .. [1] K. Zhang, C. Banyon, J. Bugler, H. J. Curran, A. Rodriguez, O. Herbinet, F.
+#        Battin-Leclerc, C. B'Chir, K. A. Heufer (2016). "An updated experimental and
+#        kinetic modeling study of n-heptane oxidation," *Combustion and Flame* 172,
+#        116-135, https://doi.org/10.1016/j.combustflame.2016.06.028.
 
 # sphinx_gallery_thumbnail_number = -1

--- a/samples/python/reactors/continuous_reactor.py
+++ b/samples/python/reactors/continuous_reactor.py
@@ -58,7 +58,7 @@ print(f"Running Cantera version: {ct.__version__}")
 # can be found in the paper by Zhang et al. [1]_ We will use the same mechanism reported
 # in the paper. It consists of 1268 species and 5336 reactions.
 
-gas = ct.Solution("example_data/n-hexane-NUIG-2015.yaml")
+gas = ct.Solution("example_data/n-heptane-NUIG-2016.yaml")
 
 # %%
 # Define initial conditions

--- a/samples/python/reactors/preconditioned_integration.py
+++ b/samples/python/reactors/preconditioned_integration.py
@@ -3,7 +3,7 @@ Acceleration of reactor integration using a sparse preconditioned solver
 ========================================================================
 
 Ideal gas, constant-pressure, adiabatic kinetics simulation that compares preconditioned
-and non-preconditioned integration of n-hexane.
+and non-preconditioned integration of n-heptane.
 
 Requires: cantera >= 3.2.0, matplotlib >= 2.0
 
@@ -19,13 +19,13 @@ from timeit import default_timer
 # ----------------
 #
 # Create a reactor network for simulating the constant pressure ignition of a
-# stoichiometric n-hexane/air mixture, with or without the use of the preconditioned
+# stoichiometric n-heptane/air mixture, with or without the use of the preconditioned
 # solver.
 def integrate_reactor(preconditioner=True):
-    # Use a detailed n-hexane mechanism with 1268 species
-    gas = ct.Solution('example_data/n-hexane-NUIG-2015.yaml')
+    # Use a detailed n-heptane mechanism with 1268 species
+    gas = ct.Solution('example_data/n-heptane-NUIG-2016.yaml')
     gas.TP = 1000, ct.one_atm
-    gas.set_equivalence_ratio(1, 'NC6H14', 'N2:3.76, O2:1.0')
+    gas.set_equivalence_ratio(1, 'NC7H16', 'N2:3.76, O2:1.0')
     reactor = ct.IdealGasConstPressureMoleReactor(gas, clone=False)
     # set volume for reactors
     reactor.volume = 0.1
@@ -55,17 +55,17 @@ def integrate_reactor(preconditioner=True):
         print(f"{key:>24s}: {value}")
     print("\n")
     # return some variables for plotting
-    return states.time, states.T, states('CO2').Y, states('NC6H14').Y
+    return states.time, states.T, states('CO2').Y, states('NC7H16').Y
 
 # %%
 # Integrate with sparse, preconditioned solver
 # --------------------------------------------
-timep, Tp, CO2p, NC6H14p = integrate_reactor(preconditioner=True)
+timep, Tp, CO2p, NC7H16p = integrate_reactor(preconditioner=True)
 
 # %%
 # Integrate with direct linear solver
 # -----------------------------------
-timenp, Tnp, CO2np, NC6H14np  = integrate_reactor(preconditioner=False)
+timenp, Tnp, CO2np, NC7H16np  = integrate_reactor(preconditioner=False)
 
 # %%
 # Plot selected state variables
@@ -85,8 +85,8 @@ ax2.plot(timep, CO2p, linewidth=2, linestyle=":")
 ax2.legend(["Normal", "Preconditioned"])
 # C12H26 plot
 ax3.set_xlabel("Time")
-ax3.set_ylabel("NC6H14")
-ax3.plot(timenp, NC6H14np, linewidth=2)
-ax3.plot(timep, NC6H14p, linewidth=2, linestyle=":")
+ax3.set_ylabel("NC7H16")
+ax3.plot(timenp, NC7H16np, linewidth=2)
+ax3.plot(timep, NC7H16p, linewidth=2, linestyle=":")
 ax3.legend(["Normal", "Preconditioned"])
 plt.show()


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

This resolves an issue noted in [this Users' Group post](https://groups.google.com/g/cantera-users/c/o26ziBHEecU) that the conditions in the example `continuous_reactor.py` did not correspond to the conditions in the referenced paper ([10.1016/j.combustflame.2015.08.001](https://doi.org/10.1016/j.combustflame.2015.08.001)). It was observed that the figure in the paper showing results for n-heptane combustion was at an equivalence ratio of 1.0 while the conditions in `continuous_reactor.py` were for a mixture with equivalence ratio 2.0.

However, it turns out that the mechanism used in the example is actually not from this paper, which was mainly on n-hexane combustion, but from another paper by many of the same authors on n-heptane combustion ([10.1016/j.combustflame.2016.06.028](https://doi.org/10.1016/j.combustflame.2016.06.028)), and is incorrectly named as being the n-hexane mechanism. In addition, the supplementary material from this second paper includes a spreadsheet with the exact experimental data plotted in `continuous_reactor.py`. 

_Open question_: one thing I'm not quite decided on is whether to just go with the simple rename of the mechanism file (as implemented here so far) or whether to introduce a shim file with the old name that issues a deprecation warning when you try to use it. That would avoid users getting a "file not found" error that doesn't explain what they need to do.

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Rename `n-hexane-NUIG-2015.yaml` to `n-heptane-NUIG-2016.yaml`
- Update examples using this mechanism to specify `NC7H16` as the fuel instead of `NC6H14`
- Fix `windows-2022` CI errors by pinning `micromamba` version

**AI Statement (required)**

- **No generative AI was used.** This contribution was written entirely without AI assistance.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [ ] The pull request is ready for review
