### PR TITLE
Fix wrong ylabel in catalytic_combustion.py example

### DIFF
--- a/samples/python/onedim/catalytic_combustion.py
+++ b/samples/python/onedim/catalytic_combustion.py
@@ -146,7 +146,7 @@ sim.show_stats()
 # -------------------
 fig, ax = plt.subplots()
 ax.plot(sim.grid, sim.T, color='C3')
-ax.set_ylabel('heat release rate [MW/m³]')
+ax.set_ylabel('Temperature [K]')
 ax.set(xlabel='distance from inlet [m]')
 plt.show()
 


### PR DESCRIPTION
Fixes #2154.

The first plot plots Temperature (sim.T) but the ylabel incorrectly states 'heat release rate [MW/m³]'. This simple PR updates the ylabel to match the plotted data ('Temperature [K]').