### PR TITLE
Fix using Pixi-provided compilers on Linux

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -313,11 +313,11 @@ config_options = [
     Option(
         "AR",
         "The archiver to use.",
-        "${AR}"),
+        os.environ.get("AR") or "${AR}"),
     Option(
         "CXX",
         "The C++ compiler to use.",
-        "${CXX}"),
+        os.environ.get("CXX") or "${CXX}"),
     Option(
         "cxx_flags",
         """Compiler flags passed to the C++ compiler only. Separate multiple
@@ -330,7 +330,7 @@ config_options = [
     Option(
         "CC",
         "The C compiler to use. This is only used to compile CVODE.",
-        "${CC}"),
+        os.environ.get("CC") or "${CC}"),
     Option(
         "cc_flags",
         """Compiler flags passed to both the C and C++ compilers, regardless of
@@ -397,10 +397,11 @@ config_options = [
         "default", ("y", "n", "default")),
     PathOption(
         "FORTRAN",
-        """The Fortran (90) compiler. If unspecified, the builder will look for a
-           compatible compiler (pgfortran, gfortran, ifort, ifx, g95) in the 'PATH'
-           environment variable. Used only for compiling the Fortran 90 interface.""",
-        "", PathVariable.PathAccept),
+        """The Fortran (90) compiler. If unspecified, the 'FC' environment variable is
+           used if set; otherwise the builder will look for a compatible compiler
+           (pgfortran, gfortran, ifort, ifx, g95) in the 'PATH' environment variable.
+           Used only for compiling the Fortran 90 interface.""",
+        os.environ.get("FC") or "", PathVariable.PathAccept),
     Option(
         "FORTRANFLAGS",
         "Compilation options for the Fortran (90) compiler.",

--- a/pixi.toml
+++ b/pixi.toml
@@ -31,8 +31,14 @@ pytest = ">=9.0.2,<10"
 "ruamel.yaml" = ">=0.19.1,<0.20"
 jinja2 = ">=3.1.6,<4"
 
+# Provide a self-consistent compiler toolchain matching the conda-forge-built
+# dependencies. The activation packages set CC/CXX/AR, which SConstruct honors. To build
+# with the system compiler instead, set `CXX = "g++"` and `CC = "gcc"` in cantera.conf.
 [feature.core.target.linux-64.dependencies]
-clangxx = ">=18.0"
+gxx_linux-64 = ">=13"
+
+[feature.core.target.linux-aarch64.dependencies]
+gxx_linux-aarch64 = ">=13"
 
 [feature.samples.dependencies]
 pandas = ">=3.0.0,<4"


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Make SCons look for `CC`/`CXX`/`AR`/`FC` environment variables for compiler setup (overridden by command line options and `cantera.conf`)
- Install the preferred compiler toolchain package rather than just the compiler package in Pixi environments, which sets the aforementioned variables and also avoids aliasing the system compiler toolchain's binaries.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

- Closes #2118

**AI Statement (required)**

- **Extensive use of generative AI.** Significant portions of code or documentation were generated with AI, including
  logic and implementation decisions. All generated code and documentation were reviewed and understood by the contributor. Implemented using Claude Code (Opus 4.8).

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
