### PR TITLE
Fix bug in adaptive preconditioner

### DIFF
--- a/src/numerics/AdaptivePreconditioner.cpp
+++ b/src/numerics/AdaptivePreconditioner.cpp
@@ -30,7 +30,7 @@ void AdaptivePreconditioner::initialize(size_t networkSize)
     if (m_drop_tol == 0) {
         setIlutDropTol(1e-12);
     }
-    if (m_drop_tol == 0) {
+    if (m_fill_factor == 0) {
         setIlutFillFactor(static_cast<int>(m_dim) / 2);
     }
     // update initialized status


### PR DESCRIPTION
Thank you @speth for catching this. The conditional statement for the ILUT fill factor was using the wrong variable.

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Updated the boolean for preconditioner fill factor


**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #2167 

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->


**AI Statement (required)**

<!-- Please include one of the following options in your PR description:

- **No generative AI was used.** This contribution was written entirely without AI
  assistance.

For additional information on Cantera's AI policy, see
https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md#restrictions-on-generative-ai-usage -->


**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
