### PR TITLE
Address tpx convergence issue

### DIFF
--- a/src/tpx/Sub.cpp
+++ b/src/tpx/Sub.cpp
@@ -11,6 +11,7 @@
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/global.h"
 #include <cmath>
+#include <limits>
 
 using namespace Cantera;
 
@@ -300,17 +301,15 @@ double Substance::x()
 double Substance::Tsat(double p)
 {
     double Tsave = T;
-    if (p <= 0. || p > Pcrit()) {
-        // @todo: this check should also fail below the triple point pressure
-        // (calculated as Ps() for Tmin() as it is not available as a numerical
-        // parameter). A bug causing low-temperature TP setters to fail for
-        // Heptane (GitHub issue #605) prevents this at the moment.
-        // Without this check, a calculation attempt fails with the less
-        // meaningful error "No convergence" below.
-        throw CanteraError("Substance::Tsat",
-                           "Illegal pressure value: {}", p);
-    }
+    // The minimum pressure is not stored as a numerical parameter, so it is evaluated
+    // as the saturation pressure at the minimum temperature. Note that minimum
+    // temperature and pressure are often defined at the triple point.
+    T = Tmin();
+    double Pmin = Ps();
     T = Tsave;
+    if (p <= 0. || p > Pcrit() || p < Pmin) {
+        throw CanteraError("Substance::Tsat", "Illegal pressure value: {}", p);
+    }
     Tsave = T;
 
     int LoopCount = 0;
@@ -801,9 +800,43 @@ void Substance::set_TPp(double Temp, double Pressure)
     T = Temp;
     v_here = vp();
 
+    // Track the previous iterate so that a sign change in the pressure residual
+    // can be detected and turned into a bracket (see below).
+    double v_prev = v_here;
+    double P_prev = 0.0;
+    double res_prev = 0.0;
+    bool have_prev = false;
+
     // loop
     while (P_here = Pp(),
             fabs(Pressure - P_here) >= ErrP* Pressure || LoopCount == 0) {
+        double res = P_here - Pressure;
+        if (have_prev && kbr == 0 && res*res_prev < 0.0) {
+            // The residual changed sign between the previous and current specific
+            // volume, so the root lies between them. On the steep liquid branch at low
+            // temperature the iteration can step across the (very thin) target band
+            // without the logic below ever recording a bracket, leaving the solver
+            // unable to converge. Capture the bracket explicitly so the in-bracket
+            // refinement below can proceed. Pressure decreases with specific volume
+            // here, so the smaller volume is the lower bound.
+            if (v_here < v_prev) {
+                Vmin = v_here;
+                Pmin = P_here;
+                Vmax = v_prev;
+                Pmax = P_prev;
+            } else {
+                Vmin = v_prev;
+                Pmin = P_prev;
+                Vmax = v_here;
+                Pmax = P_here;
+            }
+            kbr = 1;
+        }
+        v_prev = v_here;
+        P_prev = P_here;
+        res_prev = res;
+        have_prev = true;
+
         if (P_here < 0.0) {
             BracketSlope(Pressure);
         } else {
@@ -859,8 +892,16 @@ void Substance::set_TPp(double Temp, double Pressure)
             dv *= dvm/dva;
         }
         v_here += dv;
-        if (dv == 0.0) {
-            throw CanteraError("Substance::set_TPp", "dv = 0 and no convergence");
+        if (fabs(dv) <= 4.0*std::numeric_limits<double>::epsilon()*fabs(v_here)) {
+            // The volume step has dropped below the resolution of the specific volume
+            // in double precision, so no nearer representable volume brings the brings
+            // the pressure closer to the target. This is convergence to floating-point
+            // precision rather than a failure: it occurs on the nearly incompressible
+            // liquid branch at low temperature, where the saturation pressure is so
+            // small that the requested relative pressure tolerance is finer than one
+            // floating-point ULP of pressure, and when the initial density guess
+            // already sits at the root.
+            break;
         }
         Set(PropertyPair::TV, Temp, v_here);
         LoopCount++;

--- a/test/matlab/ctTestPureFluid.m
+++ b/test/matlab/ctTestPureFluid.m
@@ -343,13 +343,12 @@ classdef ctTestPureFluid < ctTestCase
                 self.verifySubstring(ME.message, 'Illegal temperature value');
             end
 
-            % Test disabled pending fix of Github Issue #605
             try
                 self.fluid.TP = {300, 0.999 * psat};
                 t1 = self.fluid.satTemperature;
             catch ME
                 self.verifySubstring(ME.identifier, 'Cantera:ctError');
-                % self.verifySubstring(ME.message, 'Illegal pressure value');
+                self.verifySubstring(ME.message, 'Illegal pressure value');
             end
         end
 

--- a/test/python/test_purefluid.py
+++ b/test/python/test_purefluid.py
@@ -271,10 +271,28 @@ class TestPureFluid:
         with pytest.raises(ct.CanteraError, match='Illegal temperature'):
             self.water.TP = .999 * self.water.min_temp, ct.one_atm
             self.water.P_sat
-        # @todo: test disabled pending fix of GitHub issue #605
-        # with pytest.raises(ct.CanteraError, match='Illegal pressure value'):
-        #     self.water.TP = 300, .999 * psat
-        #     self.water.T_sat
+        with pytest.raises(ct.CanteraError, match='Illegal pressure value'):
+            self.water.TP = 300, .999 * psat
+            self.water.T_sat
+
+    @pytest.mark.parametrize("name", [
+        "water", "nitrogen", "methane", "hydrogen", "oxygen", "carbon-dioxide",
+        "heptane", "HFC-134a",
+    ])
+    def test_set_TP_near_min_temp(self, name):
+        # Setting a compressed-liquid state at the minimum temperature must
+        # converge for every pure fluid. Regression test for GitHub issue #605:
+        # Heptane failed for TP setters below ~204 K because, on the nearly
+        # incompressible liquid branch, the saturation pressure is so small
+        # that the set_TPp solver stepped across the (very thin) target band
+        # without recording a bracket and never converged. The solver now
+        # detects the residual sign change to bracket the root and accepts a
+        # root resolved to within floating-point precision.
+        fluid = ct.PureFluid("liquidvapor.yaml", name)
+        fluid.TP = fluid.min_temp, ct.one_atm
+        assert fluid.T == approx(fluid.min_temp)
+        assert fluid.P == approx(ct.one_atm)
+        assert fluid.density > 0
 
     def test_TPQ(self):
         self.water.TQ = 400, 0.8


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the
list below. For further questions, refer to the contributing guide
(https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix `tpx::Substance::set_TPp` so that it converges on the nearly incompressible liquid branch at low temperature. There, the saturation pressure becomes so small that the solver's requested *relative* pressure tolerance (`ErrP * Pressure`) is finer than one floating-point ULP of pressure, so the iteration could never satisfy it and bailed out with a spurious `No convergence` error. The iteration now (a) detects a sign change of the pressure residual between successive iterates to bracket the root, and (b) terminates by accepting the root once the volume step drops below the floating-point resolution of the specific volume. `TP` setters now work down to each pure fluid's minimum temperature.
- Make `tpx::Substance::Tsat` reject pressures below the minimum pressure (evaluated as the saturation pressure at the minimum temperature) with the meaningful `Illegal pressure value` error, instead of failing later with the opaque `No convergence`. This removes a deferred `@todo`.
- Add a regression test (`test_set_TP_near_min_temp`) that sets a compressed-liquid state at the minimum temperature for every pure fluid, and re-enable the previously disabled below-triple-point `Tsat` test.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository,
use Cantera/enhancements#<issue>. -->

Closes #605

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See
https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example.
-->

The example from the issue now succeeds instead of raising `CanteraError`:

```python
import cantera as ct

p = ct.Heptane()
p.TP = 204.4, ct.one_atm      # previously: "no convergence for P* = ..."
print(p.density)              # 777.37 kg/m^3

# also works all the way down to the minimum temperature
p.TP = p.min_temp, ct.one_atm
print(p.T, p.density)         # 182.56  803.57 kg/m^3
```

AI Statement (required)

- **Extensive use of generative AI.** The root-cause analysis and implementation were carried out with Claude Code (Opus 4.8). All scoping and design decisions were made by the contributor, and every generated change was reviewed, understood, and validated (numerical reproduction of the solver behavior plus the full pure-fluid and units test suites) by the contributor.

Checklist

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (scons build & scons test) and unit tests address code coverage
- [x] Style & formatting of contributed code follows contributing guidelines
- [x] AI Statement is included
- [x] The pull request is ready for review