### PR TITLE
New thermodynamic consistency tests

### DIFF
--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -31,7 +31,9 @@
 # supports setting the state using any of the variables supported there.
 
 ideal-gas-h2o2:
-  setup: {file: h2o2.yaml}
+  setup:
+    file: h2o2.yaml
+    atol_v: 5e-11  # finite difference noise floor in dh/dP for ideal gas
   states:
   - {T: 300, P: 101325, X: {H2: 0.1, O2: 0.7, H2O2: 0.1}}
   - {T: 300, P: 101325, Y: {H2: 0.1, O2: 0.7, H2O2: 0.1}}
@@ -103,6 +105,10 @@ electron-cloud:
   setup:
     file: thermo-models.yaml
     phase: Metal
+    known-failures:
+      v_eq_dgdP_const_T: Problematic handling of "density"; See GitHub Issue #2131.
+      dhdP_const_T_eq_v_minus_T_dvdT_const_P: >-
+        Problematic handling of "density"; See GitHub Issue #2131.
   states:
   - {T: 300, P: 1 atm}
   - {T: 400, P: 1 atm}
@@ -119,6 +125,14 @@ nitrogen-purefluid:
       cv_eq_.+/3: cv not defined in two-phase region
       cp_eq_sum_cpk_Xk: cp is inf in the two-phase region
       dsdP_const_T_eq_minus_dV_dT_const_P/3: Can't set TP in two-phase region
+      sk_eq_minus_dmu_k_dT_const_P_X/3:
+        Perturbing T crosses the saturation boundary in the two-phase region
+      vk_eq_dmu_k_dP_const_T_X/3:
+        Perturbing P crosses the saturation boundary in the two-phase region
+      v_eq_dgdP_const_T/3:
+        Perturbing P crosses the saturation boundary in the two-phase region
+      dhdP_const_T_eq_v_minus_T_dvdT_const_P/3:
+        Perturbing T or P crosses the saturation boundary in the two-phase region
   states:
   - {T: 300, P: 1 atm}
   - {T: 70, P: 1 atm}
@@ -129,6 +143,8 @@ plasma:
   setup:
     file: oxygen-plasma.yaml
     phase: discretized-electron-energy-plasma
+    # finite difference noise floor in dh/dP for the pure-electron state
+    atol_v: 5e-11
     known-failures:
       g_eq_h_minus_Ts/.+: Test does not account for distinct electron temperature
       u_eq_sum_uk_Xk/.+: Test does not account for distinct electron temperature
@@ -180,8 +196,14 @@ debye-huckel-B-dot-ak:
       gibbs_duhem_const_T_P: >-
         The B-dot model with per-ion size parameters (a_k) gives ionic activity
         coefficients whose composition dependence is not balanced by a consistent
-        solvent (water) activity, so sum_k X_k dmu_k != 0. Other Debye-Huckel
-        variants (single a, beta_ij, Pitzer beta_ij) satisfy Gibbs-Duhem.
+        solvent (water) activity, so sum_k X_k dmu_k != 0. See GitHub Issue #2132.
+      dmu_k_dNj_eq_dmu_j_dNk_const_T_P: >-
+        Same root cause as gibbs_duhem_const_T_P: the B-dot model with per-ion
+        size parameters gives ionic activity coefficients that depend on all
+        ionic molalities via species-specific a_k radii, but the solvent activity
+        is not adjusted to compensate. The mu_k therefore do not derive from a
+        single G(T, P, N), so the composition Hessian is not symmetric.
+        See GitHub Issue #2132.
   states: *debye-huckel-states
 
 debye-huckel-B-dot-ak-IAPWS:
@@ -190,11 +212,8 @@ debye-huckel-B-dot-ak-IAPWS:
     phase: debye-huckel-B-dot-ak-IAPWS
     rtol_fd: 1e-5  # Good finite difference results with IAPWS are challenging
     known-failures:
-      gibbs_duhem_const_T_P: >-
-        The B-dot model with per-ion size parameters (a_k) gives ionic activity
-        coefficients whose composition dependence is not balanced by a consistent
-        solvent (water) activity, so sum_k X_k dmu_k != 0. Other Debye-Huckel
-        variants (single a, beta_ij, Pitzer beta_ij) satisfy Gibbs-Duhem.
+      gibbs_duhem_const_T_P: See GitHub Issue #2132.
+      dmu_k_dNj_eq_dmu_j_dNk_const_T_P: See GitHub Issue #2132.
   states: *debye-huckel-states
 
 debye-huckel-B-dot-a:
@@ -303,7 +322,11 @@ coverage-dependent-surface:
         The coverage-dependent enthalpy and entropy corrections are applied to
         each species' chemical potential without the cross-species coupling
         required for the mu_k to derive from a single Gibbs energy function, so
-        sum_k X_k dmu_k != 0.
+        sum_k X_k dmu_k != 0. See GitHub Issue #2133.
+      dmu_k_dNj_eq_dmu_j_dNk_const_T_P: >-
+        Same root cause as gibbs_duhem_const_T_P: the coverage-dependent surface
+        chemical potentials are not consistent partial molar Gibbs energies of a single
+        G(T, P, N), so the composition Hessian is not symmetric. See GitHub Issue #2133.
   states:
   - {T: 700, P: 1 atm,
      coverages: {Pt: 0.0, OC_Pt: 0.1, CO2_Pt: 0.5, C_Pt: 0.1, O_Pt: 0.3}}
@@ -342,7 +365,7 @@ ideal-solution-VPSS-HKFT:
     # implementation of WaterPropsIAPWSphi::dfind, and the coarser finite difference
     # step used internally in PDSS_HKFT::dVdP() relative to the consistency test finite
     # difference step.
-    rtol_fd: 4e-6
+    rtol_fd: 1.5e-5  # limited by vk_eq_dmu_k_dP test for state 3
     atol_c: 5e-14
   states:
   - {T: 300, P: 1 atm, X: {H2O(L): 0.9, Na+: 0.05, Cl-: 0.05, H+: 1e-7, OH-: 1e-7}}
@@ -364,6 +387,7 @@ Redlich-Kister-complex:
   setup:
     file: thermo-models.yaml
     phase: Redlich-Kister-complex
+    rtol_fd: 3e-5  # Limited by state 2 due to PDSS finite difference sensitivity
   states:
   - {T: 900, P: 1 atm, X: {KCl(l): 0.85, LiCl(l): 0.15}}
   - {T: 950, P: 10 atm, X: {KCl(l): 0.3, LiCl(l): 0.2, NaCl(s): 0.5}}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -87,6 +87,9 @@ binary-solution-tabulated:
   setup:
     file: BinarySolutionTabulatedThermo.yaml
     phase: anode
+    known-failures:
+      gibbs_duhem_const_T_P/[012]: >-
+        Model does not satisfy Gibbs-Duhem relation. See GitHub Issue #1928.
   states:
   - {T: 300, P: 1 atm, X: {"Li[anode]": 0.3, "V[anode]": 0.7}}
   - {T: 320, P: 1 atm, X: {"Li[anode]": 0.3, "V[anode]": 0.7}}
@@ -173,6 +176,12 @@ debye-huckel-B-dot-ak:
   setup:
     file: debye-huckel-all.yaml
     phase: debye-huckel-B-dot-ak
+    known-failures:
+      gibbs_duhem_const_T_P: >-
+        The B-dot model with per-ion size parameters (a_k) gives ionic activity
+        coefficients whose composition dependence is not balanced by a consistent
+        solvent (water) activity, so sum_k X_k dmu_k != 0. Other Debye-Huckel
+        variants (single a, beta_ij, Pitzer beta_ij) satisfy Gibbs-Duhem.
   states: *debye-huckel-states
 
 debye-huckel-B-dot-ak-IAPWS:
@@ -180,6 +189,12 @@ debye-huckel-B-dot-ak-IAPWS:
     file: debye-huckel-all.yaml
     phase: debye-huckel-B-dot-ak-IAPWS
     rtol_fd: 1e-5  # Good finite difference results with IAPWS are challenging
+    known-failures:
+      gibbs_duhem_const_T_P: >-
+        The B-dot model with per-ion size parameters (a_k) gives ionic activity
+        coefficients whose composition dependence is not balanced by a consistent
+        solvent (water) activity, so sum_k X_k dmu_k != 0. Other Debye-Huckel
+        variants (single a, beta_ij, Pitzer beta_ij) satisfy Gibbs-Duhem.
   states: *debye-huckel-states
 
 debye-huckel-B-dot-a:
@@ -283,6 +298,12 @@ coverage-dependent-surface:
     file: copt_covdepsurf_example.yaml
     phase: covdep
     atol_v: 1e-7
+    known-failures:
+      gibbs_duhem_const_T_P: >-
+        The coverage-dependent enthalpy and entropy corrections are applied to
+        each species' chemical potential without the cross-species coupling
+        required for the mu_k to derive from a single Gibbs energy function, so
+        sum_k X_k dmu_k != 0.
   states:
   - {T: 700, P: 1 atm,
      coverages: {Pt: 0.0, OC_Pt: 0.1, CO2_Pt: 0.5, C_Pt: 0.1, O_Pt: 0.3}}

--- a/test/thermo_consistency/consistency.cpp
+++ b/test/thermo_consistency/consistency.cpp
@@ -334,6 +334,74 @@ TEST_P(TestConsistency, cp_eq_sum_cpk_Xk)
     EXPECT_NEAR(cp, phase->mean_X(cpk), atol);
 }
 
