### PR TITLE
Various minor fixes to the Matlab toolbox

### DIFF
--- a/doc/sphinx/matlab/onedim.rst
+++ b/doc/sphinx/matlab/onedim.rst
@@ -78,6 +78,10 @@ Boundary
 ^^^^^^^^
 .. autoclass:: Boundary
 
+Flow
+^^^^
+.. autoclass:: Flow
+
 Sim1D
 ^^^^^
 .. autoclass:: Sim1D(domains)

--- a/doc/sphinx/matlab/zeroD.rst
+++ b/doc/sphinx/matlab/zeroD.rst
@@ -80,6 +80,10 @@ MassFlowController
 ^^^^^^^^^^^^^^^^^^
 .. autoclass:: MassFlowController(upstream, downstream[, name])
 
+PressureController
+^^^^^^^^^^^^^^^^^^
+.. autoclass:: PressureController(upstream, downstream[, name])
+
 Valve
 ^^^^^
 .. autoclass:: Valve(upstream, downstream[, name])

--- a/doc/sphinx/reference/releasenotes/v4.0.md
+++ b/doc/sphinx/reference/releasenotes/v4.0.md
@@ -63,6 +63,21 @@ have been updated to return `std::span` instead. For example,
 
 ## New features
 
+- Map between reactor state-vector indices and component names from the CLib and
+  MATLAB interfaces. The generated CLib gains `reactor_neq`,
+  `reactor_componentName` and `reactor_componentIndex`, wrapping
+  `ReactorBase::neq()`, `ReactorBase::componentName(size_t)` and
+  `ReactorBase::componentIndex(const string&)`, plus
+  `reactornet_globalComponentIndex`, wrapping
+  `ReactorNet::globalComponentIndex(const string&, size_t)`; these join the
+  existing `reactornet_neq` and `reactornet_componentName`. The MATLAB toolbox
+  gains the corresponding `ReactorBase.nVars`, `ReactorBase.componentIndex`,
+  `ReactorBase.componentName`, `ReactorNet.nVars`, `ReactorNet.componentName`
+  and `ReactorNet.globalComponentIndex`, all using 1-based indices. Note that
+  `ReactorNet.componentName` returns a name prefixed with that of the reactor it
+  belongs to, for example `reactor1: temperature`, while
+  `ReactorNet.globalComponentIndex` takes an unprefixed name resolved within a
+  given reactor.
 - Make an analytic Jacobian the default for 1D flame simulations. The species
   mass-fraction Jacobian columns at interior grid points are evaluated
   analytically from kinetics concentration-derivative functions instead of by

--- a/doc/sphinx/reference/releasenotes/v4.0.md
+++ b/doc/sphinx/reference/releasenotes/v4.0.md
@@ -53,6 +53,14 @@ have been updated to return `std::span` instead. For example,
 `const std::vector<double> Phase::molecularWeights()` has been replaced with
 `span<const double> Phase::molecularWeights()`.
 
+### CLib
+
+- The generated CLib function `reactornet_sensitivity`, which wrapped
+  `ReactorNet::sensitivity(const string& component, size_t p, int reactor)`, has been
+  renamed to `reactornet_sensitivityByName`. The name `reactornet_sensitivity` now wraps
+  the index-based overload `ReactorNet::sensitivity(size_t k, size_t p)`, where `k` is
+  an index into the global state vector of the network.
+
 ## New features
 
 - Make an analytic Jacobian the default for 1D flame simulations. The species

--- a/interfaces/clib/SConscript
+++ b/interfaces/clib/SConscript
@@ -30,7 +30,7 @@ env.Alias("doxygen_tags", tags)
 # Generated file names can be anticipated
 generated_files = []
 auto_path = Path(Dir("#interfaces/sourcegen/src/sourcegen/headers").abspath)
