### PR TITLE
Fix incorrect ylabel in catalytic_combustion.py

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -8,6 +8,7 @@ update, please report on Cantera's
 [Github issue tracker](https://github.com/Cantera/cantera/issues).
 
 - **Rounak Agarwal** [@agarwalrounak](https://github.com/agarwalrounak)
+- **Mohamed Ahmed** [@hazalkoom](https://github.com/hazalkoom) - Mansoura University
 - **David Akinpelu** [@DavidAkinpelu](https://github.com/DavidAkinpelu)
 - **Halla Ali** [@hallaali](https://github.com/hallaali)
 - **Emil Atz** [@EmilAtz](https://github.com/EmilAtz)

--- a/samples/python/onedim/catalytic_combustion.py
+++ b/samples/python/onedim/catalytic_combustion.py
@@ -17,6 +17,7 @@ Requires: cantera >= 3.0, matplotlib >= 2.0
 """
 
 import numpy as np
+
 import matplotlib.pyplot as plt
 import cantera as ct
 
@@ -144,16 +145,15 @@ sim.show_stats()
 # %%
 # Temperature Profile
 # -------------------
-fig, ax = plt.subplots()
+fig, ax = plt.subplots(num="Temperature Profile")
 ax.plot(sim.grid, sim.T, color='C3')
-ax.set_ylabel('heat release rate [MW/m³]')
-ax.set(xlabel='distance from inlet [m]')
+ax.set(xlabel='distance from inlet [m]', ylabel='temperature [K]')
 plt.show()
 
 # %%
 # Major Species Profiles
 # ----------------------
-fig, ax = plt.subplots()
+fig, ax = plt.subplots(num="Major Species Profiles")
 major = ('O2', 'CH4', 'H2O', 'CO2')
 states = sim.to_array()
 ax.plot(states.grid, states(*major).X, label=major)


### PR DESCRIPTION
Fix incorrect ylabel in catalytic_combustion.py

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Upgrade the plot in `catalytic_combustion.py` to show both Temperature and Heat Release Rate using twin y-axes.
- Corrects a typo where only Temperature was plotted but the axis was labeled as heat release rate.
- Ensures the example matches the style of other 1D flame examples in Cantera.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #2154

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->


**AI Statement (required)**

<!-- Please include one of the following options in your PR description:
...
-->

- **Limited use of generative AI.** I fixed the issue doing the suggested solution and used AI to check it and improve it.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review