### PR TITLE
[Equil] Handle mixtures where element potentials are indeterminate

### DIFF
--- a/include/cantera/equil/ChemEquil.h
+++ b/include/cantera/equil/ChemEquil.h
@@ -41,6 +41,18 @@ public:
      */
     bool enforceTemperatureLimits = false;
 
+    /**
+     * Warn when the element potentials cannot be resolved to `relTolerance` and a
+     * reduced-accuracy solution is returned.
+     *
+     * Should be disabled by callers that respond to such a return by falling back to
+     * a different solver, since in that case the reduced-accuracy solution is
+     * discarded and there is nothing for the user to act on.
+     *
+     * @since New in %Cantera 4.0.
+     */
+    bool warnOnInexactConvergence = true;
+
 };
 
 /**
@@ -90,6 +102,9 @@ public:
      * The value of two specified properties are obtained by querying the
      * ThermoPhase object. The properties must be already contained within the
      * current thermodynamic state of the system.
+     *
+     * @return See the other equilibrate() overload for the meaning of the return
+     *     value.
      */
     int equilibrate(ThermoPhase& s, const char* XY, int loglevel = 0);
 
@@ -105,9 +120,14 @@ public:
      * @param XY property pair to hold constant
      * @param elMoles specified vector of element abundances.
      * @param loglevel Specify amount of debug logging (0 to disable)
-     * @return Successful returns are indicated by a return value of 0.
-     *     Unsuccessful returns are indicated by a return value of -1 for lack
-     *     of convergence or -3 for a singular Jacobian.
+     * @return Successful returns are indicated by a return value of 0. A return
+     *     value of 1 indicates that the element potentials could not be resolved to
+     *     the specified tolerance because the problem is too poorly conditioned, and
+     *     that a solution of reduced accuracy is being returned; see
+     *     EquilOpt::warnOnInexactConvergence. Unsuccessful returns are indicated by a
+     *     return value of -1 for lack of convergence or -3 for a singular Jacobian.
+     *
+     * @since The possible return value of 1 is new in %Cantera 4.0.
      */
     int equilibrate(ThermoPhase& s, const char* XY, span<double> elMoles,
                     int loglevel = 0);

--- a/src/equil/ChemEquil.cpp
+++ b/src/equil/ChemEquil.cpp
@@ -13,6 +13,7 @@
 #include "cantera/thermo/ThermoPhase.h"
 #include "cantera/base/utilities.h"
 #include "cantera/base/global.h"