+TEST_P(TestConsistency, gibbs_duhem_const_T_P)
+{
+    // Gibbs-Duhem at constant T and P requires sum_k X_k * dmu_k = 0 for any
+    // change in composition. This is the differential complement to the Euler
+    // relation g = sum_k X_k * mu_k (tested by g_eq_sum_gk_Xk): together they
+    // are equivalent to the fundamental relation
+    // dU = T dS - P dV + sum_k mu_k dN_k. A model can report chemical potentials
+    // that satisfy the Euler relation at every individual state yet still violate
+    // this differential identity if the mu_k are not consistent partial molar
+    // Gibbs energies of a single underlying G(T, P, N).
+    vector<double> X0(nsp), mu_plus(nsp), mu_minus(nsp);
+    double T0 = phase->temperature();
+    double P0 = phase->pressure();
+    phase->getMoleFractions(X0);
+
+    // Only species that are actually present can be perturbed.
+    vector<size_t> active;
+    for (size_t k = 0; k < nsp; k++) {
+        if (k != ke && X0[k] > 1e-6) {
+            active.push_back(k);
+        }
+    }
+    if (active.size() < 2) {
+        GTEST_SKIP() << "Fewer than two species available to perturb composition";
+    }
+
+    // Test each independent composition direction by transferring a small amount
+    // of material from species active[0] to each of the other active species,
+    // using a centered difference about the original composition X0. The step is
+    // scaled to the smaller of the two mole fractions so that the relative
+    // perturbation (and hence the finite-difference truncation error) is the same
+    // regardless of how dilute the perturbed species are.
+    double eps = 1e-4;
+    size_t i = active[0];
+    for (size_t n = 1; n < active.size(); n++) {
+        size_t j = active[n];
+        double dx = eps * std::min(X0[i], X0[j]);
+        vector<double> Xp = X0, Xm = X0;
+        Xp[i] -= dx; Xp[j] += dx;
+        Xm[i] += dx; Xm[j] -= dx;
+
+        try {
+            phase->setMoleFractions(Xp);
+            phase->setState_TP(T0, P0);
+            phase->getChemPotentials(mu_plus);
+            phase->setMoleFractions(Xm);
+            phase->setState_TP(T0, P0);
+            phase->getChemPotentials(mu_minus);
+        } catch (NotImplementedError& err) {
+            GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+        }
+
+        double gd = 0.0;
+        double scale = 0.0;
+        for (size_t k = 0; k < nsp; k++) {
+            double term = X0[k] * (mu_plus[k] - mu_minus[k]);
+            gd += term;
+            scale = std::max(scale, std::abs(term));
+        }
+        EXPECT_NEAR(gd, 0.0, rtol_fd * scale + atol)
+            << "perturbing species " << i << " <-> " << j;
+    }
+
+    // Restore the original state for any subsequent use of the cached phase.
+    phase->setMoleFractions(X0);
+    phase->setState_TP(T0, P0);
+}
+
 TEST_P(TestConsistency, cp_eq_dhdT)
 {
     double h1, cp1;

--- a/test/thermo_consistency/consistency.cpp
+++ b/test/thermo_consistency/consistency.cpp
@@ -9,6 +9,7 @@
 #include "cantera/base/Solution.h"
 #include "cantera/base/utilities.h"
 #include <boost/algorithm/string.hpp>
+#include <limits>
 #include <regex>
 
 // This is a set of tests that check all ThermoPhase models implemented in Cantera
@@ -633,6 +634,208 @@ TEST_P(TestConsistency, c_eq_sqrt_dP_drho_const_s)
     double c_fd = sqrt((P2 - P1) / (rho2 - rho1));
 
     EXPECT_NEAR(c_fd, c_mid, max({rtol_fd * c_mid, rtol_fd * c_fd, atol}));
+}
+
+TEST_P(TestConsistency, sk_eq_minus_dmu_k_dT_const_P_X)
+{
+    // Composition<->T Maxwell relation: partial molar entropy s_k equals
+    // -(d mu_k / dT) at constant P and composition. The s_k are read at the
+    // midpoint T0 and compared with a central finite difference of mu_k.
+    vector<double> s_k(nsp), mu1(nsp), mu2(nsp);
+    double T0 = phase->temperature();
+    double P0 = phase->pressure();
+    double dT = 1e-5 * T0;
+    try {
+        phase->getPartialMolarEntropies(s_k);
+        phase->setState_TP(T0 - dT, P0);
+        phase->getChemPotentials(mu1);
+        phase->setState_TP(T0 + dT, P0);
+        phase->getChemPotentials(mu2);
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
+    phase->setState_TP(T0, P0); // restore cached state
+    for (size_t k = 0; k < nsp; k++) {
+        if (k == ke) {
+            continue; // electron species handled by two-temperature identities
+        }
+        double dmu_dT = (mu2[k] - mu1[k]) / (2 * dT);
+        EXPECT_NEAR(-dmu_dT, s_k[k],
+            max({rtol_fd * s_k[k], rtol_fd * std::abs(dmu_dT), atol}))
+            << "for species " << k;
+    }
+}
+
+TEST_P(TestConsistency, vk_eq_dmu_k_dP_const_T_X)
+{
+    // Composition<->P Maxwell relation: partial molar volume v_k equals
+    // (d mu_k / dP) at constant T and composition.
+    vector<double> v_k(nsp), mu1(nsp), mu2(nsp);
+    double T0 = phase->temperature();
+    double P0 = phase->pressure();
+    double dP = 1e-4 * P0;
+    try {
+        phase->getPartialMolarVolumes(v_k);
+        phase->setState_TP(T0, P0 - dP);
+        phase->getChemPotentials(mu1);
+        phase->setState_TP(T0, P0 + dP);
+        phase->getChemPotentials(mu2);
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
+    phase->setState_TP(T0, P0); // restore cached state
+    for (size_t k = 0; k < nsp; k++) {
+        if (k == ke) {
+            continue;
+        }
+        double dmu_dP = (mu2[k] - mu1[k]) / (2 * dP);
+        EXPECT_NEAR(dmu_dP, v_k[k],
+            max({rtol_fd * std::abs(v_k[k]), rtol_fd * std::abs(dmu_dP), atol_v}))
+            << "for species " << k;
+    }
+}
+
+TEST_P(TestConsistency, v_eq_dgdP_const_T)
+{
+    // dG pressure coefficient: molar volume equals (dG/dP) at constant T.
+    double T0 = phase->temperature();
+    double P0 = phase->pressure();
+    double v, g1, g2;
+    double dP = 1e-4 * P0;
+    try {
+        v = phase->molarVolume();
+        phase->setState_TP(T0, P0 - dP);
+        g1 = phase->gibbs_mole();
+        phase->setState_TP(T0, P0 + dP);
+        g2 = phase->gibbs_mole();
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
+    phase->setState_TP(T0, P0); // restore cached state
+    double dgdP = (g2 - g1) / (2 * dP);
+    double v_expected = v;
+    if (phase->type() == "plasma" && ke != npos) {
+        // For a two-temperature plasma, the electron species contributes an extra
+        // term because the pressure term in mu_e uses the electron temperature Te,
+        // giving (dG/dP)_T = V + X_e * R * (Te - T) / P (compare with h_eq_u_plus_Pv).
+        vector<double> X(nsp);
+        phase->getMoleFractions(X);
+        v_expected += X[ke] * (RTe - RT) / P0;
+    }
+    EXPECT_NEAR(dgdP, v_expected,
+        max({rtol_fd * std::abs(v_expected), rtol_fd * std::abs(dgdP), atol_v}));
+}
+
+TEST_P(TestConsistency, dhdP_const_T_eq_v_minus_T_dvdT_const_P)
+{
+    // dH pressure coefficient: (dH/dP)_T = V - T (dV/dT)_P. Both the dH/dP and
+    // the dV/dT derivatives use centered differences about (T0, P0).
+    double T0 = phase->temperature();
+    double P0 = phase->pressure();
+    double dP = 1e-4 * P0;
+    double dT = 1e-4 * T0;
+    double v, h1, v_lo;
+    try {
+        v = phase->molarVolume();
+        phase->setState_TP(T0, P0 - dP);
+        h1 = phase->enthalpy_mole();
+        phase->setState_TP(T0 - dT, P0);
+        v_lo = phase->molarVolume();
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
+    phase->setState_TP(T0, P0 + dP);
+    double h2 = phase->enthalpy_mole();
+    double dhdP = (h2 - h1) / (2 * dP);
+
+    phase->setState_TP(T0 + dT, P0);
+    double v_hi = phase->molarVolume();
+    double dvdT = (v_hi - v_lo) / (2 * dT);
+
+    phase->setState_TP(T0, P0); // restore cached state
+    double rhs = v - T0 * dvdT;
+    EXPECT_NEAR(dhdP, rhs,
+        max({rtol_fd * std::abs(dhdP), rtol_fd * std::abs(rhs), atol_v}));
+}
+
+TEST_P(TestConsistency, dmu_k_dNj_eq_dmu_j_dNk_const_T_P)
+{
+    // Symmetry of the composition Hessian of G: d mu_k / dN_j = d mu_j / dN_k.
+    // This is the pure-composition Maxwell relation, equivalent to the mu_k
+    // being the gradient of a single Gibbs energy G(T, P, N). It is only
+    // nontrivial with at least three independently variable species; for a
+    // binary solution, the single composition direction is already covered by
+    // gibbs_duhem_const_T_P. Mole fractions are treated as mole numbers with
+    // total N = 1; setMoleFractions renormalizes, so perturbing one entry is
+    // equivalent to adding that species to an open system.
+    //
+    // Each mu_k carries a large, composition-independent standard-state term,
+    // so differencing mu_k has a roundoff floor of order |mu|_max * eps_machine.
+    // Divided by the perturbation dN this gives a noise floor on each computed
+    // derivative, which is added to the comparison tolerance. Species too dilute to
+    // perturb meaningfully thus are given a large floor to avoid producing false
+    // positives.
+    vector<double> X0(nsp);
+    double T0 = phase->temperature();
+    double P0 = phase->pressure();
+    phase->getMoleFractions(X0);
+
+    vector<size_t> active;
+    for (size_t k = 0; k < nsp; k++) {
+        if (k != ke && X0[k] > 1e-6) {
+            active.push_back(k);
+        }
+    }
+    if (active.size() < 3) {
+        GTEST_SKIP() << "Fewer than three species: Hessian symmetry is trivial";
+    }
+
+    double eps = 1e-4;
+    double mu_mag = 0.0;
+    vector<double> dn(active.size());
+
+    // cols[a][k] = d mu_k / dN_{active[a]} via centered difference in N_{active[a]}
+    auto dmu_dN = [&](size_t a, vector<double>& col) {
+        size_t j = active[a];
+        dn[a] = eps * X0[j];
+        vector<double> np = X0, nm = X0, mu_p(nsp), mu_m(nsp);
+        np[j] += dn[a];
+        nm[j] -= dn[a];
+        phase->setMoleFractions(np);
+        phase->setState_TP(T0, P0);
+        phase->getChemPotentials(mu_p);
+        phase->setMoleFractions(nm);
+        phase->setState_TP(T0, P0);
+        phase->getChemPotentials(mu_m);
+        for (size_t k = 0; k < nsp; k++) {
+            col[k] = (mu_p[k] - mu_m[k]) / (2 * dn[a]);
+            mu_mag = std::max({mu_mag, std::abs(mu_p[k]), std::abs(mu_m[k])});
+        }
+    };
+
+    try {
+        vector<vector<double>> cols(active.size(), vector<double>(nsp));
+        for (size_t a = 0; a < active.size(); a++) {
+            dmu_dN(a, cols[a]);
+        }
+        double eps_mach = std::numeric_limits<double>::epsilon();
+        for (size_t a = 0; a < active.size(); a++) {
+            for (size_t b = a + 1; b < active.size(); b++) {
+                double kj = cols[b][active[a]]; // d mu_{active[a]} / dN_{active[b]}
+                double jk = cols[a][active[b]]; // d mu_{active[b]} / dN_{active[a]}
+                double scale = std::max(std::abs(kj), std::abs(jk));
+                double noise = 10 * mu_mag * eps_mach
+                               * std::max(1.0 / dn[a], 1.0 / dn[b]);
+                EXPECT_NEAR(kj, jk, rtol_fd * scale + noise + atol)
+                    << "species " << active[a] << " <-> " << active[b];
+            }
+        }
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
+
+    phase->setMoleFractions(X0);
+    phase->setState_TP(T0, P0); // restore cached state
 }
 
 // ---------- Tests for consistency of standard state properties ---------------


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

This PR adds several new thermodynamic consistency tests to the test suite, using the existing framework in `consistency.cpp`. These include the following identities:

- Gibbs-Duhem relation at constant T and P: $\sum_k X_k d\mu_k = 0$. This is the differential complement to the Euler relation $g = \sum_k X_k \mu_k$, both of which must be satisfied for the fundamental relation $dU = T dS - PdV + \sum_k X_k\mu_k$.
- pure-composition Maxwell relation, which requires that the mixed partials of $G$ commute: $\partial \mu_k/\partial N_j = \partial \mu_j/\partial N_k$
- Composition-temperature Maxwell relation: $s_k = - (d\mu_k/dT)_{P,X}$
- Per-species composition-pressure Maxwell relation: $v_k = (d\mu_k/dP)_{T,X}$.
- Combined composition-pressure Maxwell relation: $v = (dg/dP)_{T}$.
- Pressure derivative of enthalpy: $(dh/dP)_T = v - T(dv/dT)_P$

**If applicable, provide an example illustrating new features this pull request is introducing**

These new tests identified/confirmed several consistency issues, which are now documented:

- #1928
- #2131 
- #2132
- #2133 

**AI Statement (required)**

- **Extensive use of generative AI.** Significant portions of code or documentation were generated with AI, including  logic and implementation decisions. All generated code and documentation were reviewed and understood by the contributor. Implemented using Claude Code with Opus 4.8.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