-yaml_files = auto_path.glob("ct*.yaml")
+yaml_files = sorted(auto_path.glob("ct*.yaml"))
 for yaml_file in yaml_files:
     base_name = yaml_file.stem
     generated_files.extend([

--- a/interfaces/julia/src/reactornet.jl
+++ b/interfaces/julia/src/reactornet.jl
@@ -100,10 +100,16 @@ end
 
 """
     sensitivity(net, component, p, reactor) -> Float64
+    sensitivity(net, k, p) -> Float64
 
-Normalized sensitivity of `component` (e.g. `"temperature"` or a species name)
-in `reactor` with respect to sensitivity parameter `p` (1-based).  `reactor` may
-be a [`Reactor`](@ref) belonging to the network or its 1-based position.
+Normalized sensitivity with respect to sensitivity parameter `p` (1-based).
+
+In the first form, `component` is the name of a state variable (for example
+`"temperature"` or a species name) resolved within `reactor`, which may be a
+[`Reactor`](@ref) belonging to the network or its 1-based position.
+
+In the second form, `k` is the 1-based index of the component in the global
+state vector of the network, as ordered by [`component_names`](@ref).
 """
 function sensitivity(net::ReactorNet, component::AbstractString, p::Integer,
                      reactor::Reactor)
@@ -114,8 +120,14 @@ end
 
 function sensitivity(net::ReactorNet, component::AbstractString, p::Integer,
                      reactor::Integer)
-    return checkd(LibCantera.reactornet_sensitivity(net.handle, component,
-                                                    Int32(p - 1), Int32(reactor - 1)))
+    return checkd(LibCantera.reactornet_sensitivityByName(net.handle, component,
+                                                          Int32(p - 1),
+                                                          Int32(reactor - 1)))
+end
+
+function sensitivity(net::ReactorNet, k::Integer, p::Integer)
+    return checkd(LibCantera.reactornet_sensitivity(net.handle, Int32(k - 1),
+                                                    Int32(p - 1)))
 end
 
 """

--- a/interfaces/julia/test/test_connectors.jl
+++ b/interfaces/julia/test/test_connectors.jl
@@ -100,6 +100,12 @@ end
     advance!(net, 2e-4)
     s = sensitivity(net, "temperature", 1, r)
     @test isfinite(s)
+    # the same value is reachable through the global state-vector index
+    k = findfirst(endswith(": temperature"), component_names(net))
+    @test k !== nothing
+    @test sensitivity(net, k, 1) == s
+    @test sensitivity(net, "temperature", 1, 1) == s
+    @test_throws CanteraError sensitivity(net, "spam", 1, 1)
     @test rtol(net) > 0
     @test atol(net) > 0
 end

--- a/interfaces/matlab/+ct/+impl/errorCode.m
+++ b/interfaces/matlab/+ct/+impl/errorCode.m
@@ -1,3 +1,10 @@
 function err = errorCode()
-    err = [-1, -2, -999.999, double(intmax('uint64'))];
+    % Values returned by CLib functions to signal that an exception was raised.
+    %
+    % `ERR` (-999) and `DERR` (-999.999) are the sentinels defined by
+    % `clib_defs.h`; -1 and -2 are returned in their place by generated functions
+    % whose normal return value is a length or a handle. `intmax('uint64')` is the
+    % C++ `npos`.
+
+    err = [-1, -2, -999, -999.999, double(intmax('uint64'))];
 end

--- a/interfaces/matlab/+ct/+oneD/ReactingSurface.m
+++ b/interfaces/matlab/+ct/+oneD/ReactingSurface.m
@@ -10,12 +10,8 @@ classdef ReactingSurface < ct.oneD.Boundary
     %     String ID of the reacting surface.
 
     properties
-        % Set bounds on the solution components. ::
-        %
-        %     >> d.coverageEnabled = flag
-        %
-        % :param flag:
-        %     Boolean flag indicating whether coverage equations are enabled.
+        % Boolean flag that controls whether or not the surface coverage equations
+        % are solved as part of the 1D problem.
         coverageEnabled
     end
 

--- a/interfaces/matlab/+ct/+zeroD/FlowDevice.m
+++ b/interfaces/matlab/+ct/+zeroD/FlowDevice.m
@@ -12,12 +12,13 @@ classdef (Abstract) FlowDevice < ct.zeroD.Connector
     % pressure difference equals the difference in pressure between the
     % upstream and downstream reactors.
     %
-    % See also: :mat:class:`ct.zeroD.MassFlowController`, :mat:class:`ct.zeroD.Valve`
+    % See also: :mat:class:`ct.zeroD.MassFlowController`,
+    % :mat:class:`ct.zeroD.PressureController`, :mat:class:`ct.zeroD.Valve`
     %
     % :param typ:
     %     Type of :mat:class:`ct.zeroD.FlowDevice` to be created. ``typ='MassFlowController'``
     %     for :mat:class:`ct.zeroD.MassFlowController`,  ``typ='PressureController'`` for
-    %     :mat:class:`ct.PressureController`, and ``typ='Valve'`` for
+    %     :mat:class:`ct.zeroD.PressureController`, and ``typ='Valve'`` for
     %     :mat:class:`ct.zeroD.Valve`.
     % :param upstream:
     %     Upstream reactor or reservoir.
@@ -53,6 +54,14 @@ classdef (Abstract) FlowDevice < ct.zeroD.Connector
         % as long as this produces a positive value.  If this expression is
         % negative, zero is returned.
         valveCoeff
+
+        % The coefficient defining the behavior of this
+        % :mat:class:`ct.zeroD.FlowDevice`, with a meaning that depends on the type
+        % of the device: the mass flow rate [kg/s] for a
+        % :mat:class:`ct.zeroD.MassFlowController`, the valve coefficient [kg/s/Pa]
+        % for a :mat:class:`ct.zeroD.Valve`, and the pressure coefficient [kg/s/Pa]
+        % for a :mat:class:`ct.zeroD.PressureController`.
+        deviceCoefficient
     end
 
     methods
@@ -75,6 +84,10 @@ classdef (Abstract) FlowDevice < ct.zeroD.Connector
 
         function mdot = get.massFlowRate(obj)
             mdot = ct.impl.call('mFlowdev_massFlowRate', obj.id);
+        end
+
+        function c = get.deviceCoefficient(obj)
+            c = ct.impl.call('mFlowdev_deviceCoefficient', obj.id);
         end
 
         %% FlowDevice Set Methods
@@ -104,8 +117,12 @@ classdef (Abstract) FlowDevice < ct.zeroD.Connector
             % :param d:
             %     Instance of class :mat:class:`ct.zeroD.FlowDevice`.
 
+            if ~isa(d, 'ct.zeroD.FlowDevice')
+                error('Primary device must be an instance of ct.zeroD.FlowDevice.');
+            end
+
             if strcmp(obj.type, 'PressureController')
-                ct.impl.call('mFlowdev_setPrimary', obj.id, d);
+                ct.impl.call('mFlowdev_setPrimary', obj.id, d.id);
             else
                 error('Primary flow device can only be set for pressure controllers.');
             end
@@ -118,7 +135,11 @@ classdef (Abstract) FlowDevice < ct.zeroD.Connector
                 error('Valve coefficient can only be set for valves.');
             end
 
-            ct.impl.call('mFlowdev_setDeviceCoefficient', obj.id, k);
+            obj.deviceCoefficient = k;
+        end
+
+        function set.deviceCoefficient(obj, c)
+            ct.impl.call('mFlowdev_setDeviceCoefficient', obj.id, c);
         end
 
     end

--- a/interfaces/matlab/+ct/+zeroD/FlowReactor.m
+++ b/interfaces/matlab/+ct/+zeroD/FlowReactor.m
@@ -24,7 +24,13 @@ classdef FlowReactor < ct.zeroD.ReactorBase
 
     properties (SetAccess = public)
 
-        massFlowRate % Mass flow rate [kg/s].
+        % Mass flow rate through the reactor [kg/s].
+        %
+        % Setting the mass flow rate sets the flow speed based on the current
+        % density of the reactor contents and the reactor area. The value read
+        % back is computed from the flow speed, density and area at the end of
+        % the last call to "advance" or "step".
+        massFlowRate
 
     end
 
@@ -43,7 +49,7 @@ classdef FlowReactor < ct.zeroD.ReactorBase
 
         %% FlowReactor Get Methods
 
-        function flag = get.massFlowRate(obj)
+        function rate = get.massFlowRate(obj)
             rate = ct.impl.call('mReactor_massFlowRate', obj.id);
         end
 
@@ -51,7 +57,6 @@ classdef FlowReactor < ct.zeroD.ReactorBase
 
         function set.massFlowRate(obj, MFR)
             ct.impl.call('mReactor_setMassFlowRate', obj.id, MFR);
-            obj.massFlowRate = MFR;
         end
 
     end

--- a/interfaces/matlab/+ct/+zeroD/PressureController.m
+++ b/interfaces/matlab/+ct/+zeroD/PressureController.m
@@ -1,0 +1,68 @@
+classdef PressureController < ct.zeroD.FlowDevice
+    % Create a pressure controller. ::
+    %
+    %     >> p = ct.zeroD.PressureController(upstream, downstream, name)
+    %
+    % Creates an instance of class :mat:class:`ct.zeroD.FlowDevice` configured to
+    % simulate a pressure controller. A :mat:class:`ct.zeroD.PressureController` is
+    % designed to be used in conjunction with another primary flow device, typically a
+    % :mat:class:`ct.zeroD.MassFlowController`. The primary flow device is installed on
+    % the inlet of the reactor, and the corresponding
+    % :mat:class:`ct.zeroD.PressureController` is installed on the outlet of the
+    % reactor. The mass flow rate through the :mat:class:`ct.zeroD.PressureController`
+    % is equal to the mass flow rate of the primary device, plus a correction that
+    % depends on the pressure difference:
+    %
+    % .. math:: \dot{m} = \dot{m}_{primary} + K_v(P_{upstream} - P_{downstream})
+    %
+    % as long as this produces a positive value. If this expression is negative, zero
+    % is returned. The primary device is set using
+    % :mat:meth:`ct.zeroD.FlowDevice.setPrimary` and must be set before the mass flow
+    % rate can be evaluated.
+    %
+    % see also: :mat:class:`ct.zeroD.FlowDevice`,
+    % :mat:class:`ct.zeroD.MassFlowController`, :mat:class:`ct.zeroD.Valve`
+    %
+    % :param upstream:
+    %     Upstream :mat:class:`ct.zeroD.ReactorBase`.
+    % :param downstream:
+    %     Downstream :mat:class:`ct.zeroD.ReactorBase`.
+    % :param name:
+    %     Flow device name (optional; default is ``(none)``).
+
+    properties (SetAccess = public)
+
+        % Proportionality constant :math:`K_v` in kg/s/Pa between the pressure drop
+        % and the mass flow rate correction added to the primary device's mass flow
+        % rate.
+        pressureCoeff
+
+    end
+
+    methods
+
+        function obj = PressureController(upstream, downstream, name)
+            arguments
+                upstream (1,1) ct.zeroD.ReactorBase
+                downstream (1,1) ct.zeroD.ReactorBase
+                name (1,1) string = "(none)"
+            end
+
+            obj@ct.zeroD.FlowDevice('PressureController', upstream, downstream, name);
+        end
+
+        %% PressureController Get Methods
+
+        function k = get.pressureCoeff(obj)
+            k = obj.deviceCoefficient;
+        end
+
+        %% PressureController Set Methods
+
+        function set.pressureCoeff(obj, k)
+            obj.deviceCoefficient = k;
+        end
+
+    end
+
+end

--- a/interfaces/matlab/+ct/+zeroD/ReactorBase.m
+++ b/interfaces/matlab/+ct/+zeroD/ReactorBase.m
@@ -16,6 +16,23 @@ classdef (Abstract) ReactorBase < handle
 
     end
 
+    properties (SetAccess = protected)
+
+        % Number of state variables (equations) for this reactor, that is, the
+        % length of its state vector.
+        %
+        % For a :mat:class:`ct.zeroD.Reactor` or
+        % :mat:class:`ct.zeroD.IdealGasReactor`, this is the number of species plus
+        % three (mass, volume, and internal energy or temperature). For a
+        % :mat:class:`ct.zeroD.ConstPressureReactor` or
+        % :mat:class:`ct.zeroD.IdealGasConstPressureReactor`, it is the number of
+        % species plus two (mass, and enthalpy or temperature). Reactor types that
+        % have no state vector of their own, such as
+        % :mat:class:`ct.zeroD.Reservoir`, report zero.
+        nVars
+
+    end
+
     properties (SetAccess = public)
 
         type  % reactor type.
@@ -112,7 +129,66 @@ classdef (Abstract) ReactorBase < handle
             ct.impl.call('mReactor_addSensitivityReaction', obj.id, m - 1);
         end
 
+        function n = componentIndex(obj, name)
+            % Index of a state-vector component of this reactor, given its name. ::
+            %
+            %     >> n = r.componentIndex(name)
+            %
+            % :param name:
+            %    String name of the component, without the reactor-name prefix that
+            %    :mat:meth:`ct.zeroD.ReactorNet.componentName` adds. Which names are
+            %    accepted depends on the reactor type; a species name always is, as
+            %    are ``'mass'`` and ``'volume'`` for a :mat:class:`ct.zeroD.Reactor`
+            %    and its descendants. Reactor types that have no state vector of
+            %    their own, such as :mat:class:`ct.zeroD.Reservoir`, raise an error.
+            % :return:
+            %    Integer, 1-based index of the component within the state vector of
+            %    this reactor. Use
+            %    :mat:meth:`ct.zeroD.ReactorNet.globalComponentIndex` to get the
+            %    corresponding index within the state vector of a network.
+
+            arguments
+                obj (1,1) ct.zeroD.ReactorBase
+                name (1,:) char
+            end
+
+            n = ct.impl.call('mReactor_componentIndex', obj.id, name);
+
+            if n < 0
+                error('Cantera:ctError', ct.impl.getError());
+            end
+
+            n = n + 1;
+        end
+
+        function s = componentName(obj, k)
+            % Name of a state-vector component of this reactor, given its index. ::
+            %
+            %     >> s = r.componentName(k)
+            %
+            % :param k:
+            %    Integer, 1-based index of the component within the state vector of
+            %    this reactor.
+            % :return:
+            %    Character array naming the component, for example ``'int_energy'``
+            %    for a :mat:class:`ct.zeroD.Reactor` or ``'temperature'`` for a
+            %    :mat:class:`ct.zeroD.IdealGasReactor`. The name is not prefixed with
+            %    the name of the reactor; compare
+            %    :mat:meth:`ct.zeroD.ReactorNet.componentName`.
+
+            arguments
+                obj (1,1) ct.zeroD.ReactorBase
+                k (1,1) double {mustBeInteger, mustBePositive}
+            end
+
+            s = ct.impl.getString('mReactor_componentName', obj.id, k - 1);
+        end
+
         %% ReactorBase Get Methods
+
+        function n = get.nVars(obj)
+            n = ct.impl.call('mReactor_neq', obj.id);
+        end
 
         function typ = get.type(obj)
             typ = ct.impl.getString('mReactor_type', obj.id);

--- a/interfaces/matlab/+ct/+zeroD/ReactorBase.m
+++ b/interfaces/matlab/+ct/+zeroD/ReactorBase.m
@@ -152,13 +152,7 @@ classdef (Abstract) ReactorBase < handle
                 name (1,:) char
             end
 
-            n = ct.impl.call('mReactor_componentIndex', obj.id, name);
-
-            if n < 0
-                error('Cantera:ctError', ct.impl.getError());
-            end
-
-            n = n + 1;
+            n = ct.impl.call('mReactor_componentIndex', obj.id, name) + 1;
         end
 
         function s = componentName(obj, k)

--- a/interfaces/matlab/+ct/+zeroD/ReactorBase.m
+++ b/interfaces/matlab/+ct/+zeroD/ReactorBase.m
@@ -106,9 +106,10 @@ classdef (Abstract) ReactorBase < handle
             %     >> r.addSensitivityReaction(m)
             %
             % :param m:
-            %    Index number of reaction.
+            %    Integer, 1-based index of the reaction within the reactor's
+            %    `Kinetics` object.
 
-            ct.impl.call('mReactor_addSensitivityReaction', obj.id, m);
+            ct.impl.call('mReactor_addSensitivityReaction', obj.id, m - 1);
         end
 
         %% ReactorBase Get Methods

--- a/interfaces/matlab/+ct/+zeroD/ReactorNet.m
+++ b/interfaces/matlab/+ct/+zeroD/ReactorNet.m
@@ -20,6 +20,15 @@ classdef ReactorNet < handle
         reactors
     end
 
+    properties (SetAccess = protected)
+
+        % Number of state variables (equations) in the network, that is, the length
+        % of its global state vector. Equal to the sum of the
+        % :mat:attr:`ct.zeroD.ReactorBase.nVars` of the reactors it contains.
+        nVars
+
+    end
+
     properties (SetAccess = public)
 
         % Current time [s].
@@ -150,6 +159,10 @@ classdef ReactorNet < handle
 
         %% ReactorNet get methods
 
+        function n = get.nVars(obj)
+            n = ct.impl.call('mReactornet_neq', obj.id);
+        end
+
         function t = get.time(obj)
             t = ct.impl.call('mReactornet_time', obj.id);
         end
@@ -204,6 +217,85 @@ classdef ReactorNet < handle
                        'string, or an integer index, not a %s.'], class(component));
             end
 
+            index = obj.reactorIndex(r);
+
+            s = ct.impl.call('mReactornet_sensitivityByName', obj.id, ...
+                             char(component), p - 1, index - 1);
+
+        end
+
+        function i = globalComponentIndex(obj, component, r)
+            % Index of a component of the global state vector of the network, given
+            % the name of the component and the reactor it belongs to. ::
+            %
+            %     >> i = n.globalComponentIndex(component)
+            %     >> i = n.globalComponentIndex(component, r)
+            %
+            % This is the inverse of :mat:meth:`ct.zeroD.ReactorNet.componentName`,
+            % except that the name given here is *not* prefixed with the name of the
+            % reactor.
+            %
+            % :param component:
+            %    Name of the component within the reactor `r`, given as a character
+            %    array or a string, for example ``'temperature'`` or a species name.
+            % :param r:
+            %    The reactor in which `component` is to be found, given either as an
+            %    instance of :mat:class:`ct.zeroD.ReactorBase` belonging to this
+            %    network or as its 1-based position within the network. Defaults to
+            %    the first reactor in the network.
+            % :return:
+            %    Integer, 1-based index of the component within the global state
+            %    vector of the network.
+
+            arguments
+                obj (1,1) ct.zeroD.ReactorNet
+                component (1,:) char
+                r = 1
+            end
+
+            index = obj.reactorIndex(r);
+
+            i = ct.impl.call('mReactornet_globalComponentIndex', obj.id, ...
+                             component, index - 1);
+
+            if i < 0
+                error('Cantera:ctError', ct.impl.getError());
+            end
+
+            i = i + 1;
+        end
+
+        function s = componentName(obj, i)
+            % Name of a component of the global state vector of the network, given
+            % its index. ::
+            %
+            %     >> s = n.componentName(i)
+            %
+            % :param i:
+            %    Integer, 1-based index of the component within the global state
+            %    vector of the network.
+            % :return:
+            %    Character array naming the component, prefixed with the name of the
+            %    reactor it belongs to, for example ``'reactor1: temperature'``. The
+            %    unprefixed name is what
+            %    :mat:meth:`ct.zeroD.ReactorNet.globalComponentIndex` and
+            %    :mat:meth:`ct.zeroD.ReactorNet.sensitivity` accept.
+
+            arguments
+                obj (1,1) ct.zeroD.ReactorNet
+                i (1,1) double {mustBeInteger, mustBePositive}
+            end
+
+            s = ct.impl.getString('mReactornet_componentName', obj.id, i - 1);
+        end
+
+    end
+
+    methods (Access = private)
+
+        function index = reactorIndex(obj, r)
+            % Resolve a reactor argument to its 1-based position in the network.
+
             if isa(r, 'ct.zeroD.ReactorBase')
                 index = find(cellfun(@(x) x == r, obj.reactors), 1);
                 if isempty(index)
@@ -211,13 +303,15 @@ classdef ReactorNet < handle
                 end
             elseif isnumeric(r) && isscalar(r)
                 index = r;
+                if mod(index, 1) ~= 0 || index < 1 || index > numel(obj.reactors)
+                    error(['Reactor must be given as a 1-based index between 1 ' ...
+                           'and %d for this network, not %g.'], ...
+                          numel(obj.reactors), index);
+                end
             else
                 error(['Reactor must be a ct.zeroD.ReactorBase object or a ' ...
                        '1-based index, not a %s.'], class(r));
             end
-
-            s = ct.impl.call('mReactornet_sensitivityByName', obj.id, ...
-                             char(component), p - 1, index - 1);
 
         end
 

--- a/interfaces/matlab/+ct/+zeroD/ReactorNet.m
+++ b/interfaces/matlab/+ct/+zeroD/ReactorNet.m
@@ -256,13 +256,7 @@ classdef ReactorNet < handle
             index = obj.reactorIndex(r);
 
             i = ct.impl.call('mReactornet_globalComponentIndex', obj.id, ...
-                             component, index - 1);
-
-            if i < 0
-                error('Cantera:ctError', ct.impl.getError());
-            end
-
-            i = i + 1;
+                             component, index - 1) + 1;
         end
 
         function s = componentName(obj, i)

--- a/interfaces/matlab/+ct/+zeroD/ReactorNet.m
+++ b/interfaces/matlab/+ct/+zeroD/ReactorNet.m
@@ -14,6 +14,10 @@ classdef ReactorNet < handle
 
     properties (SetAccess = immutable)
         id = -1
+
+        % Cell array of the :mat:class:`ct.zeroD.ReactorBase` objects that make up
+        % the network, in the order in which they were installed.
+        reactors
     end
 
     properties (SetAccess = public)
@@ -54,6 +58,7 @@ classdef ReactorNet < handle
             reactorIDs = cellfun(@(r) r.id, reactors);
 
             obj.id = ct.impl.call('mReactornet_new', reactorIDs);
+            obj.reactors = reactors;
             obj.time = 0;
 
         end
@@ -158,21 +163,61 @@ classdef ReactorNet < handle
         end
 
         function s = sensitivity(obj, component, p, r)
-            % Sensitivity of the solution variable `c` in reactor `r`
-            % with respect to the parameter `p` ::
+            % Sensitivity of a solution variable with respect to a sensitivity
+            % parameter. ::
             %
+            %     >> s = n.sensitivity(component, p)
             %     >> s = n.sensitivity(component, p, r)
             %
             % :param component:
-            %    String name of variable.
+            %    Name of the solution variable, given as a character array or a
+            %    string, for example ``'temperature'`` or a species name. It is
+            %    resolved within the reactor `r`. Alternatively, an integer giving
+            %    the 1-based index of the variable in the global state vector of
+            %    the network, in which case `r` is not used.
             % :param p:
-            %    Integer sensitivity parameter.
+            %    Integer, 1-based index of the sensitivity parameter.
             % :param r:
-            %    Instance of class :mat:class:`ct.zeroD.ReactorBase`.
+            %    The reactor in which `component` is to be found, given either as an
+            %    instance of :mat:class:`ct.zeroD.ReactorBase` belonging to this
+            %    network or as its 1-based position within the network. Defaults to
+            %    the first reactor in the network.
+            % :return:
+            %    Scalar normalized sensitivity coefficient.
 
-            if isa(component, 'string')
-                s = ct.impl.call('mReactornet_sensitivity', obj.id, component, p, r.id);
+            arguments
+                obj
+                component
+                p (1,1) double
+                r = 1
             end
+
+            if isnumeric(component)
+                % Global index into the network state vector
+                s = ct.impl.call('mReactornet_sensitivity', obj.id, ...
+                                 component - 1, p - 1);
+                return
+            end
+
+            if ~(ischar(component) || isstring(component))
+                error(['Sensitivity component must be a character array, a ' ...
+                       'string, or an integer index, not a %s.'], class(component));
+            end
+
+            if isa(r, 'ct.zeroD.ReactorBase')
+                index = find(cellfun(@(x) x == r, obj.reactors), 1);
+                if isempty(index)
+                    error('The given reactor is not part of this network.');
+                end
+            elseif isnumeric(r) && isscalar(r)
+                index = r;
+            else
+                error(['Reactor must be a ct.zeroD.ReactorBase object or a ' ...
+                       '1-based index, not a %s.'], class(r));
+            end
+
+            s = ct.impl.call('mReactornet_sensitivityByName', obj.id, ...
+                             char(component), p - 1, index - 1);
 
         end
 

--- a/interfaces/matlab/Base/+ct/Func1.m
+++ b/interfaces/matlab/Base/+ct/Func1.m
@@ -31,31 +31,33 @@ classdef Func1 < handle
             %
             % The types of functors you can create in Cantera are these:
             %
-            %     * Basic functors: ``'sin'``, ``'cos'``, ``'exp'``, ``'log'``,
-            %       ``'pow'``, ``'constant'``. Use no or scalar parameters, for example
+            % * Basic functors: ``'sin'``, ``'cos'``, ``'exp'``, ``'log'``,
+            %   ``'pow'``, ``'constant'``. Use no or scalar parameters, for
+            %   example::
             %
             %       >> x = ct.Func1('cos')
             %       >> x = ct.Func1('sin', 2)
             %
-            %     * Advanced functors: ``'polynomial3'``, ``'Fourier'``, ``'Gaussian'``,
-            %       ``'Arrhenius'``. Use vector parameter, for example
+            % * Advanced functors: ``'polynomial3'``, ``'Fourier'``, ``'Gaussian'``,
+            %   ``'Arrhenius'``. Use vector parameter, for example::
             %
             %       >> x = ct.Func1('polynomial3', [1 2 3])  % x^2 + 2x + 3
             %
-            %     * Tabulation functors: ``'tabulated-linear'``,
-            %       ``'tabulated-previous'``. Use pair of vector parameters, for example
+            % * Tabulation functors: ``'tabulated-linear'``,
+            %   ``'tabulated-previous'``. Use pair of vector parameters, for
+            %   example::
             %
             %       >> x = ct.Func1('tabulated-linear', [0 2 4], [1 3 5])
             %
-            %     * Compounding functors: ``'sum'``, ``'diff'``, ``'product'``,
-            %       ``'ratio'``, ``'composite'``. Use two functor parameters or a
-            %       corresponding operator, for example
+            % * Compounding functors: ``'sum'``, ``'diff'``, ``'product'``,
+            %   ``'ratio'``, ``'composite'``. Use two functor parameters or a
+            %   corresponding operator, for example::
             %
             %       >> x = ct.Func1('sum', ct.Func1('sin', 2.), ct.Func1('cos', 3.))
             %       >> x = ct.Func1('sin', 2.) + ct.Func1('cos', 3.)  % alternative
             %
-            %     * Modifying functors: ``'times-constant'``, ``'plus-constant'``,
-            %       ``'periodic'``. Use one functor and one scalar, for example
+            % * Modifying functors: ``'times-constant'``, ``'plus-constant'``,
+            %   ``'periodic'``. Use one functor and one scalar, for example::
             %
             %       >> x = ct.Func1('times-constant', ct.Func1('sin', 2.), 2.)
             %

--- a/interfaces/matlab/Base/+ct/Func1.m
+++ b/interfaces/matlab/Base/+ct/Func1.m
@@ -200,36 +200,47 @@ classdef Func1 < handle
         end
 
         function b = subsref(obj, s)
-            % Redefine subscripted references for functors. ::
+            % Implement subscripted reference behavior for functors. ::
             %
-            %     >> b = a.subsref(s)
+            %     >> b = f(x)
             %
-            % :param a:
+            % MATLAB calls this method automatically to resolve a subscripted
+            % expression on a functor. Its purpose is to make a functor callable
+            % like a function, so that ``f(x)`` evaluates it. Users normally reach
+            % it this way rather than calling ``subsref`` directly. All other
+            % reference forms, such as reading a property with ``f.type``, behave as
+            % they do for any object.
+            %
+            % :param f:
             %     Instance of class :mat:class:`ct.Func1`.
             % :param s:
-            %     Value at which the function should be evaluated.
+            %     Subscript-reference struct array that MATLAB passes to ``subsref``
+            %     (see the built-in ``subsref`` documentation). For a function call,
+            %     ``s(1).type`` is ``'()'`` and ``s(1).subs`` holds the point(s) at
+            %     which to evaluate the function.
             % :return:
-            %     Returns the value of the function evaluated at ``s``.
+            %     For a ``()`` reference, a vector holding the function evaluated at
+            %     each requested point. For any other reference, whatever the default
+            %     ``subsref`` returns.
 
-            if length(s) > 1
-                name = s(1).subs;
-                aa = obj.(name);
-                b = subsref(aa, s(2:end));
-                return
-            end
-            if strcmp(s.type, '()')
-                ind = s.subs{:};
+            if strcmp(s(1).type, '()')
+                ind = s(1).subs{:};
                 b = zeros(1, length(ind));
 
                 for k = 1:length(ind)
                     b(k) = ct.impl.call('mFunc1_eval', obj.id, ind(k));
                 end
 
-            elseif strcmp(s.type, '.')
-                name = s.subs;
-                b = obj.(name);
+                if length(s) > 1
+                    % A chained reference such as f(x).foo applies the rest of
+                    % the subscripts to the computed values.
+                    b = builtin('subsref', b, s(2:end));
+                end
             else
-                error('Specify value for x as p(x)');
+                % Evaluation is the only behavior this class defines. Every
+                % other reference type, such as reading a property, gets the
+                % behavior it would have without this overload.
+                b = builtin('subsref', obj, s);
             end
 
         end

--- a/interfaces/matlab/Base/+ct/Interface.m
+++ b/interfaces/matlab/Base/+ct/Interface.m
@@ -102,7 +102,7 @@ classdef Interface < ct.Solution
                     error('wrong size for coverage array');
                 end
 
-                ct.impl.call('mSurf_setCoverages', obj.tpID, cov, 0);
+                ct.impl.call('mSurf_setCoveragesNoNorm', obj.tpID, cov);
             else
                 error('Coverage must be a numeric array');
             end

--- a/interfaces/matlab/Base/+ct/Mixture.m
+++ b/interfaces/matlab/Base/+ct/Mixture.m
@@ -361,7 +361,7 @@ classdef Mixture < handle
 
         end
 
-        function r = equilibrate(obj, XY, solver, rtol, maxsteps, maxiter, estimate_equil)
+        function equilibrate(obj, XY, solver, rtol, maxsteps, maxiter, estimate_equil)
             % Set the mixture to a state of chemical equilibrium. ::
             %
             %     >> m.equilibrate(XY, solver, rtol, maxsteps, maxiter, estimate_equil)
@@ -402,8 +402,6 @@ classdef Mixture < handle
             %     If -1, the initial mole fraction vector is thrown out,
             %     and an estimate is formulated.
             %     Default: 0.
-            % :return:
-            %     The error in the solution.
 
             arguments
                 obj
@@ -416,7 +414,7 @@ classdef Mixture < handle
                 estimate_equil (1,1) double {mustBeInteger} = 0
             end
 
-            r = ct.impl.call('mMix_equilibrate', obj.mixID, XY, solver, rtol, ...
+            ct.impl.call('mMix_equilibrate', obj.mixID, XY, solver, rtol, ...
                         maxsteps, maxiter, estimate_equil);
         end
 

--- a/interfaces/matlab/Base/+ct/ThermoPhase.m
+++ b/interfaces/matlab/Base/+ct/ThermoPhase.m
@@ -373,7 +373,7 @@ classdef (Abstract) ThermoPhase < handle
             disp(obj.report);
         end
 
-        function tp = equilibrate(obj, xy, solver, rtol, maxsteps, maxiter, loglevel)
+        function equilibrate(obj, xy, solver, rtol, maxsteps, maxiter, loglevel)
             % Set the phase to a state of chemical equilibrium ::
             %
             %     >> tp.equilibrate(xy, solver, rtol, maxsteps, maxiter, loglevel)

--- a/interfaces/matlab/Utility/+ct/dataDirectories.m
+++ b/interfaces/matlab/Utility/+ct/dataDirectories.m
@@ -9,5 +9,5 @@ function d = dataDirectories()
     %     Cell array with strings representing the data file search directories
 
     ct.isLoaded(true);
-    d = ct.impl.getString('mCt_getDataDirectories', ';');
+    d = strsplit(ct.impl.getString('mCt_getDataDirectories', pathsep), pathsep);
 end

--- a/interfaces/sourcegen/src/sourcegen/headers/ctreactor.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctreactor.yaml
@@ -39,6 +39,10 @@ recipes:
 - name: massFractions
 - name: nSensParams
 - name: addSensitivityReaction
+- name: neq  # number of state variables for this reactor
+- name: componentName  # name of state-vector component k
+  uses: neq
+- name: componentIndex
 # FlowReactor
 - name: massFlowRate
 - name: setMassFlowRate

--- a/interfaces/sourcegen/src/sourcegen/headers/ctreactornet.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctreactornet.yaml
@@ -30,6 +30,7 @@ recipes:
 - name: getState  # current state vector, length neq()
 - name: componentName  # name of state-vector component i
   uses: neq
+- name: globalComponentIndex  # index of a named component in the global state vector
 # service functions
 - name: del
 - name: cabinetSize

--- a/interfaces/sourcegen/src/sourcegen/headers/ctreactornet.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctreactornet.yaml
@@ -22,6 +22,9 @@ recipes:
 - name: rtol
 - name: atol
 - name: sensitivity
+  wraps: sensitivity(size_t, size_t)
+  uses: neq
+- name: sensitivityByName
   wraps: sensitivity(const string&, size_t, int)
 - name: neq  # number of state variables / network components
 - name: getState  # current state vector, length neq()

--- a/interfaces/sourcegen/src/sourcegen/headers/ctthermo.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctthermo.yaml
@@ -153,6 +153,7 @@ recipes:
 - name: setState_Tsat
 - name: getCoverages
 - name: setCoverages
+- name: setCoveragesNoNorm
 - name: getConcentrations  # Changed in Cantera 3.2 (previously used 'surf' prefix')
 - name: setConcentrations  # Changed in Cantera 3.2 (previously used 'surf' prefix')
 - name: siteDensity

--- a/samples/matlab/burner_flame.m
+++ b/samples/matlab/burner_flame.m
@@ -33,7 +33,6 @@ nz = 11;
 
 logLevel = 1;  % amount of diagnostic output (0 to 5)
 refineGrid = 1;  % 1 to enable refinement, 0 to disable
-maxJacobianAge = [5, 10];
 
 %%
 % **Create the gas object**
@@ -90,7 +89,6 @@ uOut = mdot / rhoOut;
 % Once the component parts have been created, they can be assembled
 % to create the flame object.
 fl = ct.oneD.Sim1D({burner, flow, out});
-fl.setMaxJacAge(maxJacobianAge(1), maxJacobianAge(2));
 
 % Supply initial guess
 locs = [0.0, 0.2, 1.0];

--- a/samples/matlab/catalytic_combustion.m
+++ b/samples/matlab/catalytic_combustion.m
@@ -46,9 +46,6 @@ comp2 = 'CH4:0.095, O2:0.21, N2:0.78, AR:0.01';
 initial_grid = [0.0, 0.02, 0.04, 0.06, 0.08, 0.1];  % m
 
 % numerical parameters
-tol_ss = {1.0e-8 1.0e-14};  % {rtol atol} for steady-state problem
-tol_ts = {1.0e-4 1.0e-9};  % {rtol atol} for time stepping
-
 loglevel = 1;  % amount of diagnostic output (0 to 5)
 
 refine_grid = 1;  % 1 to enable refinement, 0 to disable
@@ -119,8 +116,6 @@ flow = ct.oneD.AxisymmetricFlow(gas, 'flow');
 % set some parameters for the flow
 flow.P = p;
 flow.grid = initial_grid;
-flow.setSteadyTolerances(tol_ss{:});
-flow.setTransientTolerances(tol_ts{:});
 
 %%
 % **Create the surface**
@@ -157,7 +152,6 @@ fprintf("Profile used for initial guess:\n\n")
 flow.info()
 
 stack.setTimeStep(1.0e-5, [1, 3, 6, 12]);
-stack.setMaxJacAge(4, 5);
 
 %%
 % Solution

--- a/samples/matlab/diffusion_flame.m
+++ b/samples/matlab/diffusion_flame.m
@@ -28,13 +28,11 @@ mdot_f = 0.24;  % Fuel mass flux, kg/m^2/s
 transport = 'mixture-averaged';  % Transport model
 
 %%
-% Set-up initial grid, loglevel, tolerances. Enable/Disable grid refinement
+% Set-up initial grid and loglevel. Enable/Disable grid refinement
 
 width = 0.02;
 nz = 11;
 
-tol_ss = {1.0e-5, 1.0e-9};  % {rtol atol} for steady-state problem
-tol_ts = {1.0e-3, 1.0e-9};  % {rtol atol} for time stepping
 logLevel = 1;  % Amount of diagnostic output (0 to 5)
 refineGrid = 1;  % 1 to enable refinement, 0 to disable
 
@@ -53,14 +51,15 @@ fuelcomp = 'C2H6:1';  % Fuel composition
 %
 % For this problem, the ``AxisymmetricFlow`` model is needed. Set the state of
 % the flow as the fuel gas object. This is arbitrary and is only used to
-% initialize the flow object. Set the grid to the initial grid defined
-% prior, same for the tolerances.
+% initialize the flow object. Set the grid to the initial grid defined prior.
 
 flow = ct.oneD.AxisymmetricFlow(gas, 'flow');
 flow.P = p;
 flow.setupUniformGrid(nz, width, 0.0);
-flow.setSteadyTolerances(tol_ss{:}, 'default');
-flow.setTransientTolerances(tol_ts{:}, 'default');
+% Relax the transient absolute tolerance. The default is too tight for the time
+% stepping needed to get this flame started, and the solver stalls at its minimum
+% timestep. The relative tolerance is left at its default value.
+flow.setTransientTolerances(1.0e-4, 1.0e-9);
 
 %%
 % **Create the fuel and oxidizer inlet steams**

--- a/samples/matlab/flamespeed.m
+++ b/samples/matlab/flamespeed.m
@@ -57,7 +57,6 @@ fprintf("phi = %1.1f, Tad = %1.1f\n", phi, Tad);
 % Create the flow domain
 flame = ct.oneD.FreeFlow(gas);
 flame.setupUniformGrid(nz, lz, 0.);
-flame.setSteadyTolerances(1e-5, 1e-11);
 flame.P = pressure;
 
 % Create the inlet

--- a/samples/matlab/flamespeed.m
+++ b/samples/matlab/flamespeed.m
@@ -49,7 +49,7 @@ gas.equilibrate('HP');
 rhoOut = gas.massDensity;
 Yout = gas.Y;
 Tad = gas.T;
-disp(sprintf("phi = %1.1f, Tad = %1.1f\n", phi, Tad));
+fprintf("phi = %1.1f, Tad = %1.1f\n", phi, Tad);
 
 %%
 % **Create domains required for a flame simulation**
@@ -125,7 +125,7 @@ stack.setFixedTemperature(0.5 * (Tin + Tad));
 flame.energyEnabled = true;
 stack.solve(logLevel, refineGrid);
 uVec = flame.values('velocity');
-disp(sprintf("Flame speed with mixture-averaged transport: %1.4f m/s\n", uVec(1)));
+fprintf("Flame speed with mixture-averaged transport: %1.4f m/s\n", uVec(1));
 stack.save(fileName, "mix", "Solution with mixture-averaged transport", true);
 
 %%
@@ -135,7 +135,7 @@ stack.save(fileName, "mix", "Solution with mixture-averaged transport", true);
 flame.transportModel = 'multicomponent';
 stack.solve(logLevel, refineGrid);
 uVec = flame.values('velocity');
-disp(sprintf("Flame speed with multicomponent transport: %1.4f m/s\n", uVec(1)));
+fprintf("Flame speed with multicomponent transport: %1.4f m/s\n", uVec(1));
 stack.save(fileName, "multi", "Solution with multicomponent transport", true);
 
 %%
@@ -145,7 +145,7 @@ stack.save(fileName, "multi", "Solution with multicomponent transport", true);
 flame.soretEnabled = true;
 stack.solve(logLevel, refineGrid);
 uVec = flame.values('velocity');
-disp(sprintf("Flame speed with multicomponent transport + Soret: %1.4f m/s\n", uVec(1)));
+fprintf("Flame speed with multicomponent transport + Soret: %1.4f m/s\n", uVec(1));
 stack.save(fileName, "soret", "Solution with multicomponent transport and Soret", true);
 
 %%

--- a/samples/matlab/rankine.m
+++ b/samples/matlab/rankine.m
@@ -43,7 +43,7 @@ turbine_work = expand(w, p1, eta_turbine);
 %%
 % Compute the efficiency
 efficiency = (turbine_work - pump_work) / heat_added;
-disp(sprintf('efficiency = %.2f%%', efficiency*100));
+fprintf('efficiency = %.2f%%\n', efficiency*100);
 
 %%
 % Local Functions

--- a/test/clib/test_ctreactor.cpp
+++ b/test/clib/test_ctreactor.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <gmock/gmock.h>
 
 #include "cantera/core.h"
 #include "cantera/zerodim.h"
@@ -137,4 +138,57 @@ TEST(ctreactor, surface)
         ASSERT_EQ(status, 0);
         count++;
     }
+}
+
+TEST(ctreactor, sensitivity)
+{
+    double T = 1050;
+    double P = 5 * 101325;
+    string X = "CH4:1.0, O2:2.0, N2:7.52";
+
+    int32_t sol = sol_newSolution("gri30.yaml", "gri30", "none");
+    int32_t thermo = sol_thermo(sol);
+    thermo_setMoleFractionsByName(thermo, X.c_str());
+    thermo_setTemperature(thermo, T);
+    thermo_setPressure(thermo, P);
+
+    int32_t reactor = reactor_new("IdealGasReactor", sol, 1, "test");
+    vector<int32_t> reactors{reactor};
+    int32_t net = reactornet_new(1, reactors.data());
+    ASSERT_GE(net, 0);
+    ASSERT_EQ(reactor_addSensitivityReaction(reactor, 2), 0);
+    ASSERT_EQ(reactornet_setSensitivityTolerances(net, 1e-6, 1e-6), 0);
+    ASSERT_EQ(reactornet_advance(net, 1e-3), 0);
+
+    // Locate the index of the temperature component in the global state vector
+    int32_t neq = reactornet_neq(net);
+    ASSERT_GT(neq, 0);
+    int32_t k = -1;
+    for (int32_t i = 0; i < neq; i++) {
+        int32_t len = reactornet_componentName(net, i, 0, 0);
+        vector<char> name(len);
+        reactornet_componentName(net, i, len, name.data());
+        // ReactorNet component names are prefixed with the reactor name
+        if (string(name.data()) == "test: temperature") {
+            k = i;
+            break;
+        }
+    }
+    ASSERT_GE(k, 0);
+
+    // The index-based and name-based overloads agree for the same component
+    double s_index = reactornet_sensitivity(net, k, 0);
+    double s_name = reactornet_sensitivityByName(net, "temperature", 0, 0);
+    ASSERT_NE(s_index, DERR);
+    ASSERT_NE(s_name, DERR);
+    EXPECT_DOUBLE_EQ(s_index, s_name);
+    EXPECT_TRUE(std::isfinite(s_index));
+
+    // Out-of-range requests report an error
+    ASSERT_EQ(reactornet_sensitivity(net, k, 99), DERR);
+    ASSERT_EQ(reactornet_sensitivityByName(net, "spam", 0, 0), DERR);
+    int32_t buflen = ct_getCanteraError(0, 0);
+    vector<char> buf(buflen);
+    ct_getCanteraError(buflen, buf.data());
+    EXPECT_THAT(string(buf.data()), testing::HasSubstr("spam"));
 }

--- a/test/clib/test_ctreactor.cpp
+++ b/test/clib/test_ctreactor.cpp
@@ -12,6 +12,19 @@
 
 using namespace Cantera;
 
+namespace {
+
+//! Text of the most recent %Cantera error
+string lastError()
+{
+    int32_t buflen = ct_getCanteraError(0, 0);
+    vector<char> buf(buflen);
+    ct_getCanteraError(buflen, buf.data());
+    return string(buf.data());
+}
+
+}
+
 TEST(ctreactor, reactor_soln)
 {
     int32_t sol = sol_newSolution("gri30.yaml", "gri30", "none");
@@ -187,8 +200,74 @@ TEST(ctreactor, sensitivity)
     // Out-of-range requests report an error
     ASSERT_EQ(reactornet_sensitivity(net, k, 99), DERR);
     ASSERT_EQ(reactornet_sensitivityByName(net, "spam", 0, 0), DERR);
-    int32_t buflen = ct_getCanteraError(0, 0);
-    vector<char> buf(buflen);
-    ct_getCanteraError(buflen, buf.data());
-    EXPECT_THAT(string(buf.data()), testing::HasSubstr("spam"));
+    EXPECT_THAT(lastError(), testing::HasSubstr("spam"));
+}
+
+TEST(ctreactor, components)
+{
+    int32_t sol = sol_newSolution("h2o2.yaml", "", "none");
+    int32_t reactor = reactor_new("IdealGasReactor", sol, 1, "first");
+    vector<int32_t> reactors{reactor};
+    int32_t net = reactornet_new(1, reactors.data());
+    ASSERT_GE(net, 0);
+
+    // The state vector of an IdealGasReactor is [mass, volume, temperature,
+    // mass fractions...]
+    int32_t neq = reactor_neq(reactor);
+    ASSERT_EQ(neq, thermo_nSpecies(sol_thermo(sol)) + 3);
+    ASSERT_EQ(reactornet_neq(net), neq);
+
+    // Names and indices round-trip for every component of the reactor
+    for (int32_t k = 0; k < neq; k++) {
+        int32_t len = reactor_componentName(reactor, k, 0, 0);
+        ASSERT_GT(len, 0);
+        vector<char> name(len);
+        reactor_componentName(reactor, k, len, name.data());
+        EXPECT_EQ(reactor_componentIndex(reactor, name.data()), k);
+    }
+    EXPECT_EQ(reactor_componentIndex(reactor, "temperature"), 2);
+
+    // An unknown name and an out-of-range index each report an error
+    ASSERT_EQ(reactor_componentIndex(reactor, "spam"), ERR);
+    EXPECT_THAT(lastError(), testing::HasSubstr("spam"));
+
+    ASSERT_EQ(reactor_componentName(reactor, neq, 0, 0), -1);
+    EXPECT_THAT(lastError(), testing::HasSubstr("IndexError"));
+}
+
+TEST(ctreactor, global_component_index)
+{
+    int32_t sol = sol_newSolution("h2o2.yaml", "", "none");
+    int32_t first = reactor_new("IdealGasReactor", sol, 1, "first");
+    int32_t second = reactor_new("IdealGasReactor", sol, 1, "second");
+    vector<int32_t> reactors{first, second};
+    int32_t net = reactornet_new(2, reactors.data());
+    ASSERT_GE(net, 0);
+
+    // Components of the second reactor are offset by the length of the first
+    int32_t offset = reactor_neq(first);
+    ASSERT_GT(offset, 0);
+    int32_t local = reactor_componentIndex(second, "OH");
+    ASSERT_GE(local, 0);
+    int32_t global = reactornet_globalComponentIndex(net, "OH", 1);
+    EXPECT_EQ(global, offset + local);
+
+    // globalComponentIndex takes an unprefixed name, while componentName returns
+    // the name prefixed with that of the reactor it belongs to
+    int32_t len = reactornet_componentName(net, global, 0, 0);
+    ASSERT_GT(len, 0);
+    vector<char> name(len);
+    reactornet_componentName(net, global, len, name.data());
+    EXPECT_EQ(string(name.data()), "second: OH");
+
+    // The first reactor is the default
+    EXPECT_EQ(reactornet_globalComponentIndex(net, "temperature", 0),
+              reactor_componentIndex(first, "temperature"));
+
+    // An unknown name and an out-of-range index each report an error
+    ASSERT_EQ(reactornet_globalComponentIndex(net, "spam", 0), ERR);
+    EXPECT_THAT(lastError(), testing::HasSubstr("spam"));
+
+    ASSERT_EQ(reactornet_componentName(net, reactornet_neq(net), 0, 0), -1);
+    EXPECT_THAT(lastError(), testing::HasSubstr("IndexError"));
 }

--- a/test/clib/test_ctthermo.cpp
+++ b/test/clib/test_ctthermo.cpp
@@ -79,3 +79,36 @@ TEST(ctthermo, atomicWeights)
         ASSERT_NEAR(buf[i], cxx_weights[i], 1e-6);
     }
 }
+
+TEST(ctthermo, coverages)
+{
+    int32_t ret;
+    int32_t surf = sol_newInterface("ptcombust.yaml", "Pt_surf", 0, nullptr);
+    ASSERT_GE(surf, 0);
+    int32_t thermo = sol_thermo(surf);
+    ASSERT_GE(thermo, 0);
+
+    int32_t nsp = thermo_nSpecies(thermo);
+    ASSERT_GT(nsp, 1);
+    vector<double> cov(nsp, 0.0);
+    cov[0] = 0.25;
+    cov[1] = 0.25;
+    vector<double> buf(nsp);
+
+    // setCoverages normalizes the input
+    ret = surf_setCoverages(thermo, nsp, cov.data());
+    ASSERT_EQ(ret, 0);
+    ret = surf_getCoverages(thermo, nsp, buf.data());
+    ASSERT_EQ(ret, 0);
+    ASSERT_NEAR(buf[0], 0.5, 1e-12);
+    ASSERT_NEAR(buf[1], 0.5, 1e-12);
+
+    // setCoveragesNoNorm retains the unnormalized input
+    ret = surf_setCoveragesNoNorm(thermo, nsp, cov.data());
+    ASSERT_EQ(ret, 0);
+    ret = surf_getCoverages(thermo, nsp, buf.data());
+    ASSERT_EQ(ret, 0);
+    for (int32_t i = 0; i < nsp; i++) {
+        ASSERT_NEAR(buf[i], cov[i], 1e-12);
+    }
+}

--- a/test/matlab/ctTestFlowDevice.m
+++ b/test/matlab/ctTestFlowDevice.m
@@ -177,7 +177,68 @@ classdef ctTestFlowDevice < ctTestCase
         end
 
         function testPressureController(self)
-            self.assumeFail('Skipped until PressureController is implemented');
+            self.makeReactors('nr', 1);
+            g = ct.Solution('h2o2.yaml', '', 'none');
+            g.TPX = {500, 2 * ct.OneAtm, 'H2:1.0'};
+            inletReservoir = ct.zeroD.Reservoir(g);
+            g.TP = {300, ct.OneAtm};
+            outletReservoir = ct.zeroD.Reservoir(g);
+
+            mdot = 0.1;
+            mfc = ct.zeroD.MassFlowController(inletReservoir, self.r1);
+            mfc.massFlowRate = mdot;
+
+            pc = ct.zeroD.PressureController(self.r1, outletReservoir);
+            pc.setPrimary(mfc);
+            k = 2e-5;
+            pc.pressureCoeff = k;
+            self.verifyEqual(pc.pressureCoeff, k, 'RelTol', self.rtol);
+            self.verifyEqual(pc.deviceCoefficient, k, 'RelTol', self.rtol);
+            pc.pressureCoeff = 1e-5;
+            k = 1e-5;
+            self.verifyEqual(pc.pressureCoeff, k, 'RelTol', self.rtol);
+
+            net = ct.zeroD.ReactorNet(self.r1);
+            t = 0;
+
+            while t < 1.0
+                t = net.step();
+                self.verifyEqual(mfc.massFlowRate, mdot, 'RelTol', self.rtol);
+                dP = self.r1.P - outletReservoir.P;
+                self.verifyEqual(pc.massFlowRate, max(mdot + k * dP, 0.0), ...
+                                 'RelTol', self.rtol);
+            end
+        end
+
+        function testPressureControllerType(self)
+            self.makeReactors();
+            res = ct.zeroD.Reservoir(self.gas1);
+            mfc = ct.zeroD.MassFlowController(res, self.r1);
+            mfc.massFlowRate = 0.6;
+            pc = ct.zeroD.PressureController(self.r1, self.r2);
+            pc.setPrimary(mfc);
+            pc.pressureCoeff = 0.5;
+            net = ct.zeroD.ReactorNet({self.r1, self.r2});
+
+            self.verifyEqual(pc.type, 'PressureController');
+            self.verifyTrue(startsWith(pc.name, 'PressureController_'));
+            pc.name = 'name-of-pressure-controller';
+            self.verifyEqual(pc.name, 'name-of-pressure-controller');
+        end
+
+        function testPressureControllerErrors(self)
+            self.makeReactors();
+            res = ct.zeroD.Reservoir(self.gas1);
+            mfc = ct.zeroD.MassFlowController(res, self.r1);
+            mfc.massFlowRate = 0.6;
+            pc = ct.zeroD.PressureController(self.r1, self.r2);
+
+            % Mass flow rate cannot be evaluated before the primary device is set
+            self.verifyError(@() pc.massFlowRate, 'Cantera:ctError');
+
+            % Only pressure controllers accept a primary device
+            v = ct.zeroD.Valve(self.r1, self.r2);
+            self.verifyError(@() v.setPrimary(mfc), ?MException);
         end
 
     end

--- a/test/matlab/ctTestFlowReactor1.m
+++ b/test/matlab/ctTestFlowReactor1.m
@@ -8,6 +8,10 @@ classdef ctTestFlowReactor1 < ctTestCase
         rsurf
     end
 
+    properties (SetAccess = protected)
+        rtol = 1e-6;
+    end
+
     methods (Test)
 
         function testNonReacting(self)
@@ -84,6 +88,24 @@ classdef ctTestFlowReactor1 < ctTestCase
             % kCH4 = self.gas.speciesIndex('CH4');
             % kH2 = self.gas.speciesIndex('H2');
             % kCO = self.gas.speciesIndex('CO');
+        end
+
+        function testMassFlowRate(self)
+            self.gas = ct.Solution('../data/ch4_minimal.yaml', ...
+                                   'testConstPressureReactor');
+            self.gas.TPX = {300, ct.OneAtm, 'O2:1.0'};
+            self.reactor = ct.zeroD.FlowReactor(self.gas);
+
+            self.reactor.massFlowRate = 10;
+            self.verifyEqual(self.reactor.massFlowRate, 10, 'RelTol', self.rtol);
+
+            % Changing the area rescales the flow speed, leaving the mass flow
+            % rate unchanged.
+            self.reactor.area = 0.5;
+            self.verifyEqual(self.reactor.massFlowRate, 10, 'RelTol', self.rtol);
+
+            self.reactor.massFlowRate = 2.5;
+            self.verifyEqual(self.reactor.massFlowRate, 2.5, 'RelTol', self.rtol);
         end
 
         function testComponentNames(self)

--- a/test/matlab/ctTestKinetics.m
+++ b/test/matlab/ctTestKinetics.m
@@ -216,6 +216,32 @@ classdef ctTestKinetics < ctTestCase
             end
         end
 
+        function testUnnormalizedCoverages(self)
+            surf = ct.Interface('ptcombust.yaml', 'Pt_surf');
+            nsp = surf.nSpecies;
+
+            cov = zeros(1, nsp);
+            cov(1) = 0.25;
+            cov(2) = 0.25;
+            tol = ones(1, nsp) .* self.atol;
+
+            % Assigning coverages normalizes them to sum to one
+            surf.coverages = cov;
+            self.verifyEqual(sum(surf.coverages), 1.0, 'AbsTol', self.atol);
+            self.verifyEqual(surf.coverages, cov .* 2, 'AbsTol', tol);
+
+            % Setting unnormalized coverages leaves the values unchanged
+            surf.setUnnormalizedCoverages(cov);
+            self.verifyEqual(surf.coverages, cov, 'AbsTol', tol);
+            self.verifyEqual(sum(surf.coverages), 0.5, 'AbsTol', self.atol);
+
+            % Invalid inputs are rejected
+            self.verifyError(@() surf.setUnnormalizedCoverages(cov(1:end-1)), ...
+                             ?MException);
+            self.verifyError(@() surf.setUnnormalizedCoverages('PT(S):1.0'), ...
+                             ?MException);
+        end
+
         function testPdepError(self)
             try
                 gas = ct.Solution('../data/addReactions_err_test.yaml');

--- a/test/matlab/ctTestReactor.m
+++ b/test/matlab/ctTestReactor.m
@@ -402,11 +402,10 @@ classdef ctTestReactor < ctTestCase
             self.verifyNotEqual(s, 0);
 
             % A char array, a string, and the 1-based index of 'temperature' within the
-            % global state vector all name the same component. For an IdealGasReactor
-            % that vector is [mass, volume, temperature, mass fractions...], so
-            % 'temperature' is component 3.
+            % global state vector all name the same component.
             self.verifyEqual(net.sensitivity("temperature", 1), s);
-            self.verifyEqual(net.sensitivity(3, 1), s);
+            k = net.globalComponentIndex('temperature');
+            self.verifyEqual(net.sensitivity(k, 1), s);
 
             % The reactor may be omitted, given as an object, or given as its 1-based
             % position within the network.
@@ -421,9 +420,8 @@ classdef ctTestReactor < ctTestCase
             self.verifyTrue(isfinite(s));
             self.verifyNotEqual(s, 0);
 
-            % Species k follows the three non-species components of the reactor.
-            k = self.gas1.speciesIndex('OH');
-            self.verifyEqual(net.sensitivity(k + 3, 1), s);
+            k = net.globalComponentIndex('OH');
+            self.verifyEqual(net.sensitivity(k, 1), s);
         end
 
         function testSensitivityReactorArgument(self)
@@ -448,16 +446,16 @@ classdef ctTestReactor < ctTestCase
             self.verifyNotEqual(s2, 0);
             self.verifyEqual(net.sensitivity('temperature', 1, 2), s2);
 
-            % The state of the second reactor follows that of the first, whose
-            % length is 3 plus the number of species.
-            offset = 3 + self.gas1.nSpecies;
-            self.verifyEqual(net.sensitivity(offset + 3, 1), s2);
+            % The state of the second reactor follows that of the first.
+            k2 = net.globalComponentIndex('temperature', self.r2);
+            self.verifyEqual(net.sensitivity(k2, 1), s2);
 
             % The first reactor is unaffected by the parameter, and is what the
             % default reactor argument selects.
             self.verifyEqual(net.sensitivity('temperature', 1), 0, ...
                              'AbsTol', self.atol);
-            self.verifyEqual(net.sensitivity(3, 1), 0, 'AbsTol', self.atol);
+            k1 = net.globalComponentIndex('temperature');
+            self.verifyEqual(net.sensitivity(k1, 1), 0, 'AbsTol', self.atol);
         end
 
         function testSensitivityInvalidComponent(self)
@@ -507,7 +505,95 @@ classdef ctTestReactor < ctTestCase
             % Only one sensitivity parameter was registered.
             self.verifyError(@() net.sensitivity('temperature', 2), ...
                              'Cantera:ctError');
-            self.verifyError(@() net.sensitivity(3, 2), 'Cantera:ctError');
+            k = net.globalComponentIndex('temperature');
+            self.verifyError(@() net.sensitivity(k, 2), 'Cantera:ctError');
+        end
+
+        function testReactorComponents(self)
+            gas = ct.Solution('h2o2.yaml', '', 'none');
+            r = ct.zeroD.IdealGasReactor(gas);
+            net = ct.zeroD.ReactorNet(r);
+
+            % The state vector of an IdealGasReactor is
+            % [mass, volume, temperature, mass fractions...]
+            self.verifyEqual(r.nVars, 3 + gas.nSpecies);
+            self.verifyEqual(net.nVars, r.nVars);
+            self.verifyEqual(r.componentName(3), 'temperature');
+            self.verifyEqual(r.componentIndex('temperature'), 3);
+            self.verifyEqual(r.componentIndex('OH'), 3 + gas.speciesIndex('OH'));
+
+            % Names and 1-based indices round-trip for every component
+            for k = 1:r.nVars
+                self.verifyEqual(r.componentIndex(r.componentName(k)), k);
+            end
+
+            % Indices outside the 1-based range are rejected
+            self.verifyError(@() r.componentName(0), ...
+                             'MATLAB:validators:mustBePositive');
+            self.verifyError(@() r.componentName(r.nVars + 1), 'Cantera:ctError');
+
+            % So is an unknown component name
+            self.verifyError(@() r.componentIndex('spam'), 'Cantera:ctError');
+        end
+
+        function testReactorNetComponents(self)
+            gas = ct.Solution('h2o2.yaml', '', 'none');
+            first = ct.zeroD.IdealGasReactor(gas, 'first');
+            second = ct.zeroD.IdealGasReactor(gas, 'second');
+            net = ct.zeroD.ReactorNet({first, second});
+
+            self.verifyEqual(net.nVars, first.nVars + second.nVars);
+
+            % Components of the second reactor are offset by the length of the first
+            k = net.globalComponentIndex('temperature', 2);
+            self.verifyEqual(k, first.nVars + second.componentIndex('temperature'));
+
+            % The reactor may be omitted, given as an object, or given as its
+            % 1-based position within the network
+            self.verifyEqual(net.globalComponentIndex('temperature', second), k);
+            self.verifyEqual(net.globalComponentIndex('temperature'), ...
+                             first.componentIndex('temperature'));
+
+            % ReactorNet.componentName returns the reactor-prefixed name, while
+            % globalComponentIndex takes the unprefixed one
+            self.verifyEqual(net.componentName(k), 'second: temperature');
+            self.verifyEqual(second.componentName( ...
+                             second.componentIndex('temperature')), 'temperature');
+            self.verifyError(@() net.globalComponentIndex('second: temperature', 2), ...
+                             'Cantera:ctError');
+
+            % Indices outside the 1-based range are rejected
+            self.verifyError(@() net.componentName(0), ...
+                             'MATLAB:validators:mustBePositive');
+            self.verifyError(@() net.componentName(net.nVars + 1), 'Cantera:ctError');
+
+            % So is a reactor that is not in the network, in either form
+            try
+                net.globalComponentIndex('temperature', 3);
+                self.verifyFail('Expected an error for an out-of-range reactor.');
+            catch ME
+                self.verifySubstring(ME.message, 'between 1 and 2');
+            end
+
+            stranger = ct.zeroD.IdealGasReactor(gas);
+            try
+                net.globalComponentIndex('temperature', stranger);
+                self.verifyFail('Expected an error for a foreign reactor.');
+            catch ME
+                self.verifySubstring(ME.message, 'not part of this network');
+            end
+        end
+
+        function testReservoirComponentIndex(self)
+            % ReactorBase::componentIndex and componentName are not implemented for
+            % reactor types that have no state vector of their own.
+            gas = ct.Solution('h2o2.yaml', '', 'none');
+            res = ct.zeroD.Reservoir(gas);
+
+            self.verifyEqual(res.nVars, 0);
+            self.verifyError(@() res.componentIndex('temperature'), ...
+                             'Cantera:ctError');
+            self.verifyError(@() res.componentName(1), 'Cantera:ctError');
         end
 
         function testInvalidProperty(self)

--- a/test/matlab/ctTestReactor.m
+++ b/test/matlab/ctTestReactor.m
@@ -53,6 +53,28 @@ classdef ctTestReactor < ctTestCase
             self.w.heatTransferCoeff = arg.U;
         end
 
+        function m = sensitivityReaction(self, gas)
+            % 1-based index of the chain-branching reaction, to be used as a
+            % sensitivity parameter.
+            m = find(strcmp(gas.reactionEquations, 'H + O2 <=> O + OH'), 1);
+            self.assertNotEmpty(m);
+        end
+
+        function net = makeSensitivityNet(self)
+            % Single igniting reactor with one sensitivity parameter, advanced
+            % past ignition so that the sensitivity coefficients are nonzero.
+            self.gas1 = ct.Solution('h2o2.yaml', '', 'none');
+            self.gas1.TPX = {1050, 5 * ct.OneAtm, 'H2:2.0, O2:1.0, AR:4.0'};
+            self.r1 = ct.zeroD.IdealGasReactor(self.gas1);
+            net = ct.zeroD.ReactorNet(self.r1);
+
+            % A reactor has to be part of a network before a sensitivity
+            % parameter can be added to it.
+            self.r1.addSensitivityReaction(self.sensitivityReaction(self.gas1));
+            net.setSensitivityTolerances(1e-6, 1e-6);
+            net.advance(0.1);
+        end
+
     end
 
     methods (Test)
@@ -294,7 +316,7 @@ classdef ctTestReactor < ctTestCase
 
             net.advance(2.0);
 
-            self.verifyEqual(selfw.expansionRate, 0.0, 'AbsTol', self.atol);
+            self.verifyEqual(self.expansionRate, 0.0, 'AbsTol', self.atol);
             self.verifyEqual(self.r1.V, V1 + 1.0 * A, 'RelTol', self.rtol);
             self.verifyEqual(self.r2.V, V2 - 1.0 * A, 'RelTol', self.rtol);
         end
@@ -356,6 +378,136 @@ classdef ctTestReactor < ctTestCase
 
         function testPreconditionerUnsupported(self)
             self.assumeFail('Skipped until ReactorNet.preconditioner is implemented');
+        end
+
+        function testAddSensitivityReactionIndexing(self)
+            self.gas1 = ct.Solution('h2o2.yaml', '', 'none');
+            self.r1 = ct.zeroD.IdealGasReactor(self.gas1);
+            net = ct.zeroD.ReactorNet(self.r1);
+
+            % The last reaction is in range; 0 and one past the end are not.
+            n = self.gas1.nReactions;
+            self.r1.addSensitivityReaction(n);
+            self.verifyError(@() self.r1.addSensitivityReaction(0), ...
+                             'Cantera:ctError');
+            self.verifyError(@() self.r1.addSensitivityReaction(n + 1), ...
+                             'Cantera:ctError');
+        end
+
+        function testSensitivityComponentForms(self)
+            net = self.makeSensitivityNet();
+
+            s = net.sensitivity('temperature', 1);
+            self.verifyTrue(isfinite(s));
+            self.verifyNotEqual(s, 0);
+
+            % A char array, a string, and the 1-based index of 'temperature' within the
+            % global state vector all name the same component. For an IdealGasReactor
+            % that vector is [mass, volume, temperature, mass fractions...], so
+            % 'temperature' is component 3.
+            self.verifyEqual(net.sensitivity("temperature", 1), s);
+            self.verifyEqual(net.sensitivity(3, 1), s);
+
+            % The reactor may be omitted, given as an object, or given as its 1-based
+            % position within the network.
+            self.verifyEqual(net.sensitivity('temperature', 1, self.r1), s);
+            self.verifyEqual(net.sensitivity('temperature', 1, 1), s);
+        end
+
+        function testSensitivitySpeciesComponent(self)
+            net = self.makeSensitivityNet();
+
+            s = net.sensitivity('OH', 1);
+            self.verifyTrue(isfinite(s));
+            self.verifyNotEqual(s, 0);
+
+            % Species k follows the three non-species components of the reactor.
+            k = self.gas1.speciesIndex('OH');
+            self.verifyEqual(net.sensitivity(k + 3, 1), s);
+        end
+
+        function testSensitivityReactorArgument(self)
+            % In a network of two disjoint reactors, only the second one carries
+            % a sensitivity parameter, so the component name has to be resolved
+            % within the requested reactor to get the right answer.
+            self.gas1 = ct.Solution('h2o2.yaml', '', 'none');
+            self.gas1.TPX = {300, ct.OneAtm, 'H2:2.0, O2:1.0, AR:4.0'};
+            self.r1 = ct.zeroD.IdealGasReactor(self.gas1);
+
+            self.gas2 = ct.Solution('h2o2.yaml', '', 'none');
+            self.gas2.TPX = {1050, 5 * ct.OneAtm, 'H2:2.0, O2:1.0, AR:4.0'};
+            self.r2 = ct.zeroD.IdealGasReactor(self.gas2);
+
+            net = ct.zeroD.ReactorNet({self.r1, self.r2});
+            self.r2.addSensitivityReaction(self.sensitivityReaction(self.gas2));
+            net.setSensitivityTolerances(1e-6, 1e-6);
+            net.advance(0.1);
+
+            s2 = net.sensitivity('temperature', 1, self.r2);
+            self.verifyTrue(isfinite(s2));
+            self.verifyNotEqual(s2, 0);
+            self.verifyEqual(net.sensitivity('temperature', 1, 2), s2);
+
+            % The state of the second reactor follows that of the first, whose
+            % length is 3 plus the number of species.
+            offset = 3 + self.gas1.nSpecies;
+            self.verifyEqual(net.sensitivity(offset + 3, 1), s2);
+
+            % The first reactor is unaffected by the parameter, and is what the
+            % default reactor argument selects.
+            self.verifyEqual(net.sensitivity('temperature', 1), 0, ...
+                             'AbsTol', self.atol);
+            self.verifyEqual(net.sensitivity(3, 1), 0, 'AbsTol', self.atol);
+        end
+
+        function testSensitivityInvalidComponent(self)
+            net = self.makeSensitivityNet();
+
+            try
+                net.sensitivity({'temperature'}, 1);
+                self.verifyFail('Expected an error for a cell array component.');
+            catch ME
+                self.verifySubstring(ME.message, 'must be a character array');
+                self.verifySubstring(ME.message, 'cell');
+            end
+
+            try
+                net.sensitivity('spam', 1);
+                self.verifyFail('Expected an error for an unknown component.');
+            catch ME
+                self.verifySubstring(ME.identifier, 'Cantera:ctError');
+                self.verifySubstring(ME.message, 'spam');
+            end
+        end
+
+        function testSensitivityInvalidReactor(self)
+            net = self.makeSensitivityNet();
+
+            gas = ct.Solution('h2o2.yaml', '', 'none');
+            stranger = ct.zeroD.IdealGasReactor(gas);
+
+            try
+                net.sensitivity('temperature', 1, stranger);
+                self.verifyFail('Expected an error for a foreign reactor.');
+            catch ME
+                self.verifySubstring(ME.message, 'not part of this network');
+            end
+
+            try
+                net.sensitivity('temperature', 1, 'first');
+                self.verifyFail('Expected an error for a char reactor argument.');
+            catch ME
+                self.verifySubstring(ME.message, 'Reactor must be a');
+            end
+        end
+
+        function testSensitivityInvalidParameter(self)
+            net = self.makeSensitivityNet();
+
+            % Only one sensitivity parameter was registered.
+            self.verifyError(@() net.sensitivity('temperature', 2), ...
+                             'Cantera:ctError');
+            self.verifyError(@() net.sensitivity(3, 2), 'Cantera:ctError');
         end
 
         function testInvalidProperty(self)

--- a/test/matlab/ctTestThermo.m
+++ b/test/matlab/ctTestThermo.m
@@ -52,6 +52,18 @@ classdef ctTestThermo < ctTestCase
             self.verifyEqual(self.phase.Y, Y, 'AbsTol', self.atol);
         end
 
+        % Check the concentrations of a phase against expected values. Agreement is
+        % expected to round-off, so the class-wide tolerances are far too loose.
+        % 'scale' is the magnitude of a fully occupied concentration, which the
+        % absolute tolerance has to track: surface concentrations are ~1e-8
+        % kmol/m^2, and self.atol alone would exceed every element and make the
+        % comparison vacuous.
+        function checkConcentrations(self, phase, exp, scale)
+            c = phase.concentrations;
+            self.verifySize(c, [1, phase.nSpecies]);
+            self.verifyEqual(c, exp, 'RelTol', 1e-12, 'AbsTol', 1e-12*scale);
+        end
+
         % Check multi properties
         function checkMultiProperties(self, str)
             val = self.phase.(str);
@@ -336,6 +348,28 @@ classdef ctTestThermo < ctTestCase
             exp = 1.0 / self.phase.T;
             self.verifyEqual(val, exp, 'RelTol', self.rtol);
 
+        end
+
+        function testConcentrations(self)
+            self.phase.TPX = {800.0, 2 * ct.OneAtm, 'H2:0.4, O2:0.3, AR:0.3'};
+
+            molarDensity = self.phase.molarDensity;
+            self.checkConcentrations(self.phase, self.phase.X*molarDensity, ...
+                                     molarDensity);
+        end
+
+        function testSurfaceConcentrations(self)
+            gas = ct.Solution('ptcombust.yaml', 'gas');
+            surf = ct.Interface('ptcombust.yaml', 'Pt_surf', gas);
+            surf.coverages = 'O(S):0.1, PT(S):0.5, H(S):0.4';
+
+            % Surface concentrations [kmol/m^2] are the site density weighted by
+            % the coverages. Every species in 'Pt_surf' occupies a single site, so
+            % no division by a site size is needed and the concentrations sum to
+            % the site density.
+            siteDensity = surf.siteDensity;
+            self.checkConcentrations(surf, surf.coverages*siteDensity, siteDensity);
+            self.verifyEqual(sum(surf.concentrations), siteDensity, 'RelTol', 1e-12);
         end
 
         function testGetStateMole(self)

--- a/test/matlab/ctTestUtility.m
+++ b/test/matlab/ctTestUtility.m
@@ -1,0 +1,18 @@
+classdef ctTestUtility < ctTestCase
+
+    methods (Test)
+
+        function testDataDirectories(self)
+            d = ct.dataDirectories();
+            self.verifyClass(d, 'cell');
+            self.verifyGreaterThan(numel(d), 0);
+            for i = 1:numel(d)
+                self.verifyClass(d{i}, 'char');
+                self.verifyFalse(contains(d{i}, pathsep));
+            end
+            self.verifyTrue(any(cellfun(@isfolder, d)));
+        end
+
+    end
+
+end


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Matlab-specific updates:
- Eliminate warning from using of `disp(sprintf(...))` instead of directly calling `fprintf`
- Simplify implementation of `Func1.subsref` and give it a docstring that makes sense
- Fix docstring indentation for `Func1` lists and code blocks
- Include the 1D `Flow` class in the API documentation
- Fix `Interface.setUnnormalizedCoverages` which was incorrectly calling `surf_setCoverages` with an extra, non-existing argument
- Implement the `PressureController` class
- Remove misleading return values from both `ThermoPhase.equilibrate` and `Mixture.equilibrate`
- Fix the accessor for `FlowReactor.massFlowRate`, which previously failed while trying to return an undefined variable
- Fix the copypasta docstring for `ReactingSurface.coverageEnabled`
- Remove unnecessary tolerance setting calls from the examples
- Add a test case for `ThermoPhase.concentrations`
- Fix `ct.dataDirectories` to return a cell array as indicated in the docstring (and for consistency with Python's `ct.get_data_directories()` method
- Add methods to `Reactor` and `ReactorNet` for getting component names and indices
- Handle cases where `-999` is the sentinel error value returned by CLib

Other fixes:
- Expose both name-based and index-based overloads for `ReactorNet::sensitivity`, with the former now named `reactornet_sensitivityByName`, analogous to `sol_adjacentByName`
- Fix SCons dependency relations so that edits to `interfaces/sourcegen/.../headers/ct*.yaml` trigger rebuilds of CLib

**AI Statement (required)**

- **Extensive use of generative AI.** Significant portions of code or documentation were generated with AI, including logic and implementation decisions. All generated code and documentation were reviewed and understood by the contributor. *Implemented using Claude Code (Opus 5)*.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
