### PR TITLE
Check C++ samples for use of deprecated methods

### DIFF
--- a/doc/sphinx/develop/running-tests.md
+++ b/doc/sphinx/develop/running-tests.md
@@ -389,6 +389,46 @@ After the debugger reaches the error, the most useful command is the `where` com
 which will print a stack trace. The `up` command will move up the stack each time it is
 called and print the corresponding line of the source code.
 
+## Building and Debugging the C++ Samples
+
+The C++ samples in `samples/cxx` are not built by `scons build`. Build them explicitly
+with:
+```sh
+scons samples
+```
+They are also built automatically as a dependency when the corresponding tests are run.
+The resulting executables are placed in the build tree, for example
+`build/samples/cxx/bvp/blasius`. As with the C++ tests, running a sample directly
+requires that the operating system can find the Cantera shared library and data files;
+see [](sec-using-build-dir) for how to set `LD_LIBRARY_PATH` / `DYLD_LIBRARY_PATH` and
+`CANTERA_DATA`.
+
+When run as part of the test suite, each sample's output is compared against blessed
+reference files:
+```sh
+scons test-cxx-bvp          # build and run a single sample as a test
+scons test                  # run the full suite, including all samples
+```
+
+### Catching deprecated methods in samples and legacy tests
+
+When running the C++ samples and the legacy (`test_problems`) tests, SCons defines the
+`CANTERA_FATAL_DEPRECATION_WARNINGS` environment variable. When this variable is defined,
+Cantera turns deprecation warnings into exceptions (equivalent to calling
+{ct}`make_deprecation_warnings_fatal`), so that any use of a deprecated method aborts the
+program rather than printing a warning that goes unnoticed in the captured test output.
+The variable is read once, when Cantera is first initialized.
+
+To reproduce this behavior when running a sample directly — for instance, to find the
+source of a deprecated call under the debugger — define the variable before launching the
+program:
+```sh
+export CANTERA_FATAL_DEPRECATION_WARNINGS=1
+gdb --args build/samples/cxx/bvp/blasius
+```
+Leave the variable undefined to restore the default behavior, where deprecation warnings
+are printed but do not interrupt execution.
+
 ## Accessing Stack Traces
 
 Before resorting to running in the debugger, it can sometimes be helpful to get the

--- a/src/base/application.cpp
+++ b/src/base/application.cpp
@@ -85,6 +85,13 @@ Application::Application()
     // install a default logwriter that writes to standard output / standard error
     m_logwriter = make_unique<Logger>();
     setDefaultDirectories();
+    // if the environment variable CANTERA_FATAL_DEPRECATION_WARNINGS is defined,
+    // turn deprecation warnings into exceptions. The variable's value is ignored;
+    // only its presence matters. Used to ensure that tests and samples do not rely
+    // on deprecated methods.
+    if (getenv("CANTERA_FATAL_DEPRECATION_WARNINGS") != nullptr) {
+        make_deprecation_warnings_fatal();
+    }
 }
 
 Application* Application::Instance()

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -299,7 +299,10 @@ public:
     }
 
     //! Turns deprecation warnings into exceptions. Activated within the test
-    //! suite to make sure that no deprecated methods are being used.
+    //! suite to make sure that no deprecated methods are being used. This is also
+    //! enabled process-wide when the environment variable
+    //! `CANTERA_FATAL_DEPRECATION_WARNINGS` is defined (the value is ignored), as
+    //! done by SCons when running the legacy tests and C++ samples.
     void make_deprecation_warnings_fatal() {
         m_fatal_deprecation_warnings = true;
     }

--- a/test/general/test_misc.cpp
+++ b/test/general/test_misc.cpp
@@ -6,8 +6,53 @@
 #include "cantera/base/global.h"
 #include "cantera/base/Solution.h"
 
+#include <cstdlib>
+
 using namespace Cantera;
 using ::testing::HasSubstr;
