### PR TITLE
[SolutionArray] Ensure state is restored in setLoc

### DIFF
--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -806,7 +806,7 @@ void SolutionArray::setLoc(int loc, bool restore)
             "Unable to set location in empty SolutionArray.");
     } else if (loc < 0 || loc_ >= m_size) {
         throw IndexError("SolutionArray::setLoc", "indices", loc_, m_size);
-    } else if (static_cast<size_t>(m_active[loc_]) == m_loc) {
+    } else if (!restore && static_cast<size_t>(m_active[loc_]) == m_loc) {
         return;
     }
     m_loc = static_cast<size_t>(m_active[loc_]);

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -347,6 +347,18 @@ class TestSolutionArray:
             assert orig.P == approx(loaded.P)
             assert orig.X == approx(loaded.X)
 
+    def test_update_state(self, gas):
+        arr1 = ct.SolutionArray(gas, (1,))
+        arr1.TPX = 300, ct.one_atm, {"H2": .5, "O2": .5}
+        T1, P1, X1 = arr1.TPX
+        arr2 = ct.SolutionArray(gas, (1,))
+        arr2.TPX = 500, 2.0 * ct.one_atm, {"N2": 1.0}
+        T2, P2, X2 = arr2.TPX
+        assert arr1.T == approx(T1)
+        assert arr1.T != approx(T2)
+        assert arr1.X == approx(X1)
+        assert arr1.X != approx(X2)
+
 @pytest.fixture(scope='class')
 def setup_solution_array_info_tests(request):
     request.cls.gas = ct.Solution('h2o2.yaml', transport_model=None)


### PR DESCRIPTION
**Changes proposed in this pull request**

Fix a bug in `SolutionArray::setLoc` where the state was not being updated if other `SolutionArray` objects already set a state in the same location.

**If applicable, fill in the issue number this pull request is fixing**

Closes #2148 

**AI Statement (required)**

- **No generative AI was used.** This contribution was written entirely without AI
  assistance.

**Checklist**

- [X] The pull request includes a clear description of this code change
- [X] Commit messages have short titles and reference relevant issues
- [X] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [X] AI Statement is included
- [X] The pull request is ready for review
