### PR TITLE
Prevent inadvertent submodule downgrades

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -89,3 +89,68 @@ jobs:
             echo ":exclamation: Merge https://github.com/Cantera/cantera-example-data/pull/${DATA_PR} and update the submodule commit before merging this PR" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
+  submodule-versions:
+    name: Check for submodule downgrades
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+        name: Checkout the repository
+        with:
+          fetch-depth: 0
+          submodules: false
+          persist-credentials: false
+
+      # Submodules are occasionally downgraded by accident, usually by contributors who
+      # ran `git add .` / `git add -A` without first updating their submodules. GitHub's
+      # PR diff view doesn't clearly call this out, so check explicitly whether the new
+      # submodule commit is actually an ancestor of the old one.
+      - name: Check that submodules are not downgraded
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          ZERO_SHA="0000000000000000000000000000000000000000"
+          RETCODE=0
+
+          while IFS= read -r -d '' meta && IFS= read -r -d '' path; do
+            new_mode=$(echo "$meta" | cut -d' ' -f2)
+            old_sha=$(echo "$meta" | cut -d' ' -f3)
+            new_sha=$(echo "$meta" | cut -d' ' -f4)
+
+            # Only interested in gitlink (submodule) entries that changed commit
+            [ "$new_mode" = "160000" ] || continue
+            [ "$old_sha" = "$new_sha" ] && continue
+            [ "$old_sha" = "$ZERO_SHA" ] && continue  # submodule added
+            [ "$new_sha" = "$ZERO_SHA" ] && continue  # submodule removed
+
+            name=$(git config -f .gitmodules --get-regexp '^submodule\..*\.path$' \
+                     | awk -v p="$path" '$2 == p {print $1}' \
+                     | sed -E 's/^submodule\.(.*)\.path$/\1/')
+            url=$(git config -f .gitmodules --get "submodule.${name}.url")
+
+            echo "Checking submodule '${path}': ${old_sha} -> ${new_sha}"
+
+            tmp=$(mktemp -d)
+            git init -q --bare "${tmp}/repo.git"
+            if ! git -C "${tmp}/repo.git" fetch -q "$url" "$old_sha" "$new_sha" 2>/dev/null; then
+              # Some hosts (e.g. GitLab) don't allow fetching arbitrary commits by
+              # SHA, so fall back to fetching all branches/tags instead.
+              git -C "${tmp}/repo.git" fetch -q "$url" \
+                '+refs/heads/*:refs/remotes/origin/*' '+refs/tags/*:refs/tags/*' || true
+            fi
+
+            if git -C "${tmp}/repo.git" cat-file -e "$old_sha" 2>/dev/null && \
+               git -C "${tmp}/repo.git" cat-file -e "$new_sha" 2>/dev/null; then
+              if git -C "${tmp}/repo.git" merge-base --is-ancestor "$new_sha" "$old_sha" && \
+                 ! git -C "${tmp}/repo.git" merge-base --is-ancestor "$old_sha" "$new_sha"; then
+                echo "::error::Submodule '${path}' is being downgraded from ${old_sha} to ${new_sha}"
+                RETCODE=1
+              fi
+            else
+              echo "::warning::Could not fetch commit history for submodule '${path}' from ${url}; skipping downgrade check"
+            fi
+            rm -rf "${tmp}"
+          done < <(git diff --raw -z --diff-filter=AMD "$BASE_SHA" "$HEAD_SHA")
+
+          exit $RETCODE


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Restore `yaml-cpp` submodule to version 0.9.0
- Add a CI job to ensure that submodule downgrades are flagged as an error

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #2170 

**Example usage**

I initially opened this PR with a commit downgrading the `googletest` submodule. The new CI job fails and provides the following log messages:

<img width="1778" height="344" alt="image" src="https://github.com/user-attachments/assets/6d676644-87ef-48b2-adfc-baa0b91253c8" />


**AI Statement (required)**

- **Extensive use of generative AI.** Significant portions of code or documentation were generated with AI, including
  logic and implementation decisions. All generated code and documentation were reviewed and understood by the contributor. *Implemented using Claude Sonnet 5.*

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] AI Statement is included
- [x] The pull request is ready for review