+#include "cantera/numerics/eigen_dense.h"
 
 namespace Cantera
 {
@@ -577,15 +578,55 @@ int ChemEquil::equilibrate(ThermoPhase& s, const char* XYstr,
     }
 
     vector<double> oldx(nvar, 0.0); // old solution
+    // Stall detection: a mixture whose equilibrium composition is dominated by a few
+    // species can leave some element potentials determined only by trace species,
+    // making the numerically-evaluated Jacobian rank deficient. Plain LU then returns a
+    // meaningless step along the null direction. Detect the resulting lack of progress
+    // and switch to a rank-truncated step, which holds the unresolvable directions
+    // fixed.
+    bool stalled = false;
+    bool rankDeficient = false;
+    int noProgress = 0;
+    double bestResid = BigNumber;
+    double maxResid = 0.0;
+    double dxmax = 0.0;
+    // Largest relative error in the element abundances that will be accepted as a
+    // reduced-accuracy solution. Beyond this, the result is too inaccurate to be
+    // useful, and lack of convergence is reported instead.
+    const double maxInexactResid = 1e-5;
+
+    // Any error raised while evaluating the residual, the Jacobian, or the Newton step
+    // means the iteration has reached a point where the element potential formulation
+    // can no longer be evaluated. How this manifests depends on the linear algebra
+    // backend: LAPACK reports a singular Jacobian from the LU factorization, while
+    // Eigen silently returns a step containing infinities, so that the failure instead
+    // surfaces as a composition that cannot be normalized. The cause and the remedy are
+    // the same in either case, so handle them identically. This helper restores the
+    // saved state and returns the error for the caller to throw.
+    auto iterationError = [&](int iter, const CanteraError& err) {
+        s.restoreState(state);
+        return CanteraError("ChemEquil::equilibrate",
+            fmt::format("The element potential iteration failed at iteration {}.\n",
+                        iter)
+            + "The equilibrium state of this mixture cannot be resolved using the "
+              "element potential formulation.\nConsider trying the 'gibbs' or 'vcs' "
+              "solver, which use a different formulation.\n\n"
+              "The underlying error was:\n" + err.getMessage());
+    };
 
     for (int iter = 0; iter < options.maxIterations; iter++) {
         // check for convergence.
-        equilResidual(s, x, elMolesGoal, res_trial, xval, yval);
+        try {
+            equilResidual(s, x, elMolesGoal, res_trial, xval, yval);
+        } catch (CanteraError& err) {
+            throw iterationError(iter, err);
+        }
         double xx = m_p1(s);
         double yy = m_p2(s);
         double deltax = (xx - xval)/xval;
         double deltay = (yy - yval)/yval;
         bool passThis = true;
+        maxResid = 0.0;
         for (size_t m = 0; m < nvar; m++) {
             double tval = options.relTolerance;
             if (m < mm) {
@@ -610,10 +651,55 @@ int ChemEquil::equilibrate(ThermoPhase& s, const char* XYstr,
             if (fabs(res_trial[m]) > tval) {
                 passThis = false;
             }
+            maxResid = std::max(maxResid, fabs(res_trial[m]) / tval);
         }
-        if (iter > 0 && passThis && fabs(deltax) < options.relTolerance
+        if (maxResid < 0.9 * bestResid) {
+            bestResid = maxResid;
+            noProgress = 0;
+        } else if (++noProgress > 20) {
+            stalled = true;
+        }
+        // A solution that does not meet the requested tolerance is accepted only if
+        // the Jacobian was actually found to be rank deficient, the iteration is no
+        // longer moving, and the residual that remains is small in absolute terms.
+        // Without these conditions, an ordinary convergence failure would be
+        // indistinguishable from the ill-conditioned case handled here.
+        bool inexact = stalled && rankDeficient && dxmax < 1e-12
+                       && maxResid * options.relTolerance < maxInexactResid;
+        if ((passThis || inexact)
+                && fabs(deltax) < options.relTolerance
                 && fabs(deltay) < options.relTolerance) {
             options.iterations = iter;
+            if (!passThis && options.warnOnInexactConvergence) {
+                // Report the accuracy actually achieved in terms of the largest
+                // relative error in the mole fraction of any element.
+                double relErr = 0.0;
+                size_t worst = 0;
+                for (size_t m = 0; m < mm; m++) {
+                    if (elMolesGoal[m] > m_elemFracCutoff) {
+                        double err = fabs(m_elementmolefracs[m] - elMolesGoal[m])
+                                     / elMolesGoal[m];
+                        if (err > relErr) {
+                            relErr = err;
+                            worst = m;
+                        }
+                    }
+                }
+                warn_user("ChemEquil::equilibrate",
+                    "The equilibrium composition of this mixture is dominated by a "
+                    "few species, leaving some element potentials determined only "
+                    "by species present in trace amounts.\nThese potentials cannot "
+                    "be resolved to the requested relative tolerance of {:g}.\n"
+                    "Returning the most accurate solution available, in which the "
+                    "mole fraction of element {} deviates from the specified value "
+                    "by a relative amount of {:g}.\nErrors in the computed species "
+                    "mole fractions are expected to be of a similar relative "
+                    "magnitude, and may be much larger for species present in trace "
+                    "amounts.\nConsider using the 'gibbs' or 'vcs' solvers, which do "
+                    "not use the element potential formulation and can usually meet "
+                    "the specified tolerance for such mixtures.",
+                    options.relTolerance, s.elementName(worst), relErr);
+            }
 
             if (m_eloc != npos) {
                 adjustEloc(s, elMolesGoal);
@@ -625,14 +711,18 @@ int ChemEquil::equilibrate(ThermoPhase& s, const char* XYstr,
                     "Temperature ({} K) outside valid range of {} K "
                     "to {} K", s.temperature(), s.minTemp(), s.maxTemp());
             }
-            return 0;
+            return passThis ? 0 : 1;
         }
         // compute the residual and the Jacobian using the current
         // solution vector
-        equilResidual(s, x, elMolesGoal, res_trial, xval, yval);
+        try {
+            equilResidual(s, x, elMolesGoal, res_trial, xval, yval);
 
-        // Compute the Jacobian matrix
-        equilJacobian(s, x, elMolesGoal, jac, xval, yval);
+            // Compute the Jacobian matrix
+            equilJacobian(s, x, elMolesGoal, jac, xval, yval);
+        } catch (CanteraError& err) {
+            throw iterationError(iter, err);
+        }
 
         if (m_loglevel > 0) {
             writelogf("Jacobian matrix %d:\n", iter);
@@ -660,13 +750,26 @@ int ChemEquil::equilibrate(ThermoPhase& s, const char* XYstr,
 
         // Solve the system
         try {
-            solve(jac, res_trial);
+            if (stalled) {
+                // Rank-truncated least-squares step: components of the step
+                // along directions the Jacobian cannot resolve are dropped.
+                MappedMatrix J(const_cast<double*>(jac.data().data()),
+                               jac.nRows(), jac.nColumns());
+                Eigen::JacobiSVD<Eigen::MatrixXd> svd(
+                    J, Eigen::ComputeThinU | Eigen::ComputeThinV);
+                // The Jacobian is evaluated by forward differences with a relative
+                // perturbation of 1e-7 (see equilJacobian()), so its elements are
+                // themselves only accurate to a relative error of that order.
+                // Singular values below this threshold are indistinguishable from
+                // the noise in the finite difference approximation.
+                svd.setThreshold(1e-7);
+                rankDeficient = svd.rank() < nvar;
+                asVectorXd(res_trial) = svd.solve(asVectorXd(res_trial).eval());
+            } else {
+                solve(jac, res_trial);
+            }
         } catch (CanteraError& err) {
-            s.restoreState(state);
-            throw CanteraError("ChemEquil::equilibrate",
-                               "Jacobian is singular. \nTry adding more species, "
-                               "changing the elemental composition slightly, \nor removing "
-                               "unused elements.\n\n" + err.getMessage());
+            throw iterationError(iter, err);
         }
 
         // find the factor by which the Newton step can be multiplied
@@ -712,6 +815,10 @@ int ChemEquil::equilibrate(ThermoPhase& s, const char* XYstr,
         scale(res_trial.begin(), res_trial.end(), res_trial.begin(), fctr);
 
         dampStep(oldx, res_trial, x);
+        dxmax = 0.0;
+        for (size_t m = 0; m < nvar; m++) {
+            dxmax = std::max(dxmax, fabs(x[m] - oldx[m]));
+        }
     }
 
     // no convergence
@@ -1300,9 +1407,12 @@ int ChemEquil::estimateEP_Brinkley(ThermoPhase& s, span<double> x, span<double> 
             } catch (CanteraError& err) {
                 s.restoreState(state);
                 throw CanteraError("ChemEquil::estimateEP_Brinkley",
-                                   "Jacobian is singular. \nTry adding more species, "
-                                   "changing the elemental composition slightly, \nor removing "
-                                   "unused elements.\n\n" + err.getMessage());
+                    "The Jacobian used to estimate the initial element potentials is "
+                    "singular.\nThe equilibrium state of this mixture cannot be "
+                    "resolved using the element potential formulation.\nThe 'gibbs' "
+                    "and 'vcs' solvers do not use this formulation and can usually "
+                    "solve such problems.\n\nThe underlying error was:\n"
+                    + err.getMessage());
             }
 
             // Figure out the damping coefficient: Use a delta damping

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -1331,13 +1331,25 @@ void ThermoPhase::equilibrate(const string& XY, const string& solver,
             E.options.maxIterations = max_steps;
             E.options.relTolerance = rtol;
             E.options.enforceTemperatureLimits = temperatureLimitsEnforced();
+            // If another solver will be tried anyway, a reduced-accuracy solution from
+            // ChemEquil is going to be discarded, so suppress such warnings.
+            E.options.warnOnInexactConvergence = (solver != "auto");
             int ret = E.equilibrate(*this, XY.c_str(), log_level-1);
             if (ret < 0) {
                 throw CanteraError("ThermoPhase::equilibrate",
                     "ChemEquil solver failed. Return code: {}", ret);
             }
-            debuglog("ChemEquil solver succeeded\n", log_level);
-            return;
+            if (ret == 1 && solver == "auto") {
+                // The element potential formulation is poorly conditioned for this
+                // mixture. The Gibbs minimization solvers can usually do better, so
+                // prefer their result over a degraded one.
+                debuglog("ChemEquil solver converged only to reduced accuracy\n",
+                         log_level);
+                restoreState(initial_state);
+            } else {
+                debuglog("ChemEquil solver succeeded\n", log_level);
+                return;
+            }
         } catch (std::exception& err) {
             debuglog("ChemEquil solver failed.\n", log_level);
             debuglog(err.what(), log_level);

--- a/test/python/test_equilibrium.py
+++ b/test/python/test_equilibrium.py
@@ -1,4 +1,5 @@
 import itertools
+import warnings
 
 import numpy as np
 import pytest
@@ -151,6 +152,118 @@ class TestChemEquil(EquilTestCases):
             gas.equilibrate('HP', solver='element_potential')
         assert gas.T > gas.max_temp
         assert gas.enthalpy_mass == approx(h0, abs=1e-3)
+
+
+class TestChemEquilIllConditioned:
+    """
+    Tests for mixtures whose equilibrium composition is dominated by a few species,
+    which leaves some element potentials determined only by species present in trace
+    amounts. The Jacobian is then rank deficient to within roundoff, and the solver
+    falls back to a rank-truncated step. See GitHub issue #2125.
+    """
+
+    # Combinations of mechanism, state, and composition where some element potentials
+    # are not resolvable to the default tolerance, along with a tolerance loose enough
+    # that they are. Each of these previously failed with "no convergence" after
+    # exhausting the iteration limit, at both the default and the looser tolerance.
+    ill_conditioned = [
+        ("h2o2.yaml", 550, 2 * ct.one_atm, "H2O:2, N2:0.7", 1e-8),
+        ("h2o2.yaml", 300, ct.one_atm, "H2O:2, N2:0.7", 1e-8),
+        ("gri30.yaml", 500, ct.one_atm, "CO2:1, H2O:2, N2:7.52", 1e-7),
+    ]
+
+    # Combinations that are well conditioned enough to converge normally. These
+    # exercise the unmodified LU path and must not emit a warning.
+    well_conditioned = [
+        ("h2o2.yaml", 1000, ct.one_atm, "H2O:2, N2:0.7"),
+        ("h2o2.yaml", 2500, ct.one_atm, "H2:2, O2:1, N2:4"),
+        ("gri30.yaml", 300, ct.one_atm, "CH4:1, O2:2, N2:7.52"),
+    ]
+
+    def reference(self, mech, T, P, X):
+        """Equilibrium composition computed with an independent solver."""
+        gas = ct.Solution(mech, transport_model=None)
+        gas.TPX = T, P, X
+        gas.equilibrate('TP', solver='gibbs')
+        return gas.X
+
+    @pytest.mark.parametrize("mech,T,P,X,loose_rtol", ill_conditioned)
+    def test_ill_conditioned_default_rtol(self, mech, T, P, X, loose_rtol):
+        # At the default tolerance the element potentials cannot be fully resolved,
+        # so the solver reports the accuracy it was able to achieve.
+        Xref = self.reference(mech, T, P, X)
+        gas = ct.Solution(mech, transport_model=None)
+        gas.TPX = T, P, X
+        with pytest.warns(UserWarning, match="cannot be resolved"):
+            gas.equilibrate('TP', solver='element_potential')
+        assert gas.X == approx(Xref, abs=2e-7)
+
+    @pytest.mark.parametrize("mech,T,P,X,loose_rtol", ill_conditioned)
+    def test_ill_conditioned_loose_rtol(self, mech, T, P, X, loose_rtol):
+        # With a tolerance the conditioning can support, the same cases converge
+        # normally and without a warning.
+        Xref = self.reference(mech, T, P, X)
+        gas = ct.Solution(mech, transport_model=None)
+        gas.TPX = T, P, X
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            gas.equilibrate('TP', solver='element_potential', rtol=loose_rtol)
+        assert gas.X == approx(Xref, abs=2e-7)
+
+    @pytest.mark.parametrize("mech,T,P,X", well_conditioned)
+    def test_well_conditioned_unaffected(self, mech, T, P, X):
+        # Well-conditioned problems keep using the plain LU step and converge to the
+        # default tolerance without any loss of accuracy.
+        Xref = self.reference(mech, T, P, X)
+        gas = ct.Solution(mech, transport_model=None)
+        gas.TPX = T, P, X
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            gas.equilibrate('TP', solver='element_potential')
+        assert gas.X == approx(Xref, abs=1e-9)
+
+    @pytest.mark.parametrize("mech,T,P,X,loose_rtol", ill_conditioned)
+    def test_auto_prefers_accurate_solver(self, mech, T, P, X, loose_rtol):
+        # The 'auto' solver should not settle for the reduced-accuracy element
+        # potential result when a Gibbs minimization solver can meet the requested
+        # tolerance. Since that result is discarded, there is nothing for the user
+        # to act on and no warning should be emitted.
+        Xref = self.reference(mech, T, P, X)
+        gas = ct.Solution(mech, transport_model=None)
+        gas.TPX = T, P, X
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            gas.equilibrate('TP')  # solver='auto' is the default
+        assert gas.X == approx(Xref, abs=1e-12)
+
+    def test_auto_resolves_trace_species(self):
+        # Trace species are exponentially sensitive to the element potentials that
+        # cannot be resolved, so they are where the element potential solver does
+        # worst. Check that the default solver is not affected by this.
+        mech, T, P, X, _ = self.ill_conditioned[0]
+        gas = ct.Solution(mech, transport_model=None)
+        gas.TPX = T, P, X
+        gas.equilibrate('TP')
+        # The element potential solver leaves H2 near the 1e-8 value used to
+        # initialize the trace species, six orders of magnitude too high.
+        assert gas['H2'].X[0] == approx(1.5e-14, rel=0.5)
+        assert gas['O2'].X[0] == approx(9e-15, rel=0.5)
+
+    def test_unconvergeable_still_fails(self):
+        # A reduced-accuracy solution is only accepted where the Jacobian is
+        # genuinely rank deficient and the remaining residual is small. A mixture
+        # that the element potential solver simply cannot handle must still be
+        # reported as a failure rather than being accepted as approximate.
+        gas = ct.Solution("h2o2.yaml", transport_model=None)
+        gas.TPX = 300, ct.one_atm, "H2:2, O2:1"
+        with pytest.raises(ct.CanteraError,
+                           match="element potential iteration failed"):
+            gas.equilibrate('TP', solver='element_potential')
+
+        # The 'auto' solver falls back and gets the right answer.
+        gas.TPX = 300, ct.one_atm, "H2:2, O2:1"
+        gas.equilibrate('TP')
+        assert gas['H2O'].X[0] == approx(1.0)
 
 
 class TestMultiphaseEquil(EquilTestCases):


### PR DESCRIPTION
For mixtures where fewer species than elements are effectively present in the equilibrium state, the system being solved for the element potentials is ill conditioned. Using a rank-aware solver (SVD) rather than a simple LU factorization can reduce errors significantly. However, this solver may still not be able to meet specified tolerances, and falling back to one of the Gibbs minimization solvers avoids this conditioning problem and can return an accurate solution.

Fixes #2125

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Check for stalled convergence in `element_potential` equilibrium solver.
- Switch to a rank-aware solver (SVD) in such cases to get a solution that minimizes error in the element potentials. This may still not result in sufficient convergence of the species mole fractions.
- If species cannot be converged to the specified tolerance when the `element_potential` solver is requested explicitly, issue a warning and return the approximate solution. Otherwise, fall back to the next solver chosen by `auto` (VCS).

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #2125

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

```py
import cantera as ct
gas = ct.Solution('h2o2.yaml')
gas.TPX = 550, 2 * ct.one_atm, "H2:2.0, O2:1.0, N2:0.7"
gas.equilibrate('TP', solver='element_potential')
gas()
```
Instead of raising a `CanteraError`, this now outputs:
```
<ipython-input-4-a21c8a6f496c>:4: UserWarning: ChemEquil::equilibrate: The equilibrium composition of this mixture is dominated by a few species, leaving some element potentials determined only by species present in trace amounts.
These potentials cannot be resolved to the requested relative tolerance of 1e-09.
Returning the most accurate solution available, in which the mole fraction of element O deviates from the specified value by a relative amount of 1.73623e-08.
Errors in the computed species mole fractions are expected to be of a similar relative magnitude, and may be much larger for species present in trace amounts.
Consider using the 'gibbs' or 'vcs' solvers, which do not use the element potential formulation and can usually meet the specified tolerance for such mixtures.
  gas.equilibrate('TP', solver='element_potential'); gas()

  ohmech:

       temperature   550 K
          pressure   2.0265e+05 Pa
           density   0.91321 kg/m^3
  mean mol. weight   20.607 kg/kmol
   phase of matter   gas

                          1 kg             1 kmol
                     ---------------   ---------------
          enthalpy       -8.2866e+06       -1.7077e+08  J
   internal energy       -8.5085e+06       -1.7534e+08  J
           entropy             10132         2.088e+05  J/K
    Gibbs function       -1.3859e+07        -2.856e+08  J
 heat capacity c_p            1660.6             34221  J/K
 heat capacity c_v            1257.1             25906  J/K

                      mass frac. Y      mole frac. X     chem. pot. / RT
                     ---------------   ---------------   ---------------
                H2         2.071e-09         2.117e-08           -33.236
               H2O           0.64756           0.74074           -75.833
                N2           0.35244           0.25926           -24.234
     [   +7 minor]        9.9776e-21        1.2171e-20
```

**AI Statement (required)**

- **Extensive use of generative AI.** Significant portions of code or documentation were generated with AI, including
  logic and implementation decisions. All generated code and documentation were reviewed and understood by the contributor. Implemented using Claude Code (Opus 5), with a round of review by ChatGPT 5.6 Sol.


**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