+
+namespace {
+
+void setFatalDeprecationEnv(bool enable)
+{
+    // The value is ignored by Cantera; only the presence of the variable matters.
+#ifdef _WIN32
+    _putenv_s("CANTERA_FATAL_DEPRECATION_WARNINGS", enable ? "1" : "");
+#else
+    if (enable) {
+        setenv("CANTERA_FATAL_DEPRECATION_WARNINGS", "1", 1);
+    } else {
+        unsetenv("CANTERA_FATAL_DEPRECATION_WARNINGS");
+    }
+#endif
+}
+
+} // namespace
+
+// Verify that defining the CANTERA_FATAL_DEPRECATION_WARNINGS environment variable
+// makes deprecation warnings fatal. The variable is read once when the Application
+// singleton is constructed (see Application::Application), so appdelete() is used to
+// force it to be reconstructed and the variable re-read. The configuration set in
+// main() (see string_processing.cpp) is restored at the end for subsequent tests.
+TEST(Deprecation, fatal_from_environment) {
+    setFatalDeprecationEnv(true);
+    appdelete();
+    EXPECT_THROW(warn_deprecated("Deprecation::fatal_from_environment", "testing"),
+                 CanteraError);
+
+    // Without the variable defined, the same warning is non-fatal. Suppress it to
+    // avoid polluting the test output.
+    setFatalDeprecationEnv(false);
+    appdelete();
+    suppress_deprecation_warnings();
+    EXPECT_NO_THROW(warn_deprecated("Deprecation::fatal_from_environment", "testing"));
+
+    // Restore the configuration established in main() for any subsequent tests.
+    appdelete();
+    make_deprecation_warnings_fatal();
+    addDataDirectory("test/data");
+    addDataDirectory("data");
+}
 
 TEST(FatalError, stacktrace) {
     EXPECT_DEATH(std::abort(), "Stack trace");

--- a/test_problems/SConscript
+++ b/test_problems/SConscript
@@ -19,6 +19,11 @@ localenv['ENV']['CANTERA_DATA'] = (Dir('#data').abspath + os.pathsep +
                                    Dir('#samples/data').abspath + os.pathsep +
                                    Dir('#test/data').abspath)
 
+# Turn deprecation warnings into errors so that legacy tests and C++ samples that
+# use deprecated methods cause the corresponding test to fail (see Application
+# constructor in src/base/application.cpp).
+localenv['ENV']['CANTERA_FATAL_DEPRECATION_WARNINGS'] = '1'
+
 PASSED_FILES = {}
 
 


### PR DESCRIPTION
**Changes proposed in this pull request**

- Make Cantera honor a new `CANTERA_FATAL_DEPRECATION_WARNINGS` environment variable: when defined, the `Application` singleton turns deprecation warnings into exceptions at startup (equivalent to `make_deprecation_warnings_fatal()`), read once when Cantera is first initialized.
- Define `CANTERA_FATAL_DEPRECATION_WARNINGS` in the SCons test environment for all `test_problems` (legacy) tests and C++ samples, so that any use of a deprecated method now causes the corresponding test to fail with a nonzero exit code instead of printing a warning that goes unnoticed in the (mostly uncompared) sample output.
- Add a GoogleTest case (`Deprecation.fatal_from_environment`) verifying that defining the variable makes
`warn_deprecated()` throw, and that the behavior reverts when it is unset.
- Document building/running/debugging the C++ samples and the new variable in `doc/sphinx/develop/running-tests.md`, with a doxygen note on `Application::make_deprecation_warnings_fatal()`.

**If applicable, fill in the issue number this pull request is fixing**

Closes #1603

**If applicable, provide an example illustrating new features this pull request is introducing**

With this change, deprecated method usage in a sample is no longer silent:

```sh
export CANTERA_FATAL_DEPRECATION_WARNINGS=1
./build/samples/cxx/bvp/blasius     # aborts with a CanteraError instead of printing
                                    # "DeprecationWarning: ..." and continuing
```

Because SCons sets this variable when running the sample and legacy test suites, `scons test-cxx-bvp` (and `scons test`
generally) will now fail if a deprecated method is exercised.

**AI Statement (required)**

- **Extensive use of generative AI.** Significant portions of the code and documentation in this pull request were generated with Claude Opus 4.8 (Claude Code), including implementation decisions. All generated code and documentation were reviewed and understood by the contributor.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing
guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review