### PR TITLE
Fix issue 2138: None checks for FlameBase restart data

### DIFF
--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -807,7 +807,7 @@ class BurnerFlame(FlameBase):
         `FlameBase.set_initial_guess`).
         """
         super().set_initial_guess(data=data, group=group)
-        if data:
+        if data is not None:
             return
 
         self.gas.TPY = self.burner.T, self.P, self.burner.Y
@@ -939,7 +939,7 @@ class CounterflowDiffusionFlame(FlameBase):
             If ``data`` is provided, this option is ignored.
         """
         super().set_initial_guess(data=data, group=group)
-        if data:
+        if data is not None:
             return
         if mode not in ("stoich", "linear"):
             raise ValueError("mode must be 'stoich' or 'linear'")
@@ -1295,7 +1295,7 @@ class ImpingingJet(FlameBase):
         `FlameBase.set_initial_guess`).
         """
         super().set_initial_guess(data=data, group=group, products=products)
-        if data:
+        if data is not None:
             return
 
         Y0 = self.inlet.Y
@@ -1376,7 +1376,7 @@ class CounterflowPremixedFlame(FlameBase):
         `FlameBase.set_initial_guess`).
         """
         super().set_initial_guess(data=data, group=group, equilibrate=equilibrate)
-        if data:
+        if data is not None:
             return
 
         Yu = self.reactants.Y
@@ -1476,7 +1476,7 @@ class CounterflowTwinPremixedFlame(FlameBase):
         `FlameBase.set_initial_guess`).
         """
         super().set_initial_guess(data=data, group=group)
-        if data:
+        if data is not None:
             return
 
         if self.reactants.mdot == 0:


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

Fixes bug where certain flamelet types would fail when providing the initial guess through a pandas DataFrame. 

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Type comparison between restart data and None when reading initial guess.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #2138 

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

The following code snippet runs a burner-stabilized flamelet simulation from a previous solution by providing the initial guess through a Pandas DataFrame object. Cantera would previously fail when loading the initial guess, with the code in this PR this example runs just fine.
```
import cantera as ct 
import pandas as pd
import matplotlib.pyplot as plt 


def solveBurnerFlame(T_burner:float=300, mdot:float=0.25, restart_data:pd.DataFrame=None):
    gas = ct.Solution("h2o2.yaml")
    gas.TP=300,ct.one_atm
    gas.set_equivalence_ratio(0.6, "H2:1","O2:1,N2:3.76")
    burnerflame = ct.BurnerFlame(gas, width=2e-2)
    burnerflame.burner.T = T_burner
    burnerflame.burner.mdot = mdot
    burnerflame.set_initial_guess(data=restart_data)
    burnerflame.transport_model = "multicomponent"
    burnerflame.solve(auto=(restart_data is None))
    return burnerflame


burnerflame_initial = solveBurnerFlame()
restart_data = burnerflame_initial.to_pandas()
burnerflame_restarted = solveBurnerFlame(mdot=0.13, restart_data=restart_data)

plt.plot(burnerflame_initial.grid, burnerflame_initial.T,'b',label='Initial solution')
plt.plot(burnerflame_restarted.grid, burnerflame_restarted.T,'r',label='Restarted solution')
plt.show()
```

-  This contribution was written entirely without AI
  assistance.

For additional information on Cantera's AI policy, see
https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md#restrictions-on-generative-ai-usage -->


**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ ] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
